### PR TITLE
Hide 'local' command group from help

### DIFF
--- a/cmf-cli/Commands/local/LocalCommand.cs
+++ b/cmf-cli/Commands/local/LocalCommand.cs
@@ -4,10 +4,10 @@ using System.CommandLine;
 namespace Cmf.Common.Cli.Commands
 {
     /// <summary>
-    ///
+    /// Local commands. TODO: migrate this to the dev plugin.
     /// </summary>
     /// <seealso cref="Cmf.Common.Cli.Commands.BaseCommand" />
-    [CmfCommand("local")]
+    [CmfCommand("local", IsHidden = true)]
     public class LocalCommand : BaseCommand
     {
         /// <summary>

--- a/docs/cmf/Cmf_Common_Cli_Attributes.md
+++ b/docs/cmf/Cmf_Common_Cli_Attributes.md
@@ -22,6 +22,15 @@ The name.
   
   
 ### Properties
+<a name='Cmf_Common_Cli_Attributes_CmfCommandAttribute_IsHidden'></a>
+## CmfCommandAttribute.IsHidden Property
+should hide the command in help screens?  
+```csharp
+public bool IsHidden { get; set; }
+```
+#### Property Value
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')
+  
 <a name='Cmf_Common_Cli_Attributes_CmfCommandAttribute_Name'></a>
 ## CmfCommandAttribute.Name Property
 Gets or sets the name.  

--- a/docs/cmf/Cmf_Common_Cli_Commands.md
+++ b/docs/cmf/Cmf_Common_Cli_Commands.md
@@ -29,6 +29,15 @@ public AssembleCommand(System.IO.Abstractions.IFileSystem fileSystem);
   
   
 ### Fields
+<a name='Cmf_Common_Cli_Commands_AssembleCommand_defaultDependenciesToIgnore'></a>
+## AssembleCommand.defaultDependenciesToIgnore Field
+Dependencies that will be missing but should be ignored  
+```csharp
+private readonly string[] defaultDependenciesToIgnore;
+```
+#### Field Value
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')[[]](https://docs.microsoft.com/en-us/dotnet/api/System.Array 'System.Array')
+  
 <a name='Cmf_Common_Cli_Commands_AssembleCommand_packagesLocation'></a>
 ## AssembleCommand.packagesLocation Field
 Packages names and Uri to saved in a file in the end of the command execution  
@@ -840,6 +849,22 @@ Derived
 &#8627; [TestCommand](Cmf_Common_Cli_Commands_New.md#Cmf_Common_Cli_Commands_New_TestCommand 'Cmf.Common.Cli.Commands.New.TestCommand')  
 &#8627; [UILayerTemplateCommand](Cmf_Common_Cli_Commands.md#Cmf_Common_Cli_Commands_UILayerTemplateCommand 'Cmf.Common.Cli.Commands.UILayerTemplateCommand')  
 ### Constructors
+<a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string)'></a>
+## LayerTemplateCommand.LayerTemplateCommand(string, string) Constructor
+constructor  
+```csharp
+protected LayerTemplateCommand(string commandName, string packagePrefix);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string)_commandName'></a>
+`commandName` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+the name of the command
+  
+<a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string)_packagePrefix'></a>
+`packagePrefix` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+the package prefix. used as full name if not inside a feature.
+  
+  
 <a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string_System_IO_Abstractions_IFileSystem)'></a>
 ## LayerTemplateCommand.LayerTemplateCommand(string, string, IFileSystem) Constructor
 constructor  
@@ -858,22 +883,6 @@ the package prefix. used as full name if not inside a feature.
 <a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string_System_IO_Abstractions_IFileSystem)_fileSystem'></a>
 `fileSystem` [System.IO.Abstractions.IFileSystem](https://docs.microsoft.com/en-us/dotnet/api/System.IO.Abstractions.IFileSystem 'System.IO.Abstractions.IFileSystem')  
 the filesystem implementation
-  
-  
-<a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string)'></a>
-## LayerTemplateCommand.LayerTemplateCommand(string, string) Constructor
-constructor  
-```csharp
-protected LayerTemplateCommand(string commandName, string packagePrefix);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string)_commandName'></a>
-`commandName` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
-the name of the command
-  
-<a name='Cmf_Common_Cli_Commands_LayerTemplateCommand_LayerTemplateCommand(string_string)_packagePrefix'></a>
-`packagePrefix` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
-the package prefix. used as full name if not inside a feature.
   
   
 ### Fields
