### PR TITLE
Allow publishing test versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,10 +4,7 @@
 name: cmf-cli
 
 on:
-  # workflow_dispatch:
-  #   inputs:
-  #     tag:
-  #       description: 'Main tag to publish'
+  workflow_dispatch:
   release:
     types: [published]
 jobs:
@@ -55,10 +52,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: npm run publish
-        if: "github.event.release.prerelease"
+        if: "github.event.release && github.event.release.prerelease"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: npm run publish:live
-        if: "!github.event.release.prerelease"
+        if: "github.event.release && !github.event.release.prerelease"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm run publish:branch
+        if: "!github.event.release"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/PUBLISHING.MD
+++ b/PUBLISHING.MD
@@ -7,6 +7,9 @@ Publishing from GitHub is done using releases. As a guideline creating:
 - a pre-release publishes a new version of the cli to the **@next** tag
     - these releases may be created from branch _development_
 
+- running the npm-publish workflow manually will publish under a tag similar to the branch name
+    - this still requires a valid version number, that should include a pre-release suffix
+
 
 Go to [Releases](https://github.com/criticalmanufacturing/cli/releases) and click "Draft a new release"
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "build:prod:selfcontained:osx": "dotnet publish ./cmf-cli/cmf.csproj -c Release -r osx-x64 -o dist/osx-x64 --self-contained=false /p:PublishSingleFile=true",
     "publish": "cd npm && npm publish --tag next && cd ..",
     "publish:live": "cd npm && npm publish --tag latest && cd ..",
+    "publish:branch": "cd npm && npm publish --tag $(basename $GITHUB_REF) && cd ..",
     "bump:npm:pre": "cd npm && npm version prerelease --no-git-tag-version && cd ..",
     "bump:npm:patch": "cd npm && npm version patch --no-git-tag-version && cd ..",
     "bump:npm:feature": "cd npm && npm version minor --no-git-tag-version && cd ..",


### PR DESCRIPTION
For development, sometimes it is useful to publish a test version to npm for use in pipelines or other automation scenarios.
We currently have the @next tag, but this is exclusively for development versions with unstable but commited features.
This PR allows:
- running the publish workflow manually
- will publish to npm with the tag equal to the branch name
 - this limits us to one version published per branch, which should be more than enough for any testing
- @latest and @next will still be published by releasing and pre-releasing, respectively