### PR TITLE
feat: add version checks at start up refactor: add an IoC Container for easily mocking services

### DIFF
--- a/cmf-cli/Objects/ExecutionContext.cs
+++ b/cmf-cli/Objects/ExecutionContext.cs
@@ -1,5 +1,7 @@
 using Cmf.Common.Cli.Utilities;
 using System.IO.Abstractions;
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.Common.Cli.Objects
 {
@@ -25,6 +27,22 @@ namespace Cmf.Common.Cli.Objects
         /// The current execution RepositoriesConfig object
         /// </summary>
         public RepositoriesConfig RepositoriesConfig { get; set; }
+
+        /// <summary>
+        /// Get the current (executing) version of the CLI
+        /// </summary>
+        public static string CurrentVersion => (ServiceProvider.GetService<IVersionService>()!.CurrentVersion) ?? "dev";
+
+        /// <summary>
+        /// true if we're running a development/unstable version 
+        /// </summary>
+        public static bool IsDevVersion => CurrentVersion.Contains("-");
+        
+        /// <summary>
+        /// IoC container for services
+        /// NOTE: As we already have this ExecutionContext object, we're not enabling Hosting, but instead we are hosting the container in the execution context
+        /// </summary>
+        public static ServiceProvider ServiceProvider { get; set; }
 
         private ExecutionContext(IFileSystem fileSystem)
         {

--- a/cmf-cli/Objects/NPMClient.cs
+++ b/cmf-cli/Objects/NPMClient.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Reflection;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace Cmf.Common.Cli.Objects
+{
+    /// <summary>
+    /// The NPM Registry client interface
+    /// </summary>
+    public interface INPMClient
+    {
+        /// <summary>
+        /// gets the latest version of the CLI from the NPM registry
+        /// </summary>
+        /// <param name="preRelease">get the pre-release latest version</param>
+        /// <returns>a version identifier</returns>
+        Task<string> GetLatestVersion(bool preRelease = false);
+    }
+
+    /// <summary>
+    /// A live implementation of the NPM Registry client
+    /// </summary>
+    public class NPMClient : INPMClient
+    {
+        private string packageId = "@criticalmanufacturing/cli";
+        private string registry = "https://registry.npmjs.org/";
+
+        /// <summary>
+        /// gets the latest version of the CLI from the NPM registry
+        /// </summary>
+        /// <param name="preRelease">get the pre-release latest version</param>
+        /// <returns>a version identifier</returns>
+        public async Task<string> GetLatestVersion(bool preRelease = false)
+        {
+            var client = this.GetClient();
+            var res = await client.GetAsync($"{registry}{packageId}");
+            var body = await res.Content.ReadFromJsonAsync<JsonElement>();
+            return (body).GetProperty("dist-tags").GetProperty(preRelease ? "next" : "latest").GetString();
+        }
+
+        private HttpClient GetClient()
+        {
+            var client = new HttpClient();
+            client.DefaultRequestHeaders.Add("User-Agent",
+                $"criticalmanufacturing/cli v{ExecutionContext.CurrentVersion}");
+            return client;
+        }
+    }
+}

--- a/cmf-cli/Objects/VersionService.cs
+++ b/cmf-cli/Objects/VersionService.cs
@@ -1,0 +1,20 @@
+using System.Reflection;
+
+namespace Cmf.Common.Cli.Objects
+{
+    /// <summary>
+    /// Interface for a service that returns the current (running) CLI version
+    /// </summary>
+    public interface IVersionService
+    {
+        string CurrentVersion { get;  }
+    }
+
+    /// <summary>
+    /// Implementation for a service that return the current (running) CLI version
+    /// </summary>
+    public class VersionService : IVersionService
+    {
+        public string CurrentVersion => Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "dev";
+    }
+}

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>2.2.0-0</Version>
+    <Version>2.2.0-1</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,6 +23,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.3" />
     <PackageReference Include="Microsoft.TemplateEngine.Cli" Version="5.0.0-rtm.20509.1" />
     <PackageReference Include="Microsoft.TemplateEngine.Core" Version="5.0.204" />

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "2.2.0-0",
+  "version": "2.2.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "2.2.0-0",
+  "version": "2.2.0-1",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"

--- a/tests/Specs/Logging.cs
+++ b/tests/Specs/Logging.cs
@@ -21,7 +21,16 @@ namespace tests.Specs
         private AnsiConsoleFactory factory = new AnsiConsoleFactory();
         private StringWriter _writer = null;
         [TestInitialize]
-        public void Setup_Logging() 
+        public void Setup_Logging()
+        {
+            GetLogStringWriter();
+        }
+
+        /// <summary>
+        /// create a test console and return its string writer, which will contain all the console content
+        /// </summary>
+        /// <returns></returns>
+        public StringWriter GetLogStringWriter()
         {
             _writer = new StringWriter();
             Environment.SetEnvironmentVariable("cmf_cli_loglevel", null);
@@ -38,6 +47,8 @@ namespace tests.Specs
                     UseDefaultEnrichers = false,
                 },
             });