@@ -1013,6 +1022,7 @@ a set of repositories for remote packages
   
 <a name='Cmf_Common_Cli_Commands_LocalCommand'></a>
 ## LocalCommand Class
+Local commands. TODO: migrate this to the dev plugin.  
 ```csharp
 public class LocalCommand : Cmf.Common.Cli.Commands.BaseCommand
 ```
@@ -1367,6 +1377,17 @@ Derived
 &#8627; [FeatureCommand](Cmf_Common_Cli_Commands_New.md#Cmf_Common_Cli_Commands_New_FeatureCommand 'Cmf.Common.Cli.Commands.New.FeatureCommand')  
 &#8627; [NewCommand](Cmf_Common_Cli_Commands.md#Cmf_Common_Cli_Commands_NewCommand 'Cmf.Common.Cli.Commands.NewCommand')  
 ### Constructors
+<a name='Cmf_Common_Cli_Commands_TemplateCommand_TemplateCommand(string)'></a>
+## TemplateCommand.TemplateCommand(string) Constructor
+constructor  
+```csharp
+protected TemplateCommand(string commandName);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Commands_TemplateCommand_TemplateCommand(string)_commandName'></a>
+`commandName` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+  
+  
 <a name='Cmf_Common_Cli_Commands_TemplateCommand_TemplateCommand(string_System_IO_Abstractions_IFileSystem)'></a>
 ## TemplateCommand.TemplateCommand(string, IFileSystem) Constructor
 constructor  
@@ -1379,17 +1400,6 @@ protected TemplateCommand(string commandName, System.IO.Abstractions.IFileSystem
   
 <a name='Cmf_Common_Cli_Commands_TemplateCommand_TemplateCommand(string_System_IO_Abstractions_IFileSystem)_fileSystem'></a>
 `fileSystem` [System.IO.Abstractions.IFileSystem](https://docs.microsoft.com/en-us/dotnet/api/System.IO.Abstractions.IFileSystem 'System.IO.Abstractions.IFileSystem')  
-  
-  
-<a name='Cmf_Common_Cli_Commands_TemplateCommand_TemplateCommand(string)'></a>
-## TemplateCommand.TemplateCommand(string) Constructor
-constructor  
-```csharp
-protected TemplateCommand(string commandName);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Commands_TemplateCommand_TemplateCommand(string)_commandName'></a>
-`commandName` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
   
   
 ### Methods
@@ -1490,6 +1500,22 @@ Derived
 &#8627; [HelpCommand](Cmf_Common_Cli_Commands_New.md#Cmf_Common_Cli_Commands_New_HelpCommand 'Cmf.Common.Cli.Commands.New.HelpCommand')  
 &#8627; [HTMLCommand](Cmf_Common_Cli_Commands_New.md#Cmf_Common_Cli_Commands_New_HTMLCommand 'Cmf.Common.Cli.Commands.New.HTMLCommand')  
 ### Constructors
