### PR TITLE
Ignore driver packages on IoT Packages pack

### DIFF
--- a/cmf-cli/Constants/CliConstants.cs
+++ b/cmf-cli/Constants/CliConstants.cs
@@ -51,6 +51,11 @@
         /// </summary>
         public const string LBOsFileLocation = "Libs/LBOs/NetStandard/Cmf.LightBusinessObjects.dll";
 
+        /// <summary>
+        /// Driver keyword for IoT Packages
+        /// </summary>
+        public const string Driver = "driver";
+
         #endregion
 
         #region Generic

--- a/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
@@ -46,7 +46,7 @@ namespace Cmf.Common.Cli.Handlers
                             string packageName = packageJson.name;
 
                             // For IoT Packages we should ignore the driver packages
-                            if (!packageName.Contains(CliConstants.Driver, System.StringComparison.InvariantCultureIgnoreCase))
+                            if (CmfPackage.PackageType == PackageType.IoT && !packageName.Contains(CliConstants.Driver, System.StringComparison.InvariantCultureIgnoreCase))
                             {
                                 packageList.Add($"'{packageName}'");
                             }

--- a/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
@@ -43,7 +43,13 @@ namespace Cmf.Common.Cli.Handlers
                         dynamic packageJson = packDirectory.GetPackageJsonFile();
                         if (packageJson != null)
                         {
-                            packageList.Add($"'{packageJson.name}'");
+                            string packageName = packageJson.name;
+
+                            // For IoT Packages we should ignore the driver packages
+                            if (!packageName.Contains(CliConstants.Driver, System.StringComparison.InvariantCultureIgnoreCase))
+                            {
+                                packageList.Add($"'{packageName}'");
+                            }
                         }
                     }
                 }

--- a/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
@@ -46,10 +46,12 @@ namespace Cmf.Common.Cli.Handlers
                             string packageName = packageJson.name;
 
                             // For IoT Packages we should ignore the driver packages
-                            if (CmfPackage.PackageType == PackageType.IoT && !packageName.Contains(CliConstants.Driver, System.StringComparison.InvariantCultureIgnoreCase))
+                            if (CmfPackage.PackageType == PackageType.IoT && packageName.Contains(CliConstants.Driver, System.StringComparison.InvariantCultureIgnoreCase))
                             {
-                                packageList.Add($"'{packageName}'");
+                                continue;
                             }
+
+                            packageList.Add($"'{packageName}'");
                         }
                     }
                 }

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>1.0.5-0</Version>
+    <Version>1.0.5-1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/docs/cmf/Cmf_Common_Cli_Constants.md
+++ b/docs/cmf/Cmf_Common_Cli_Constants.md
@@ -45,6 +45,15 @@ public const string DeploymentMetadataDependency = Cmf.Custom.DeploymentMetadata
 #### Field Value
 [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
   
+<a name='Cmf_Common_Cli_Constants_CliConstants_Driver'></a>
+## CliConstants.Driver Field
+Driver keyword for IoT Packages  
+```csharp
+public const string Driver = driver;
+```
+#### Field Value
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+  
 <a name='Cmf_Common_Cli_Constants_CliConstants_FolderInstallDependencies'></a>
 ## CliConstants.FolderInstallDependencies Field
 The folder install dependencies  

--- a/docs/cmf/cmf.xml
+++ b/docs/cmf/cmf.xml
@@ -840,6 +840,11 @@
             The lb os file location
             </summary>
         </member>
+        <member name="F:Cmf.Common.Cli.Constants.CliConstants.Driver">
+            <summary>
+            Driver keyword for IoT Packages
+            </summary>
+        </member>
         <member name="F:Cmf.Common.Cli.Constants.CliConstants.RootPackageDefaultKeyword">
             <summary>
             The root package default keyword

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "1.0.5-0",
+  "version": "1.0.5-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "1.0.5-0",
+  "version": "1.0.5-1",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"


### PR DESCRIPTION
For IoT Packages we should ignore the driver packages.
This was tested and validated