### PR TITLE
Fix global run detection logic

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -33,6 +33,7 @@
     "debug": "^4.3.1",
     "env-paths": "^2.2.1",
     "is-installed-globally": "^0.4.0",
+    "is-path-inside": "^3.0.3",
     "mkdirp": "^1.0.4",
     "node_modules-path": "^2.0.5",
     "rimraf": "^3.0.2",

--- a/npm/run.js
+++ b/npm/run.js
@@ -5,6 +5,7 @@ const envPaths = require('env-paths');
 const path = require('path');
 const fs = require('fs');
 const isInstalledGlobally = require('is-installed-globally');
+const isPathInside = require('is-path-inside');
 const node_modules = require('node_modules-path');
 const dbg = require('debug');
 const { parsePackageJson, ARCH_MAPPING, PLATFORM_MAPPING } = require('./utils');
@@ -15,7 +16,7 @@ const debug = dbg("cmf:debug");
 debug("Executing cmf-cli");
 let exePath = null;
 debug("Determining if cli is installed globally or locally...");
-if (isInstalledGlobally) {
+if (isInstalledGlobally || isPathInside(__dirname, process.env.APPDATA)) {
   debug("cli is installed globally. Getting binary location from user profile...");
   const paths = envPaths("cmf-cli", {suffix: ""});
   exePath = path.join(paths.data, opts.binName);


### PR DESCRIPTION
Closes #44, provides a workaround for a case that [sindresorhus/is-installed-globally](https://github.com/sindresorhus/is-installed-globally) does not cover