+<a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string)'></a>
+## UILayerTemplateCommand.UILayerTemplateCommand(string, string) Constructor
+constructor  
+```csharp
+protected UILayerTemplateCommand(string commandName, string packagePrefix);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string)_commandName'></a>
+`commandName` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+the name of the command
+  
+<a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string)_packagePrefix'></a>
+`packagePrefix` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+the package prefix. used as full name if not inside a feature.
+  
+  
 <a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string_System_IO_Abstractions_IFileSystem)'></a>
 ## UILayerTemplateCommand.UILayerTemplateCommand(string, string, IFileSystem) Constructor
 constructor  
@@ -1508,22 +1534,6 @@ the package prefix. used as full name if not inside a feature.
 <a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string_System_IO_Abstractions_IFileSystem)_fileSystem'></a>
 `fileSystem` [System.IO.Abstractions.IFileSystem](https://docs.microsoft.com/en-us/dotnet/api/System.IO.Abstractions.IFileSystem 'System.IO.Abstractions.IFileSystem')  
 the filesystem implementation
-  
-  
-<a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string)'></a>
-## UILayerTemplateCommand.UILayerTemplateCommand(string, string) Constructor
-constructor  
-```csharp
-protected UILayerTemplateCommand(string commandName, string packagePrefix);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string)_commandName'></a>
-`commandName` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
-the name of the command
-  
-<a name='Cmf_Common_Cli_Commands_UILayerTemplateCommand_UILayerTemplateCommand(string_string)_packagePrefix'></a>
-`packagePrefix` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
-the package prefix. used as full name if not inside a feature.
   
   
 ### Methods

