### PR TITLE
fix(pipelines): make repository paths consistent

### DIFF
--- a/cmf-cli/Commands/new/BusinessCommand.cs
+++ b/cmf-cli/Commands/new/BusinessCommand.cs
@@ -44,7 +44,7 @@ namespace Cmf.Common.Cli.Commands.New
                 this.fileSystem.Path.Join("..", "..", //always two levels deep, this is the depth of the business solution projects
                     this.fileSystem.Path.GetRelativePath(
                         workingDir.FullName,
-                        this.fileSystem.Path.Join(projectRoot.FullName, "LocalEnviroment"))
+                        this.fileSystem.Path.Join(projectRoot.FullName, "LocalEnvironment"))
                 );
             var relativePathToDeploymentMetadata =
                 this.fileSystem.Path.Join("..", //always one levels deep, this is the depth of the business solution cmfpackage.json

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
@@ -76,7 +76,7 @@
     },
     "type": "TfsGit",
     "name": "<%= $CLI_PARAM_ProjectName %>",
-    "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/<%= $CLI_PARAM_ProjectName %>/_git/<%= $CLI_PARAM_ProjectName %>",
+    "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",
     "checkoutSubmodules": false

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
@@ -76,7 +76,7 @@
     },
     "type": "TfsGit",
     "name": "<%= $CLI_PARAM_ProjectName %>",
-    "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/<%= $CLI_PARAM_ProjectName %>/_git/<%= $CLI_PARAM_ProjectName %>",
+    "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",
     "checkoutSubmodules": false

--- a/cmf-cli/resources/template_feed/init/Builds/Environment-BackupRestore.json
+++ b/cmf-cli/resources/template_feed/init/Builds/Environment-BackupRestore.json
@@ -51,7 +51,7 @@
   },
   "repository": {
     "properties": {
-      "cloneUrl": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/<%= $CLI_PARAM_ProjectName %>/_git/<%= $CLI_PARAM_ProjectName %>",
+      "cloneUrl": "<%= $CLI_PARAM_RepositoryURL %>",
       "fullName": "<%= $CLI_PARAM_ProjectName %>",
       "defaultBranch": "refs/heads/development",
       "isFork": "False",
@@ -67,7 +67,7 @@
     },
     "type": "TfsGit",
     "name": "<%= $CLI_PARAM_ProjectName %>",
-    "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/<%= $CLI_PARAM_ProjectName %>/_git/<%= $CLI_PARAM_ProjectName %>",
+    "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": null,
     "checkoutSubmodules": false

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
@@ -76,7 +76,7 @@
     },
     "type": "TfsGit",
     "name": "<%= $CLI_PARAM_ProjectName %>",
-    "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/<%= $CLI_PARAM_ProjectName %>/_git/<%= $CLI_PARAM_ProjectName %>",
+    "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",
     "checkoutSubmodules": false

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
@@ -53,7 +53,7 @@ steps:
       # get pipeline
       $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
       $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' }
+      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "\PR-Builds" }
 
       if ($def -eq $null) {
           Write-Host "Build definition '${{ variables.PRPipeline }}' not found in project $(System.TeamProject)"

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
@@ -76,7 +76,7 @@
     },
     "type": "TfsGit",
     "name": "<%= $CLI_PARAM_ProjectName %>",
-    "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/<%= $CLI_PARAM_ProjectName %>/_git/<%= $CLI_PARAM_ProjectName %>",
+    "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",
     "checkoutSubmodules": false


### PR DESCRIPTION
Repository paths in some places were using some internal nomenclature instead of the Repository `init` input.
We also now make sure PR-Changes invoke PR-Package only if enabled and in the same folder (this was unlikely to cause conflicts nowadays as we had with CI-Package during a migration, but the behaviour should be the same in both places for consistency)