### PR TITLE
List Package Dependencies

### DIFF
--- a/cmf-cli/Commands/list/ListDependencies.cs
+++ b/cmf-cli/Commands/list/ListDependencies.cs
@@ -1,0 +1,97 @@
+﻿using Cmf.Common.Cli.Attributes;
+using Cmf.Common.Cli.Constants;
+using Cmf.Common.Cli.Objects;
+using Cmf.Common.Cli.Utilities;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cmf.Common.Cli.Commands
+{
+    [CmfCommand("ls")]
+    class ListDependencies : BaseCommand
+    {
+        public override void Configure(Command cmd)
+        {
+            cmd.AddArgument(new Argument<DirectoryInfo>(
+                name: "workingDir",
+                getDefaultValue: () => { return new("."); },
+                description: "Working Directory"));
+
+            cmd.AddOption(new Option<string>(
+                aliases: new string[] { "-r", "--repo" },
+                description: "Repository where dependencies are located (url or folder)"));
+
+            // Add the handler
+            cmd.Handler = CommandHandler.Create<DirectoryInfo, string>(Execute);
+        }
+
+
+        public void Execute(DirectoryInfo workingDir, string repo)
+        {
+            FileInfo cmfpackageFile = new($"{workingDir}/{CliConstants.CmfPackageFileName}");
+
+            // Reading cmfPackage
+            CmfPackage cmfPackage = CmfPackage.Load(cmfpackageFile, setDefaultValues: true);
+            Log.Progress("Starting ls...");
+            var loadedPackage = cmfPackage.LoadDependencies(repo, true);
+            Log.Progress("Finished ls", true);
+            DisplayTree(loadedPackage);
+        }
+        
+        private string PrintBranch(List<bool> levels, bool isLast = false) {
+            var sb = new StringBuilder();
+            while (levels.Count > 0)
+            {
+                var level = levels[0];
+                if (levels.Count > 1)
+                {
+                    sb.Append(level ? "  " : "| ");
+                }
+                else
+                {
+                    sb.Append(isLast ? "`-- " : "+-- ");
+                }
+                levels.RemoveAt(0);
+            }
+            return sb.ToString();
+        }
+
+
+
+        private void DisplayTree(CmfPackage pkg, List<bool> levels = null, bool isLast = false)
+        {
+            levels ??= new();
+
+            Log.Information($"{this.PrintBranch(levels.ToList(), isLast)}{pkg.PackageId}@{pkg.Version} [{pkg.Location.ToString()}]");
+            if (pkg.Dependencies.HasAny()) {
+                for (int i = 0; i < pkg.Dependencies.Count; i++)
+                {
+                    Dependency dep = pkg.Dependencies[i];
+                    var isDepLast = (i == (pkg.Dependencies.Count - 1));
+                    var l = levels.Append(isDepLast).ToList();
+                    if (dep.IsMissing)
+                    {
+                        if (dep.Mandatory)
+                        {
+                            Log.Error($"{this.PrintBranch(l, isDepLast)} MISSING {dep.Id}@{dep.Version}");
+                        }
+                        else
+                        {
+                            Log.Warning($"{this.PrintBranch(l, isDepLast)} MISSING {dep.Id}@{dep.Version}");
+                        }
+                    }
+                    else
+                    {
+                        DisplayTree(dep.CmfPackage, l, isDepLast);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cmf-cli/Enums/PackageLocation.cs
+++ b/cmf-cli/Enums/PackageLocation.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cmf.Common.Cli.Enums
+{
+    /// <summary>
+    /// Possible source for a CmfPackage
+    /// </summary>
+    public enum PackageLocation
+    {
+        /// <summary>
+        /// Local filesystem
+        /// </summary>
+        Local,
+        /// <summary>
+        /// a specified repository
+        /// </summary>
+        Repository
+    }
+}

--- a/cmf-cli/Logger.cs
+++ b/cmf-cli/Logger.cs
@@ -1,4 +1,6 @@
 using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace Cmf.Common.Cli
 {
@@ -65,6 +67,62 @@ namespace Cmf.Common.Cli
             Console.ForegroundColor = ConsoleColor.Red;
             Write(msg);
             Console.ResetColor();
+        }
+
+        /// <summary>
+        /// Logs the progress of an operation, single line with a spinner
+        /// TODO: this needs a better API and implementation, it's a mess
+        /// </summary>
+        /// <param name="msg">message to print</param>
+        /// <param name="end">should stop the spinner and clear the console line</param>
+        private static BackgroundWorker worker = null;
+        private static string curMsg = string.Empty;
+        public static void Progress(string msg, bool end = false)
+        {
+            curMsg = msg;
+            var spinnerPosition = Console.CursorLeft;
+            if (worker == null)
+            {
+                worker = new BackgroundWorker();
+                worker.DoWork += delegate (object _, DoWorkEventArgs e)
+                {
+                    Console.CursorVisible = false;
+                    while (!worker.CancellationPending)
+                    {
+
+                        char[] spinChars = new char[] { '|', '/', '-', '\\' };
+                        foreach (char spinChar in spinChars)
+                        {
+                            Console.CursorLeft = spinnerPosition;
+                            Console.Write(spinChar);
+                            Console.ForegroundColor = ConsoleColor.DarkGray;
+                            Console.Write($" {curMsg}{string.Join("",Enumerable.Repeat<char>(' ', Console.BufferWidth - curMsg.Length - 3).ToArray())}");
+                            Console.ResetColor();
+                            System.Threading.Thread.Sleep(50);
+                        }
+                    }
+                    e.Cancel = true;
+                    e.Result = "done";
+                };
+                worker.WorkerSupportsCancellation = true;
+                worker.RunWorkerAsync();
+            }
+            if (end)
+            {
+                worker.CancelAsync();
+                // according to docs, Cancel should trigger RunWorkerCompleted, but in .NET 5 I could not do anything complex there
+                // such as wiping the last line. This needs more debugging.
+                // So the thread sleep here allows for the worker to finish printing
+                System.Threading.Thread.Sleep(100);
+                // this clears the last line
+                Console.CursorVisible = true;
+                int currentLineCursor = Console.CursorTop;
+                Console.SetCursorPosition(0, Console.CursorTop);
+                Console.Write(new string(' ', Console.BufferWidth));
+                Console.SetCursorPosition(0, currentLineCursor);
+                // this allows the console to reset before we actually continue printing stuff
+                System.Threading.Thread.Sleep(100);
+            }
         }
 
         /// <summary>

--- a/cmf-cli/Objects/CmfPackage.cs
+++ b/cmf-cli/Objects/CmfPackage.cs
@@ -7,6 +7,9 @@ using Newtonsoft.Json.Serialization;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Xml.Linq;
 
 namespace Cmf.Common.Cli.Objects
 {
@@ -183,6 +186,13 @@ namespace Cmf.Common.Cli.Objects
         /// </value>
         [JsonProperty(Order = 13)]
         public List<string> XmlInjection { get; private set; }
+
+        /// <summary>
+        /// The location of the package
+        /// </summary>
+        [JsonProperty(Order = 13)]
+        [JsonIgnore]
+        public PackageLocation Location { get; private set; }
 
         #endregion
 
@@ -372,6 +382,85 @@ namespace Cmf.Common.Cli.Objects
             Version = version;
         }
 
+        /// <summary>
+        /// Builds a dependency tree by attaching the CmfPackage objects to the parent's dependencies
+        /// Can run recursively and fetch packages from a DF repository.
+        /// Supports cycles
+        /// </summary>
+        /// <param name="repo">the address of the repository (currently only folders are supported)</param>
+        /// <param name="recurse">should we run recursively</param>
+        /// <returns>this CmfPackage for chaining, but the method itself is mutable</returns>
+        public CmfPackage LoadDependencies(string repo, bool recurse = false) {
+            Uri repoUri = repo != null ? new Uri(repo) : null;
+            var loadedPackages = new List<CmfPackage>();
+            loadedPackages.Add(this);
+            Log.Progress($"Working on {this.Name ?? (this.PackageId + "@" + this.Version)}");
+
+            if (this.Dependencies.HasAny())
+            {
+                DirectoryInfo repoDirectory = null;
+                if (repoUri != null)
+                {
+                    if (repoUri.IsDirectory())
+                    {
+                        repoDirectory = new(repoUri.OriginalString);
+                    }
+                    else
+                    {
+                        throw new CliException(CliMessages.UrlsNotSupported);
+                    }
+                }
+
+                foreach (var dependency in this.Dependencies)
+                {
+                    Log.Progress($"Working on dependency {dependency.Id}@{dependency.Version}");
+                    string _dependencyFileName = $"{dependency.Id}.{dependency.Version}.zip";
+
+                    #region Get Dependencies from Dependencies Directory
+                    // 1) check if we have found this package before
+                    var dependencyPackage = loadedPackages.FirstOrDefault(x => x.PackageId.IgnoreCaseEquals(dependency.Id) && x.Version.IgnoreCaseEquals(dependency.Version));
+
+                    // 2) check if package is in repository
+                    if (dependencyPackage == null && (repoDirectory?.Exists ?? false))
+                    {
+                        FileInfo dependencyFile = repoDirectory.GetFiles(_dependencyFileName).FirstOrDefault();
+                        if (dependencyFile != null)
+                        {
+                            var zip = ZipFile.Open(dependencyFile.FullName, ZipArchiveMode.Read);
+                            var manifest = zip.GetEntry(CliConstants.DeploymentFrameworkManifestFileName);
+                            if (manifest != null)
+                            {
+                                using (var stream = manifest.Open())
+                                using (var reader = new StreamReader(stream))
+                                {
+                                    dependencyPackage = CmfPackage.FromManifest(reader.ReadToEnd(), setDefaultValues: true);
+                                }
+
+                            }
+                        }
+                    }
+
+                    // 3) search in the source code repository
+                    if (dependencyPackage == null)
+                    {
+                        dependencyPackage = this.GetFileInfo().Directory.LoadCmfPackagesFromSubDirectories(setDefaultValues: true).GetDependency(dependency);
+                    }
+
+                    if (dependencyPackage != null)
+                    {
+                        loadedPackages.Add(dependencyPackage);
+                        dependency.CmfPackage = dependencyPackage;
+                        if (recurse)
+                        {
+                            dependencyPackage.LoadDependencies(repo, recurse);
+                        }
+                    }
+                }
+                #endregion
+            }
+            return this;
+        }
+
         #region Static Methods
 
         /// <summary>
@@ -392,10 +481,70 @@ namespace Cmf.Common.Cli.Objects
 
             string fileContent = file.ReadToString();
             CmfPackage cmfPackage = JsonConvert.DeserializeObject<CmfPackage>(fileContent);
-            cmfPackage.FileInfo = file;
             cmfPackage.IsToSetDefaultValues = setDefaultValues;
-
+            cmfPackage.FileInfo = file;
+            cmfPackage.Location = PackageLocation.Local;
             cmfPackage.ValidatePackage();
+
+            return cmfPackage;
+        }
+
+        /// <summary>
+        /// Create a CmfPackage object from a DF package manifest
+        /// </summary>
+        /// <param name="manifest">the manifest content</param>
+        /// <param name="setDefaultValues">should set default values</param>
+        /// <returns>a CmfPackage</returns>
+        public static CmfPackage FromManifest(string manifest, bool setDefaultValues = false)
+        {
+            StringReader dFManifestReader = new(manifest);
+            XDocument dFManifestTemplate = XDocument.Load(dFManifestReader);
+            var tokens = new Dictionary<string, string>();
+
+            XElement rootNode = dFManifestTemplate.Element("deploymentPackage", true);
+            if (rootNode == null)
+            {
+                throw new CliException(string.Format(CliMessages.InvalidManifestFile));
+            }
+            DependencyCollection deps = new DependencyCollection();
+            foreach (XElement element in rootNode.Elements())
+            {
+                // Get the Property Value based on the Token name
+                string token = element.Value.Trim();
+
+                if (element.Name.LocalName == "dependencies")
+                {
+                    var deplist = element.Elements().Select(depEl => new Dependency(depEl.Attribute("id").Value, depEl.Attribute("version").Value));
+                    deps.AddRange(deplist);
+                }
+
+                if (string.IsNullOrEmpty(token))
+                {
+                    continue;
+                }
+
+                tokens.Add(element.Name.LocalName.ToLowerInvariant(), token);
+            }
+
+            // TODO: we're extracting only the essentials here for `cmf ls` but we can get extra data from the manifests
+            var cmfPackage = new CmfPackage(
+                tokens.ContainsKey("name") ? tokens["name"] : null,
+                tokens["packageid"],
+                tokens["version"],
+                tokens.ContainsKey("description") ? tokens["description"] : null,
+                PackageType.Generic,
+                "",
+                false,
+                false,
+                tokens.ContainsKey("keywords") ? tokens["keywords"] : null,
+                true,
+                deps,
+                null,
+                null,
+                null
+                );
+
+            cmfPackage.Location = PackageLocation.Repository;
 
             return cmfPackage;
         }

--- a/cmf-cli/Objects/Dependency.cs
+++ b/cmf-cli/Objects/Dependency.cs
@@ -40,6 +40,20 @@ namespace Cmf.Common.Cli.Objects
         [JsonIgnore]
         public bool Mandatory { get; set; }
 
+        /// <summary>
+        /// The CmfPackage that satisfies this dependency
+        /// </summary>
+        [JsonProperty(Order = 3)]
+        [JsonIgnore]
+        public CmfPackage CmfPackage { get; set; }
+
+        /// <summary>
+        /// Is this package missing, i.e. we could not find it anywhere to satisfy this dependency
+        /// </summary>
+        [JsonProperty(Order = 4)]
+        [JsonIgnore]
+        public bool IsMissing => this.CmfPackage == null;
+
         #endregion
 
         #region Constructors
@@ -52,7 +66,7 @@ namespace Cmf.Common.Cli.Objects
         /// <exception cref="ArgumentNullException">id
         /// or
         /// version</exception>
-        public Dependency(string id, string version)
+        public Dependency(string id, string version) : this()
         {
             Id = id ?? throw new ArgumentNullException(nameof(id));
             Version = version ?? throw new ArgumentNullException(nameof(version));


### PR DESCRIPTION
The purpose of this feature is two-fold: to provide a command to list the package tree (like npm ls) and also to provide a data structure to build this tree before we execute actions on the packages, such as pack, separating the "read" phase from the pack phase, which would make this both more testable and easier to debug.