--- a/docs/cmf/Cmf_Common_Cli_Constants.md
+++ b/docs/cmf/Cmf_Common_Cli_Constants.md
@@ -108,6 +108,15 @@ public const string LBOsFileLocation = Libs/LBOs/NetStandard/Cmf.LightBusinessOb
 #### Field Value
 [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
   
+<a name='Cmf_Common_Cli_Constants_CliConstants_NpmJsUrl'></a>
+## CliConstants.NpmJsUrl Field
+npm.js repository url  
+```csharp
+public const string NpmJsUrl = https://registry.npmjs.com;
+```
+#### Field Value
+[System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')
+  
 <a name='Cmf_Common_Cli_Constants_CliConstants_PackageJson'></a>
 ## CliConstants.PackageJson Field
 The package json  

--- a/docs/cmf/Cmf_Common_Cli_Handlers.md
+++ b/docs/cmf/Cmf_Common_Cli_Handlers.md
@@ -414,6 +414,19 @@ Derived
 
 Implements [IPackageTypeHandler](Cmf_Common_Cli_Interfaces.md#Cmf_Common_Cli_Interfaces_IPackageTypeHandler 'Cmf.Common.Cli.Interfaces.IPackageTypeHandler')  
 ### Constructors
+<a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_PackageTypeHandler(Cmf_Common_Cli_Objects_CmfPackage)'></a>
+## PackageTypeHandler.PackageTypeHandler(CmfPackage) Constructor
+Initializes a new instance of the [PackageTypeHandler](Cmf_Common_Cli_Handlers.md#Cmf_Common_Cli_Handlers_PackageTypeHandler 'Cmf.Common.Cli.Handlers.PackageTypeHandler') class.  
+```csharp
+public PackageTypeHandler(Cmf.Common.Cli.Objects.CmfPackage cmfPackage);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_PackageTypeHandler(Cmf_Common_Cli_Objects_CmfPackage)_cmfPackage'></a>
+`cmfPackage` [CmfPackage](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_CmfPackage 'Cmf.Common.Cli.Objects.CmfPackage')  
+  
+#### Exceptions
+[CliException](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_CliException 'Cmf.Common.Cli.Utilities.CliException')  
+  
 <a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_PackageTypeHandler(Cmf_Common_Cli_Objects_CmfPackage_System_IO_Abstractions_IFileSystem)'></a>
 ## PackageTypeHandler.PackageTypeHandler(CmfPackage, IFileSystem) Constructor
 Initializes a new instance of the [PackageTypeHandler](Cmf_Common_Cli_Handlers.md#Cmf_Common_Cli_Handlers_PackageTypeHandler 'Cmf.Common.Cli.Handlers.PackageTypeHandler') class.  
@@ -427,19 +440,6 @@ public PackageTypeHandler(Cmf.Common.Cli.Objects.CmfPackage cmfPackage, System.I
 <a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_PackageTypeHandler(Cmf_Common_Cli_Objects_CmfPackage_System_IO_Abstractions_IFileSystem)_fileSystem'></a>
 `fileSystem` [System.IO.Abstractions.IFileSystem](https://docs.microsoft.com/en-us/dotnet/api/System.IO.Abstractions.IFileSystem 'System.IO.Abstractions.IFileSystem')  
   
-  
-<a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_PackageTypeHandler(Cmf_Common_Cli_Objects_CmfPackage)'></a>
-## PackageTypeHandler.PackageTypeHandler(CmfPackage) Constructor
-Initializes a new instance of the [PackageTypeHandler](Cmf_Common_Cli_Handlers.md#Cmf_Common_Cli_Handlers_PackageTypeHandler 'Cmf.Common.Cli.Handlers.PackageTypeHandler') class.  
-```csharp
-public PackageTypeHandler(Cmf.Common.Cli.Objects.CmfPackage cmfPackage);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_PackageTypeHandler(Cmf_Common_Cli_Objects_CmfPackage)_cmfPackage'></a>
-`cmfPackage` [CmfPackage](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_CmfPackage 'Cmf.Common.Cli.Objects.CmfPackage')  
-  
-#### Exceptions
-[CliException](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_CliException 'Cmf.Common.Cli.Utilities.CliException')  
   
 ### Fields
 <a name='Cmf_Common_Cli_Handlers_PackageTypeHandler_BuildSteps'></a>

--- a/docs/cmf/Cmf_Common_Cli_Objects.md
+++ b/docs/cmf/Cmf_Common_Cli_Objects.md
@@ -835,6 +835,22 @@ public class DependencyCollection : System.Collections.Generic.List<Cmf.Common.C
 
 Inheritance [System.Object](https://docs.microsoft.com/en-us/dotnet/api/System.Object 'System.Object') &#129106; [System.Collections.Generic.List&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.List-1 'System.Collections.Generic.List`1')[Dependency](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_Dependency 'Cmf.Common.Cli.Objects.Dependency')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.List-1 'System.Collections.Generic.List`1') &#129106; DependencyCollection  
 ### Methods
+<a name='Cmf_Common_Cli_Objects_DependencyCollection_Contains(Cmf_Common_Cli_Objects_Dependency)'></a>
+## DependencyCollection.Contains(Dependency) Method
+Gets the dependency.  
+```csharp
+public bool Contains(Cmf.Common.Cli.Objects.Dependency dependency);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Objects_DependencyCollection_Contains(Cmf_Common_Cli_Objects_Dependency)_dependency'></a>
+`dependency` [Dependency](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_Dependency 'Cmf.Common.Cli.Objects.Dependency')  
+The dependency.
+  
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
+`true` if [contains] [the specified dependency]; otherwise, `false`.  
+            
+  
 <a name='Cmf_Common_Cli_Objects_DependencyCollection_Contains(Cmf_Common_Cli_Objects_Dependency_bool)'></a>
 ## DependencyCollection.Contains(Dependency, bool) Method
 Determines whether this instance contains the object.  
@@ -849,22 +865,6 @@ The dependency.
 <a name='Cmf_Common_Cli_Objects_DependencyCollection_Contains(Cmf_Common_Cli_Objects_Dependency_bool)_ignoreVersion'></a>
 `ignoreVersion` [System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
 if set to `true` [ignore version].
-  
-#### Returns
-[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
-`true` if [contains] [the specified dependency]; otherwise, `false`.  
-            
-  
-<a name='Cmf_Common_Cli_Objects_DependencyCollection_Contains(Cmf_Common_Cli_Objects_Dependency)'></a>
-## DependencyCollection.Contains(Dependency) Method
-Gets the dependency.  
-```csharp
-public bool Contains(Cmf.Common.Cli.Objects.Dependency dependency);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Objects_DependencyCollection_Contains(Cmf_Common_Cli_Objects_Dependency)_dependency'></a>
-`dependency` [Dependency](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_Dependency 'Cmf.Common.Cli.Objects.Dependency')  
-The dependency.
   
 #### Returns
 [System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
@@ -1061,6 +1061,21 @@ Initializes a new instance of the [Step](Cmf_Common_Cli_Objects.md#Cmf_Common_Cl
 public Step();
 ```
   
+<a name='Cmf_Common_Cli_Objects_Step_Step(System_Nullable_Cmf_Common_Cli_Enums_StepType_)'></a>
+## Step.Step(Nullable&lt;StepType&gt;) Constructor
+Initializes a new instance of the [Step](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_Step 'Cmf.Common.Cli.Objects.Step') class.  
+```csharp
+public Step(System.Nullable<Cmf.Common.Cli.Enums.StepType> type);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Objects_Step_Step(System_Nullable_Cmf_Common_Cli_Enums_StepType_)_type'></a>
+`type` [System.Nullable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')[StepType](Cmf_Common_Cli_Enums.md#Cmf_Common_Cli_Enums_StepType 'Cmf.Common.Cli.Enums.StepType')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')  
+The type.
+  
+#### Exceptions
+[System.ArgumentNullException](https://docs.microsoft.com/en-us/dotnet/api/System.ArgumentNullException 'System.ArgumentNullException')  
+type
+  
 <a name='Cmf_Common_Cli_Objects_Step_Step(System_Nullable_Cmf_Common_Cli_Enums_StepType__string_string_string_string_System_Nullable_bool__string_System_Nullable_Cmf_Common_Cli_Enums_MessageType_)'></a>
 ## Step.Step(Nullable&lt;StepType&gt;, string, string, string, string, Nullable&lt;bool&gt;, string, Nullable&lt;MessageType&gt;) Constructor
 Initializes a new instance of the [Step](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_Step 'Cmf.Common.Cli.Objects.Step') class.  
@@ -1099,21 +1114,6 @@ The target database.
 <a name='Cmf_Common_Cli_Objects_Step_Step(System_Nullable_Cmf_Common_Cli_Enums_StepType__string_string_string_string_System_Nullable_bool__string_System_Nullable_Cmf_Common_Cli_Enums_MessageType_)_messageType'></a>
 `messageType` [System.Nullable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')[MessageType](Cmf_Common_Cli_Enums.md#Cmf_Common_Cli_Enums_MessageType 'Cmf.Common.Cli.Enums.MessageType')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')  
 Type of the message.
-  
-#### Exceptions
-[System.ArgumentNullException](https://docs.microsoft.com/en-us/dotnet/api/System.ArgumentNullException 'System.ArgumentNullException')  
-type
-  
-<a name='Cmf_Common_Cli_Objects_Step_Step(System_Nullable_Cmf_Common_Cli_Enums_StepType_)'></a>
-## Step.Step(Nullable&lt;StepType&gt;) Constructor
-Initializes a new instance of the [Step](Cmf_Common_Cli_Objects.md#Cmf_Common_Cli_Objects_Step 'Cmf.Common.Cli.Objects.Step') class.  
-```csharp
-public Step(System.Nullable<Cmf.Common.Cli.Enums.StepType> type);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Objects_Step_Step(System_Nullable_Cmf_Common_Cli_Enums_StepType_)_type'></a>
-`type` [System.Nullable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')[StepType](Cmf_Common_Cli_Enums.md#Cmf_Common_Cli_Enums_StepType 'Cmf.Common.Cli.Enums.StepType')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Nullable-1 'System.Nullable`1')  
-The type.
   
 #### Exceptions
 [System.ArgumentNullException](https://docs.microsoft.com/en-us/dotnet/api/System.ArgumentNullException 'System.ArgumentNullException')  

--- a/docs/cmf/Cmf_Common_Cli_Utilities.md
+++ b/docs/cmf/Cmf_Common_Cli_Utilities.md
@@ -16,6 +16,18 @@ Initializes a new instance of the [CliException](Cmf_Common_Cli_Utilities.md#Cmf
 public CliException();
 ```
   
+<a name='Cmf_Common_Cli_Utilities_CliException_CliException(string)'></a>
+## CliException.CliException(string) Constructor
+Initializes a new instance of the [CliException](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_CliException 'Cmf.Common.Cli.Utilities.CliException') class.  
+```csharp
+public CliException(string message);
+```
+#### Parameters
+<a name='Cmf_Common_Cli_Utilities_CliException_CliException(string)_message'></a>
+`message` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
+The message that describes the error.
+  
+  
 <a name='Cmf_Common_Cli_Utilities_CliException_CliException(string_System_Exception)'></a>
 ## CliException.CliException(string, Exception) Constructor
 Initializes a new instance of the [CliException](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_CliException 'Cmf.Common.Cli.Utilities.CliException') class.  
@@ -30,18 +42,6 @@ The error message that explains the reason for the exception.
 <a name='Cmf_Common_Cli_Utilities_CliException_CliException(string_System_Exception)_innerException'></a>
 `innerException` [System.Exception](https://docs.microsoft.com/en-us/dotnet/api/System.Exception 'System.Exception')  
 The exception that is the cause of the current exception, or a null reference ([Nothing](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/Nothing 'https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/Nothing') in Visual Basic) if no inner exception is specified.
-  
-  
-<a name='Cmf_Common_Cli_Utilities_CliException_CliException(string)'></a>
-## CliException.CliException(string) Constructor
-Initializes a new instance of the [CliException](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_CliException 'Cmf.Common.Cli.Utilities.CliException') class.  
-```csharp
-public CliException(string message);
-```
-#### Parameters
-<a name='Cmf_Common_Cli_Utilities_CliException_CliException(string)_message'></a>
-`message` [System.String](https://docs.microsoft.com/en-us/dotnet/api/System.String 'System.String')  
-The message that describes the error.
   
   
 <a name='Cmf_Common_Cli_Utilities_CliException_CliException(System_Runtime_Serialization_SerializationInfo_System_Runtime_Serialization_StreamingContext)'></a>
@@ -215,6 +215,27 @@ The object.
 `true` if [has] [the specified object]; otherwise, `false`.  
             
   
+<a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)'></a>
+## ExtensionMethods.HasAny&lt;TSource&gt;(IEnumerable&lt;TSource&gt;) Method
+Determines whether a sequence contains any elements.  
+```csharp
+public static bool HasAny<TSource>(this System.Collections.Generic.IEnumerable<TSource> source);
+```
+#### Type parameters
+<a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)_TSource'></a>
+`TSource`  
+The type of the source.
+  
+#### Parameters
+<a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)_source'></a>
+`source` [System.Collections.Generic.IEnumerable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1 'System.Collections.Generic.IEnumerable`1')[TSource](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)_TSource 'Cmf.Common.Cli.Utilities.ExtensionMethods.HasAny&lt;TSource&gt;(System.Collections.Generic.IEnumerable&lt;TSource&gt;).TSource')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1 'System.Collections.Generic.IEnumerable`1')  
+The source.
+  
+#### Returns
+[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
+`true` if the specified source has any; otherwise, `false`.  
+            
+  
 <a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource__System_Func_TSource_bool_)'></a>
 ## ExtensionMethods.HasAny&lt;TSource&gt;(IEnumerable&lt;TSource&gt;, Func&lt;TSource,bool&gt;) Method
 Determines whether a sequence contains any elements.  
@@ -233,27 +254,6 @@ The source.
   
 <a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource__System_Func_TSource_bool_)_predicate'></a>
 `predicate` [System.Func&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Func-2 'System.Func`2')[TSource](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource__System_Func_TSource_bool_)_TSource 'Cmf.Common.Cli.Utilities.ExtensionMethods.HasAny&lt;TSource&gt;(System.Collections.Generic.IEnumerable&lt;TSource&gt;, System.Func&lt;TSource,bool&gt;).TSource')[,](https://docs.microsoft.com/en-us/dotnet/api/System.Func-2 'System.Func`2')[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Func-2 'System.Func`2')  
-  
-#### Returns
-[System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  
-`true` if the specified source has any; otherwise, `false`.  
-            
-  
-<a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)'></a>
-## ExtensionMethods.HasAny&lt;TSource&gt;(IEnumerable&lt;TSource&gt;) Method
-Determines whether a sequence contains any elements.  
-```csharp
-public static bool HasAny<TSource>(this System.Collections.Generic.IEnumerable<TSource> source);
-```
-#### Type parameters
-<a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)_TSource'></a>
-`TSource`  
-The type of the source.
-  
-#### Parameters
-<a name='Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)_source'></a>
-`source` [System.Collections.Generic.IEnumerable&lt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1 'System.Collections.Generic.IEnumerable`1')[TSource](Cmf_Common_Cli_Utilities.md#Cmf_Common_Cli_Utilities_ExtensionMethods_HasAny_TSource_(System_Collections_Generic_IEnumerable_TSource_)_TSource 'Cmf.Common.Cli.Utilities.ExtensionMethods.HasAny&lt;TSource&gt;(System.Collections.Generic.IEnumerable&lt;TSource&gt;).TSource')[&gt;](https://docs.microsoft.com/en-us/dotnet/api/System.Collections.Generic.IEnumerable-1 'System.Collections.Generic.IEnumerable`1')  
-The source.
   
 #### Returns
 [System.Boolean](https://docs.microsoft.com/en-us/dotnet/api/System.Boolean 'System.Boolean')  

--- a/docs/cmf/cmf.xml
+++ b/docs/cmf/cmf.xml
@@ -26,6 +26,11 @@
             The parent.
             </value>
         </member>
+        <member name="P:Cmf.Common.Cli.Attributes.CmfCommandAttribute.IsHidden">
+            <summary>
+            should hide the command in help screens?
+            </summary>
+        </member>
         <member name="M:Cmf.Common.Cli.Attributes.CmfCommandAttribute.#ctor(System.String)">
             <summary>
             Initializes a new instance of the <see cref="T:Cmf.Common.Cli.Attributes.CmfCommandAttribute" /> class.
@@ -523,6 +528,11 @@
         <member name="F:Cmf.Common.Cli.Commands.AssembleCommand.packagesLocation">
             <summary>
             Packages names and Uri to saved in a file in the end of the command execution
+            </summary>
+        </member>
+        <member name="F:Cmf.Common.Cli.Commands.AssembleCommand.defaultDependenciesToIgnore">
+            <summary>
+            Dependencies that will be missing but should be ignored
             </summary>
         </member>
         <member name="M:Cmf.Common.Cli.Commands.AssembleCommand.#ctor">
@@ -1036,10 +1046,10 @@
             <returns></returns>
         </member>
         <member name="T:Cmf.Common.Cli.Commands.LocalCommand">
-             <summary>
-            
-             </summary>
-             <seealso cref="T:Cmf.Common.Cli.Commands.BaseCommand" />
+            <summary>
+            Local commands. TODO: migrate this to the dev plugin.
+            </summary>
+            <seealso cref="T:Cmf.Common.Cli.Commands.BaseCommand" />
         </member>
         <member name="M:Cmf.Common.Cli.Commands.LocalCommand.Configure(System.CommandLine.Command)">
             <summary>
@@ -1528,6 +1538,11 @@
         <member name="F:Cmf.Common.Cli.Constants.CliConstants.Driver">
             <summary>
             Driver keyword for IoT Packages
+            </summary>
+        </member>
+        <member name="F:Cmf.Common.Cli.Constants.CliConstants.NpmJsUrl">
+            <summary>
+            npm.js repository url
             </summary>
         </member>
         <member name="F:Cmf.Common.Cli.Constants.CliConstants.TokenStartElement">


### PR DESCRIPTION
The local command group contains commands only useful to CMF employees, as they depend on our internal infrastructure. These commands will be migrated to a plugin in the near future, but to prevent confusion we should remove it from the help, at least.