### PR TITLE
Improvements to plugins loading

### DIFF
--- a/cmf-cli/Commands/plugin/PluginCommand.cs
+++ b/cmf-cli/Commands/plugin/PluginCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
@@ -58,7 +59,7 @@ namespace Cmf.Common.Cli.Commands
         {
             ProcessStartInfo ps = new();
             ps.FileName = this.commandPath;
-            ps.Arguments = String.Join(' ', args);
+            args.ToList().ForEach(arg => ps.ArgumentList.Add(arg));
             ps.UseShellExecute = false;
             ps.RedirectStandardOutput = true;
 


### PR DESCRIPTION
Improvements to CLI plugins discovery and execution:
- Avoid loading plugin **cmf-.exe** (or other valid extension), that would result in a command named **""**
- On the extraction of the command name from the executable name, do not replace "cmf-" and the extension everywhere, this may lead to a wrong command name
- On a plugin execution, parameters were not correctly quoted/handled if they contained spaces