+
+            return _writer;
         }
 
         [TestMethod]

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -1,0 +1,99 @@
+using System.Threading.Tasks;
+using Cmf.Common.Cli.Objects;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace tests.Specs
+{
+    [TestClass]
+    public class Startup
+    {
+        #region mock services
+        class MockNPMClient999 : INPMClient
+        {
+            public Task<string> GetLatestVersion(bool preRelease = false)
+            {
+                return Task.FromResult("999.99.99");
+            }
+        }
+        
+        class MockNPMClientCurrent : INPMClient
+        {
+            public Task<string> GetLatestVersion(bool preRelease = false)
+            {
+                return Task.FromResult(ExecutionContext.CurrentVersion);
+            }
+        }
+
+        class MockVersionService : IVersionService
+        {
+            public string CurrentVersion => "1.0.0";
+        }
+        
+        class MockVersionServiceDev : IVersionService
+        {
+            public string CurrentVersion => "1.0.0-0";
+        }
+        #endregion
+
+        [TestMethod]
+        public async Task NotAtLatestVersion()
+        {
+            ExecutionContext.ServiceProvider = (new ServiceCollection())
+                .AddSingleton<INPMClient, MockNPMClient999>()
+                .AddSingleton<IVersionService, MockVersionService>()
+                .BuildServiceProvider();
+
+            var logWriter = (new Logging()).GetLogStringWriter();
+            
+            await Cmf.Common.Cli.Program.VersionChecks();
+            
+            Assert.IsTrue(logWriter.ToString().Contains("Please update"));
+        }
+        
+        [TestMethod]
+        public async Task AtLatestVersion()
+        {
+            ExecutionContext.ServiceProvider = (new ServiceCollection())
+                .AddSingleton<INPMClient, MockNPMClientCurrent>()
+                .AddSingleton<IVersionService, MockVersionService>()
+                .BuildServiceProvider();
+
+            var logWriter = (new Logging()).GetLogStringWriter();
+            
+            await Cmf.Common.Cli.Program.VersionChecks();
+            
+            Assert.IsFalse(logWriter.ToString().Contains("Please update"));
+        }
+
+        [TestMethod]
+        public async Task InDevVersion()
+        {
+            ExecutionContext.ServiceProvider = (new ServiceCollection())
+                .AddSingleton<INPMClient, MockNPMClientCurrent>()
+                .AddSingleton<IVersionService, MockVersionServiceDev>()
+                .BuildServiceProvider();
+            
+            var logWriter = (new Logging()).GetLogStringWriter();
+            
+            await Cmf.Common.Cli.Program.VersionChecks();
+            
+            Assert.IsTrue(logWriter.ToString().Contains("You are using development version"));
+        }
+        
+        [TestMethod]
+        public async Task InStableVersion()
+        {
+            ExecutionContext.ServiceProvider = (new ServiceCollection())
+                .AddSingleton<INPMClient, MockNPMClientCurrent>()
+                .AddSingleton<IVersionService, MockVersionService>()
+                .BuildServiceProvider();
+            
+            var logWriter = (new Logging()).GetLogStringWriter();
+            
+            await Cmf.Common.Cli.Program.VersionChecks();
+            
+            Assert.IsFalse(logWriter.ToString().Contains("You are using development version"));
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #94 
To help with decoupling and testing, we're using the dotnet default IoC container to register a few singletons. This could replace most of the properties of the ExecutionContext.
If we prefer to use Hosting, we may remove the ExecutionContext altogether, this is something we can look into.