### PR TITLE
replace getDefault with parseArgument in command arguments/options

### DIFF
--- a/cmf-cli/Commands/BaseCommand.cs
+++ b/cmf-cli/Commands/BaseCommand.cs
@@ -2,6 +2,7 @@ using Cmf.Common.Cli.Attributes;
 using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Parsing;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
@@ -172,6 +173,23 @@ namespace Cmf.Common.Cli.Commands
                 cmdInstance.AddCommand(childCmd);
             }
             return cmdInstance;
+        }
+
+        /// <summary>
+        /// parse argument/option
+        /// </summary>
+        /// <typeparam name="T">the (target) type of the argument/parameter</typeparam>
+        /// <param name="argResult">the arguments to parse</param>
+        /// <param name="default">the default value if no value is passed for the argument</param>
+        /// <returns></returns>
+        protected T Parse<T>(ArgumentResult argResult, string @default) where T: IDirectoryInfo
+        {
+            var path = @default;
+            if (argResult.Tokens.Any())
+            {
+                path = argResult.Tokens.First().Value;
+            }
+            return (T)this.fileSystem.DirectoryInfo.FromDirectoryName(path);
         }
     }
 }

--- a/cmf-cli/Commands/bump/BumpCommandIoTConfiguration.cs
+++ b/cmf-cli/Commands/bump/BumpCommandIoTConfiguration.cs
@@ -26,8 +26,12 @@ namespace Cmf.Common.Cli.Commands
         {
             cmd.AddArgument(new Argument<IDirectoryInfo>(
                 name: "path",
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("."); },
-                description: "path"));
+                parse: (argResult) => Parse<IDirectoryInfo>(argResult, "."),
+                isDefault: true
+            )
+            {
+                Description = "Working Directory"
+            });
 
             cmd.AddOption(new Option<string>(
                 aliases: new string[] { "-v", "--version" },

--- a/cmf-cli/Commands/bump/BumpCommandIoTCustomization.cs
+++ b/cmf-cli/Commands/bump/BumpCommandIoTCustomization.cs
@@ -25,8 +25,12 @@ namespace Cmf.Common.Cli.Commands
         {
             cmd.AddArgument(new Argument<IDirectoryInfo>(
                 name: "packagePath",
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("."); },
-                description: "Package path"));
+                parse: (argResult) => Parse<IDirectoryInfo>(argResult, "."),
+                isDefault: true
+            )
+            {
+                Description = "Package Path"
+            });
 
             cmd.AddOption(new Option<string>(
                 aliases: new string[] { "-v", "--version" },

--- a/cmf-cli/Commands/list/ListDependenciesCommand.cs
+++ b/cmf-cli/Commands/list/ListDependenciesCommand.cs
@@ -43,8 +43,12 @@ namespace Cmf.Common.Cli.Commands
         {
             cmd.AddArgument(new Argument<IDirectoryInfo>(
                 name: "workingDir",
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("."); },
-                description: "Working Directory"));
+                parse: (argResult) => Parse<IDirectoryInfo>(argResult, "."),
+                isDefault: true
+            )
+            {
+                Description = "Working Directory"
+            });
 
             cmd.AddOption(new Option<string>(
                 aliases: new string[] { "-r", "--repo" },

--- a/cmf-cli/Commands/pack/PackCommand.cs
+++ b/cmf-cli/Commands/pack/PackCommand.cs
@@ -9,6 +9,7 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using System.IO.Abstractions;
+using System.Linq;
 
 namespace Cmf.Common.Cli.Commands
 {
@@ -27,13 +28,18 @@ namespace Cmf.Common.Cli.Commands
         {
             cmd.AddArgument(new Argument<IDirectoryInfo>(
                 name: "workingDir",
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("."); },
-                description: "Working Directory"));
+                parse: (argResult) => Parse<IDirectoryInfo>(argResult, "."),
+                isDefault: true
+            )
+            {
+                Description = "Working Directory"
+            });
 
             cmd.AddOption(new Option<IDirectoryInfo>(
                 aliases: new string[] { "-o", "--outputDir" },
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("Package"); },
-                description: "Output directory for created package"));
+                parseArgument: argResult => Parse<IDirectoryInfo>(argResult, "Package"),
+                isDefault: true,
+                description: "Output directory for created package"));;
 
             cmd.AddOption(new Option<string>(
                 aliases: new string[] { "-r", "--repo" },

--- a/cmf-cli/Commands/publish/PublishCommand.cs
+++ b/cmf-cli/Commands/publish/PublishCommand.cs
@@ -127,12 +127,17 @@ namespace Cmf.Common.Cli.Commands
         {
             cmd.AddArgument(new Argument<IDirectoryInfo>(
                 name: "workingDir",
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("."); },
-                description: "Working Directory"));
+                parse: (argResult) => Parse<IDirectoryInfo>(argResult, "."),
+                isDefault: true
+            )
+            {
+                Description = "Working Directory"
+            });
 
             cmd.AddOption(new Option<IDirectoryInfo>(
                 aliases: new string[] { "-o", "--outputDir" },
-                getDefaultValue: () => { return this.fileSystem.DirectoryInfo.FromDirectoryName("Package"); },
+                parseArgument: argResult => Parse<IDirectoryInfo>(argResult, "Package"),
+                isDefault: true,
                 description: "Output directory for created package"));
 
             cmd.AddOption(new Option<string>(


### PR DESCRIPTION
replace getDefault with parseArgument in command arguments/options of type IDirectoryInfo, as the default casts do not work with IDirectoryInfo (closes #16)