### PR TITLE
test: migrate tests to xUnit

### DIFF
--- a/tests/Objects/AssertWithMessage.cs
+++ b/tests/Objects/AssertWithMessage.cs
@@ -1,0 +1,82 @@
+using System;
+using Xunit.Sdk;
+
+namespace tests
+{
+    /// <summary>
+    /// Extra Asserts that support custom reason
+    /// </summary>
+    public class AssertWithMessage : Xunit.Assert
+    {
+        public static void Equal<T>(T expected, T actual, string message)
+        {
+            try
+            {
+                Equal(expected, actual);
+            }
+            catch (EqualException)
+            {
+                throw new EqualWithMessageException(expected, actual, message);
+            }
+        }
+
+        public static void Null(object expected, string message)
+        {
+            try
+            {
+                Null(expected);
+            }
+            catch (NullException)
+            {
+                throw new NullWithMessageException(expected, message);
+            }
+        }
+        
+        public static void NotNull(object @object, string message)
+        {
+            try
+            {
+                NotNull(@object);
+            }
+            catch (NotNullException)
+            {
+                throw new NotNullWithMessageException(message);
+            }
+        }
+    }
+
+    public class EqualWithMessageException : EqualException
+    {
+        public EqualWithMessageException(object expected, object actual, string message) : base(expected, actual)
+        {
+            this.Message = message;
+        }
+
+        /// <summary>
+        /// <inheritdoc cref="EqualException.Message"/>
+        /// </summary>
+        public override string Message { get; }
+    }
+    
+    class NullWithMessageException : AssertActualExpectedException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="NullException"/> class.
+        /// </summary>
+        /// <param name="actual"></param>
+        /// <param name="message"></param>
+        public NullWithMessageException(object actual, string message)
+            : base(null, actual, message)
+        { }
+    }
+    
+    class NotNullWithMessageException : XunitException
+    {
+        /// <summary>
+        /// Creates a new instance of the <see cref="NotNullException"/> class.
+        /// </summary>
+        public NotNullWithMessageException(string message)
+            : base(message)
+        { }
+    }
+}

--- a/tests/Specs/CmfPackage_Load.cs
+++ b/tests/Specs/CmfPackage_Load.cs
@@ -1,20 +1,16 @@
 ﻿using Cmf.Common.Cli.Constants;
 using Cmf.Common.Cli.Objects;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
 
 namespace tests
 {
-    [TestClass]
     public class CmfPackage_Load
     {
-        [TestMethod]
+        [Fact]
         public void Root_HappyPath()
         {
             KeyValuePair<string, string> packageRoot = new("Cmf.Custom.Package", "1.1.0");
@@ -54,14 +50,14 @@ namespace tests
                 message = ex.Message;
             }
 
-            Assert.AreEqual(string.Empty, message);
-            Assert.IsNotNull(cmfPackage);
-            Assert.AreEqual(packageDep1.Value, cmfPackage.Dependencies[0].Version);
-            Assert.AreEqual(packageDep1.Value, cmfPackage.Dependencies[0].Version);
-            Assert.AreEqual(true, cmfPackage.Dependencies[0].IsMissing);
+            Assert.Equal(string.Empty, message);
+            Assert.NotNull(cmfPackage);
+            Assert.Equal(packageDep1.Value, cmfPackage.Dependencies[0].Version);
+            Assert.Equal(packageDep1.Value, cmfPackage.Dependencies[0].Version);
+            Assert.True(cmfPackage.Dependencies[0].IsMissing);
         }
 
-        [TestMethod]
+        [Fact]
         public void Root_WithoutMandatoryDependencies()
         {
             KeyValuePair<string, string> packageRoot = new("Cmf.Custom.Package", "1.1.0");
@@ -100,11 +96,10 @@ namespace tests
                 message = ex.Message;
             }
 
-            Assert.AreEqual("Mandatory Dependency criticalmanufacturing.deploymentmetadata or cmf.environment. not found", message);
+            Assert.Equal("Mandatory Dependency criticalmanufacturing.deploymentmetadata or cmf.environment. not found", message);
         }
-
-        // When is fixed by the product team, ignore can be removed
-        [TestMethod, Ignore]
+        
+        [Fact(Skip = "awaiting product fix")]
         public void IoT_WithoutMandatoryDependencies()
         {
             KeyValuePair<string, string> packageIoT = new("Cmf.Custom.IoT", "1.1.0");
@@ -144,10 +139,10 @@ namespace tests
                 message = ex.Message;
             }
 
-            Assert.AreEqual("Mandatory Dependency cmf.connectiot.packages. not found", message);
+            Assert.Equal("Mandatory Dependency cmf.connectiot.packages. not found", message);
         }
 
-        [TestMethod]
+        [Fact]
         public void Business_WithoutContentToPack()
         {
             KeyValuePair<string, string> packageRoot = new("Cmf.Custom.Business", "1.1.0");
@@ -181,7 +176,7 @@ namespace tests
             }
             string fileLocation = fileSystem.FileInfo.FromFileName("/repo/cmfpackage.json").FullName;
 
-            Assert.AreEqual(@$"Missing mandatory property ContentToPack in file { fileLocation }", message);
+            Assert.Equal(@$"Missing mandatory property ContentToPack in file { fileLocation }", message);
         }
     }
 }

--- a/tests/Specs/CmfPackage_Save.cs
+++ b/tests/Specs/CmfPackage_Save.cs
@@ -1,7 +1,6 @@
 ﻿using Cmf.Common.Cli.Commands;
 using Cmf.Common.Cli.Constants;
 using Cmf.Common.Cli.Objects;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -12,19 +11,19 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Xunit;
 
 namespace tests.Specs
 {
     /// <summary>
     /// The cmf package_ save.
     /// </summary>
-    [TestClass]
     public class CmfPackage_Save
     {
         /// <summary>
         /// Validates that the enums are serialized as string and not as int
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void KeepEnumStrings()
         {
             KeyValuePair<string, string> package = new("Cmf.Custom.Data", "1.1.0");
@@ -59,17 +58,17 @@ namespace tests.Specs
             cmfPackageObj.SaveCmfPackage();
 
             dynamic cmfpackageFileContent = JsonConvert.DeserializeObject(fileSystem.File.ReadAllText(cmfpackageFile.FullName));
-            Assert.AreEqual("Data", cmfpackageFileContent.packageType.ToString());
-            Assert.AreEqual("CreateIntegrationEntries", cmfpackageFileContent.steps[0].type.ToString());
-            Assert.AreEqual("ImportObject", cmfpackageFileContent.steps[0].messageType.ToString());
-            Assert.AreEqual("Generic", cmfpackageFileContent.contentToPack[0].contentType.ToString());
-            Assert.AreEqual("Pack", cmfpackageFileContent.contentToPack[0].action.ToString());
+            Assert.Equal("Data", cmfpackageFileContent.packageType.ToString());
+            Assert.Equal("CreateIntegrationEntries", cmfpackageFileContent.steps[0].type.ToString());
+            Assert.Equal("ImportObject", cmfpackageFileContent.steps[0].messageType.ToString());
+            Assert.Equal("Generic", cmfpackageFileContent.contentToPack[0].contentType.ToString());
+            Assert.Equal("Pack", cmfpackageFileContent.contentToPack[0].action.ToString());
         }
 
         /// <summary>
         /// Validates that the handler version is not serialized
         /// </summary>
-        [TestMethod]
+        [Fact]
         public void IgnoreHandlerVersion()
         {
             KeyValuePair<string, string> package = new("Cmf.Custom.Data", "1.1.0");
@@ -96,12 +95,10 @@ namespace tests.Specs
             IFileInfo cmfpackageFile = fileSystem.FileInfo.FromFileName($"repo/{CliConstants.CmfPackageFileName}");
             CmfPackage cmfPackageObj = CmfPackage.Load(cmfpackageFile, fileSystem: fileSystem);
 
-            Assert.IsNotNull(cmfPackageObj.HandlerVersion);
-
             cmfPackageObj.SaveCmfPackage();
 
             dynamic cmfpackageFileContent = JsonConvert.DeserializeObject(fileSystem.File.ReadAllText(cmfpackageFile.FullName));
-            Assert.IsNull(cmfpackageFileContent.handlerVersion);
+            Assert.Null(cmfpackageFileContent.handlerVersion);
         }
     }
 }

--- a/tests/Specs/ConsistencyCheckValidator.cs
+++ b/tests/Specs/ConsistencyCheckValidator.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System.IO.Abstractions.TestingHelpers;
 using System.Collections.Generic;
 using Cmf.Common.Cli.Objects;
@@ -8,14 +8,14 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO.Abstractions;
 using System.CommandLine.IO;
+using FluentAssertions;
 using tests.Objects;
 
 namespace tests.Specs
 {
-    [TestClass]
     public class ConsistencyCheckValidator
     {
-        [TestMethod]
+        [Fact]
         public void ConsistencyCheckValidator_HappyPath()
         {
             MockFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -90,10 +90,10 @@ namespace tests.Specs
                 "test/Data/"
             }, console);
 
-            Assert.IsTrue(console.Error == null || string.IsNullOrEmpty(console.Error.ToString()), $"Consistency Check failed {console.Error.ToString()}");
+            Assert.True(console.Error == null || string.IsNullOrEmpty(console.Error.ToString()), $"Consistency Check failed {console.Error.ToString()}");
 
         }
-        [TestMethod]
+        [Fact]
         public void ConsistencyCheckValidator_FailData()
         {
             MockFileSystem fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -168,7 +168,7 @@ namespace tests.Specs
                 "test/Data/"
             }, console);
 
-            Assert.IsTrue(console.Error != null && console.Error.ToString().Contains("This root package dependencies must enforce version consistency. Root Version 1.1.0 Failed Package Version 1.2.0"), $"Consistency Check failed {console.Error.ToString()}");
+            console.Error.ToString().Should().Contain("This root package dependencies must enforce version consistency. Root Version 1.1.0 Failed Package Version 1.2.0", $"Consistency Check failed {console.Error.ToString()}");
 
         }
     }

--- a/tests/Specs/JsonValidator.cs
+++ b/tests/Specs/JsonValidator.cs
@@ -1,4 +1,4 @@
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System.IO.Abstractions.TestingHelpers;
 using System.Collections.Generic;
 using Cmf.Common.Cli.Objects;
@@ -12,10 +12,9 @@ using tests.Objects;
 
 namespace tests.Specs
 {
-    [TestClass]
     public class JsonValidator
     {
-        [TestMethod]
+        [Fact]
         public void Data_JsonValidator_HappyPath()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -81,11 +80,11 @@ namespace tests.Specs
                 "test/Data/"
             }, console);
 
-            Assert.IsTrue(console.Error == null || string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed {console.Error.ToString()}");
+            Assert.True(console.Error == null || string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed {console.Error.ToString()}");
 
         }
 
-        [TestMethod]
+        [Fact]
         public void Data_JsonValidator_FailData()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -150,10 +149,10 @@ namespace tests.Specs
                 "test/Data/"
             }, console);
 
-            Assert.IsTrue(console.Error != null && !string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed for Data Package: {console.Error.ToString()}");
+            Assert.True(console.Error != null && !string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed for Data Package: {console.Error.ToString()}");
         }
 
-        [TestMethod]
+        [Fact]
         public void IoTData_JsonValidator_FailData()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -257,10 +256,10 @@ namespace tests.Specs
                 "test/Data/"
             }, console);
 
-            Assert.IsTrue(console.Error != null && !string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed for IoT Data Package: {console.Error.ToString()}");
+            Assert.True(console.Error != null && !string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed for IoT Data Package: {console.Error.ToString()}");
         }
 
-        [TestMethod]
+        [Fact]
         public void IoTData_Workflow_JsonValidator_FailData()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -364,7 +363,7 @@ namespace tests.Specs
                 "test/Data/"
             }, console);
 
-            Assert.IsTrue(console.Error != null && !string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed for IoT Data Workflow Package: {console.Error.ToString()}");
+            Assert.True(!string.IsNullOrEmpty(console.Error.ToString()), $"Json Validator failed for IoT Data Workflow Package: {console.Error.ToString()}");
         }
     }
 }

--- a/tests/Specs/ListDependencies.cs
+++ b/tests/Specs/ListDependencies.cs
@@ -1,5 +1,4 @@
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO.Abstractions.TestingHelpers;
 using System.Collections.Generic;
 using System.CommandLine;
@@ -13,13 +12,14 @@ using Cmf.Common.Cli.Enums;
 using Cmf.Common.Cli.Objects;
 using Cmf.Common.Cli.Utilities;
 using tests.Objects;
+using Assert = tests.AssertWithMessage;
+using Xunit;
 
 namespace tests
 {
-    [TestClass]
     public class ListDependencies
     {
-        [TestMethod]
+        [Fact]
         public void LocalDependencies_HappyPath()
         {
             var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
@@ -88,27 +88,27 @@ namespace tests
 
             CmfPackage cmfPackage = CmfPackage.Load(fileSystem.FileInfo.FromFileName("/test/cmfpackage.json"), setDefaultValues: true, fileSystem);
             cmfPackage.LoadDependencies(null, null, true);
-            Assert.AreEqual("Cmf.Custom.Package", cmfPackage.PackageId, "Root package name doesn't match expected");
-            Assert.AreEqual(3, cmfPackage.Dependencies.Count, "Root package doesn't have expected dependencies");
+            Assert.Equal("Cmf.Custom.Package", cmfPackage.PackageId, "Root package name doesn't match expected");
+            Assert.Equal(3, cmfPackage.Dependencies.Count, "Root package doesn't have expected dependencies");
 
             var busPackage = cmfPackage.Dependencies[0];
-            Assert.IsFalse(busPackage.IsMissing, "Business package is missing");
-            Assert.IsNotNull(busPackage.CmfPackage, "Business package couldn't be loaded");
-            Assert.AreEqual("Cmf.Custom.Business", busPackage.CmfPackage.PackageId, "Business package name doesn't match expected");
-            Assert.IsNull(busPackage.CmfPackage.Dependencies, "Business package has unexpected dependencies");
+            Assert.False(busPackage.IsMissing, "Business package is missing");
+            Assert.NotNull(busPackage.CmfPackage, "Business package couldn't be loaded");
+            Assert.Equal("Cmf.Custom.Business", busPackage.CmfPackage.PackageId, "Business package name doesn't match expected");
+            Assert.Null(busPackage.CmfPackage.Dependencies, "Business package has unexpected dependencies");
 
             var htmlPackage = cmfPackage.Dependencies[1];
-            Assert.IsFalse(htmlPackage.IsMissing, "HTML package is missing");
-            Assert.IsNotNull(htmlPackage.CmfPackage, "HTML package couldn't be loaded");
-            Assert.AreEqual("Cmf.Custom.HTML", htmlPackage.CmfPackage.PackageId, "HTML package name doesn't match expected");
-            Assert.IsNull(htmlPackage.CmfPackage.Dependencies, "HTML package has unexpected dependencies");
+            Assert.False(htmlPackage.IsMissing, "HTML package is missing");
+            Assert.NotNull(htmlPackage.CmfPackage, "HTML package couldn't be loaded");
+            Assert.Equal("Cmf.Custom.HTML", htmlPackage.CmfPackage.PackageId, "HTML package name doesn't match expected");
+            Assert.Null(htmlPackage.CmfPackage.Dependencies, "HTML package has unexpected dependencies");
 
             var productPackage = cmfPackage.Dependencies[2];
-            Assert.IsTrue(productPackage.IsMissing, "Product package isn't missing");
-            Assert.IsNull(productPackage.CmfPackage, "Product package could be loaded");
+            Assert.True(productPackage.IsMissing, "Product package isn't missing");
+            Assert.Null(productPackage.CmfPackage, "Product package could be loaded");
         }
         
-        [TestMethod]
+        [Fact]
         public void LocalDependencies_RepositoryPackages()
         {
             var repoUri = OperatingSystem.IsWindows() ? new Uri("\\\\share\\dir") : new Uri("file:///repoDir");
@@ -185,36 +185,36 @@ namespace tests
             CmfPackage cmfPackage = CmfPackage.Load(fileSystem.FileInfo.FromFileName("/test/cmfpackage.json"), setDefaultValues: true, fileSystem);
             ExecutionContext.Initialize(fileSystem);
             cmfPackage.LoadDependencies(new []{ repoUri }, null, true);
-            Assert.AreEqual("Cmf.Custom.Package", cmfPackage.PackageId, "Root package name doesn't match expected");
-            Assert.AreEqual(3, cmfPackage.Dependencies.Count, "Root package doesn't have expected dependencies");
+            Assert.Equal("Cmf.Custom.Package", cmfPackage.PackageId, "Root package name doesn't match expected");
+            Assert.Equal(3, cmfPackage.Dependencies.Count, "Root package doesn't have expected dependencies");
 
             var busPackage = cmfPackage.Dependencies[0];
-            Assert.IsFalse(busPackage.IsMissing, "Business package is missing");
-            Assert.IsNotNull(busPackage.CmfPackage, "Business package couldn't be loaded");
-            Assert.AreEqual("Cmf.Custom.Business", busPackage.CmfPackage.PackageId, "Business package name doesn't match expected");
-            Assert.IsNull(busPackage.CmfPackage.Dependencies, "Business package has unexpected dependencies");
+            Assert.False(busPackage.IsMissing, "Business package is missing");
+            Assert.NotNull(busPackage.CmfPackage, "Business package couldn't be loaded");
+            Assert.Equal("Cmf.Custom.Business", busPackage.CmfPackage.PackageId, "Business package name doesn't match expected");
+            Assert.Null(busPackage.CmfPackage.Dependencies, "Business package has unexpected dependencies");
 
             var htmlPackage = cmfPackage.Dependencies[1];
-            Assert.IsFalse(htmlPackage.IsMissing, "HTML package is missing");
-            Assert.IsNotNull(htmlPackage.CmfPackage, "HTML package couldn't be loaded");
-            Assert.AreEqual("Cmf.Custom.HTML", htmlPackage.CmfPackage.PackageId, "HTML package name doesn't match expected");
-            Assert.IsNull(htmlPackage.CmfPackage.Dependencies, "HTML package has unexpected dependencies");
+            Assert.False(htmlPackage.IsMissing, "HTML package is missing");
+            Assert.NotNull(htmlPackage.CmfPackage, "HTML package couldn't be loaded");
+            Assert.Equal("Cmf.Custom.HTML", htmlPackage.CmfPackage.PackageId, "HTML package name doesn't match expected");
+            Assert.Null(htmlPackage.CmfPackage.Dependencies, "HTML package has unexpected dependencies");
 
             var productPackage = cmfPackage.Dependencies[2];
-            Assert.IsFalse(productPackage.IsMissing, "Product package is missing");
-            Assert.IsNotNull(productPackage.CmfPackage, "Product package couldn't be loaded");
-            Assert.AreEqual(productPackage.CmfPackage.Location, PackageLocation.Repository,
+            Assert.False(productPackage.IsMissing, "Product package is missing");
+            Assert.NotNull(productPackage.CmfPackage, "Product package couldn't be loaded");
+            Assert.Equal(productPackage.CmfPackage.Location, PackageLocation.Repository,
               "Product package is not located in Repository");
-            Assert.AreEqual("CriticalManufacturing", productPackage.CmfPackage.PackageId, "Product package name doesn't match expected");
-            Assert.AreEqual(1, productPackage.CmfPackage.Dependencies.Count, "Product package doesn't have expected dependencies");
+            Assert.Equal("CriticalManufacturing", productPackage.CmfPackage.PackageId, "Product package name doesn't match expected");
+            Assert.Equal(1, productPackage.CmfPackage.Dependencies.Count, "Product package doesn't have expected dependencies");
             
             var productInnerPackage = productPackage.CmfPackage.Dependencies[0];
-            Assert.IsTrue(productInnerPackage.IsMissing, "Product Inner package isn't missing");
-            Assert.IsNull(productInnerPackage.CmfPackage, "Product Inner package could be loaded");
+            Assert.True(productInnerPackage.IsMissing, "Product Inner package isn't missing");
+            Assert.Null(productInnerPackage.CmfPackage, "Product Inner package could be loaded");
             
         }
         
-        [TestMethod]
+        [Fact]
         public void Args_MultiRepo()
         {
           string _workingDir = null;
@@ -237,13 +237,13 @@ namespace tests
           }, console);
           
           var curDir = new DirectoryInfo(System.IO.Directory.GetCurrentDirectory());
-          Assert.AreEqual(curDir.Name, _workingDir, "working dir does not match expected");
-          Assert.AreEqual(2, _repos.Length, "Expecting 2 repositories");
-          Assert.AreEqual("d:\\xpto", _repos[0], "Wrong repository location");
-          Assert.AreEqual("e:\\packages", _repos[1], "Wrong repository location");
+          Assert.Equal(curDir.Name, _workingDir, "working dir does not match expected");
+          Assert.Equal(2, _repos.Length, "Expecting 2 repositories");
+          Assert.Equal("d:\\xpto", _repos[0], "Wrong repository location");
+          Assert.Equal("e:\\packages", _repos[1], "Wrong repository location");
         }
         
-        [TestMethod]
+        [Fact]
         public void Args_MultiRepo_UrlLocalMix()
         {
           string _workingDir = null;
@@ -266,15 +266,15 @@ namespace tests
           }, console);
           
           var curDir = new DirectoryInfo(System.IO.Directory.GetCurrentDirectory());
-          Assert.AreEqual(curDir.Name, _workingDir, "working dir does not match expected");
-          Assert.AreEqual(2, _repos.Length, "Expecting 2 repositories");
-          Assert.AreEqual("file:///d:/xpto", _repos[0].AbsoluteUri, "Wrong repository location");
-          Assert.AreEqual("http://repository.example/", _repos[1].AbsoluteUri, "Wrong repository location");
-          Assert.IsTrue(_repos[0].IsDirectory(), "First repo should be a directory");
-          Assert.IsFalse(_repos[1].IsDirectory(), "Second repo not should be a directory");
+          Assert.Equal(curDir.Name, _workingDir, "working dir does not match expected");
+          Assert.Equal(2, _repos.Length, "Expecting 2 repositories");
+          Assert.Equal("file:///d:/xpto", _repos[0].AbsoluteUri, "Wrong repository location");
+          Assert.Equal("http://repository.example/", _repos[1].AbsoluteUri, "Wrong repository location");
+          Assert.True(_repos[0].IsDirectory(), "First repo should be a directory");
+          Assert.False(_repos[1].IsDirectory(), "Second repo not should be a directory");
         }
         
-        [TestMethod]
+        [Fact]
         public void Args_MultiRepo_RelativeDirectory()
         {
           string _workingDir = null;
@@ -297,14 +297,14 @@ namespace tests
           }, console);
           
           var curDir = new DirectoryInfo(System.IO.Directory.GetCurrentDirectory());
-          Assert.AreEqual(curDir.Name, _workingDir, "working dir does not match expected");
-          Assert.AreEqual(2, _repos.Length, "Expecting 2 repositories");
-          Assert.AreEqual("..\\xpto", _repos[0].OriginalString, "Wrong repository location");
-          Assert.AreEqual("\\root_dir", _repos[1].OriginalString, "Wrong repository location");
+          Assert.Equal(curDir.Name, _workingDir, "working dir does not match expected");
+          Assert.Equal(2, _repos.Length, "Expecting 2 repositories");
+          Assert.Equal("..\\xpto", _repos[0].OriginalString, "Wrong repository location");
+          Assert.Equal("\\root_dir", _repos[1].OriginalString, "Wrong repository location");
           // TODO: use mock filesystem to resolve relative urls
         }
         
-        [TestMethod]
+        [Fact]
         public void Args_SingleRepo()
         {
           string _workingDir = null;
@@ -327,9 +327,9 @@ namespace tests
           }, console);
           
           var curDir = new DirectoryInfo(System.IO.Directory.GetCurrentDirectory());
-          Assert.AreEqual(curDir.Name, _workingDir, "working dir does not match expected");
-          Assert.AreEqual(1, _repos.Length, "Expecting 2 repositories");
-          Assert.AreEqual("d:\\xpto", _repos[0], "Wrong repository location");
+          Assert.Equal(curDir.Name, _workingDir, "working dir does not match expected");
+          Assert.Equal(1, _repos.Length, "Expecting 2 repositories");
+          Assert.Equal("d:\\xpto", _repos[0], "Wrong repository location");
         }
     }
     

--- a/tests/Specs/Logging.cs
+++ b/tests/Specs/Logging.cs
@@ -1,27 +1,20 @@
 ﻿using Cmf.Common.Cli;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Spectre.Console;
-using Spectre.Console.Advanced;
-using Spectre.Console.Testing;
 using System;
-using System.Collections.Generic;
 using System.CommandLine;
-using System.CommandLine.Parsing;
+using System.Diagnostics;
 using System.IO;
-using System.IO.Abstractions.TestingHelpers;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Xunit;
+using Assert = tests.AssertWithMessage;
 
 namespace tests.Specs
 {
-    [TestClass]
     public class Logging
     {
         private AnsiConsoleFactory factory = new AnsiConsoleFactory();
         private StringWriter _writer = null;
-        [TestInitialize]
-        public void Setup_Logging()
+        
+        public Logging()
         {
             GetLogStringWriter();
         }
@@ -51,16 +44,16 @@ namespace tests.Specs
             return _writer;
         }
 
-        [TestMethod]
+        [Fact]
         public void LogDebug_WhenVerbose()
         {
-            Assert.AreEqual(LogLevel.Verbose, Log.Level, "Default log level is not Verbose");
+            Assert.Equal(LogLevel.Verbose, Log.Level, "Default log level is not Verbose");
             Log.Debug("testing");
             var text = _writer.ToString();
-            Assert.AreEqual(string.Empty, text.Trim(), "Debug statement should not have been printed");
+            Assert.Equal(string.Empty, text.Trim(), "Debug statement should not have been printed");
         }
 
-        [TestMethod]
+        [Fact]
         public void LogDebug_WhenDebug_Assign()
         {
             // System.Environment.SetEnvironmentVariable("cmf:cli:loglevel", "debug");
@@ -68,13 +61,13 @@ namespace tests.Specs
             Log.Level = LogLevel.Debug;
 
             // var root = Program.Main(new string[] { "--loglevel", "debug", "ls" });
-            Assert.AreEqual(LogLevel.Debug, Log.Level, "Log level is not Debug");
+            Assert.Equal(LogLevel.Debug, Log.Level, "Log level is not Debug");
             Log.Debug("testing");
             var text = _writer.ToString();
-            Assert.AreEqual("testing", text.Trim(), "Debug statement should not have been printed");
+            Assert.Equal("testing", text.Trim(), "Debug statement should not have been printed");
         }
 
-        [TestMethod]
+        [Fact]
         public void LogDebug_WhenDebug_Option()
         {
             // System.Environment.SetEnvironmentVariable("cmf:cli:loglevel", "debug");
@@ -82,13 +75,13 @@ namespace tests.Specs
             // Log.Level = LogLevel.Debug;
 
             // var root = Program.Main(new string[] { "--loglevel", "debug", "ls" });
-            Assert.AreEqual(LogLevel.Debug, Log.Level, "Log level is not Debug");
+            Assert.Equal(LogLevel.Debug, Log.Level, "Log level is not Debug");
             Log.Debug("testing");
             var text = _writer.ToString();
-            Assert.AreEqual("testing", text.Trim(), "Debug statement should not have been printed");
+            Assert.Equal("testing", text.Trim(), "Debug statement should not have been printed");
         }
 
-        [TestMethod]
+        [Fact]
         public void LogDebug_WhenDebug_Environment()
         {
             System.Environment.SetEnvironmentVariable("cmf_cli_loglevel", "debug");
@@ -97,48 +90,18 @@ namespace tests.Specs
             // Log.Level = LogLevel.Debug;
 
             // var root = Program.Main(new string[] { "--loglevel", "debug", "ls" });
-            Assert.AreEqual(LogLevel.Debug, Log.Level, "Log level is not Debug");
+            Assert.Equal(LogLevel.Debug, Log.Level, "Log level is not Debug");
             Log.Debug("testing");
             var text = _writer.ToString();
-            Assert.AreEqual("testing", text.Trim(), "Debug statement should not have been printed");
+            Assert.Equal("testing", text.Trim(), "Debug statement should not have been printed");
         }
 
-        [TestMethod]
-        public void LogDebug()
-        {
-            LogLevelTest(LogLevel.Debug, new string[] { "debug", "verbose", "information", "warning", "error" }, new string[0]);
-        }
-
-        [TestMethod]
-        public void LogVerbose()
-        {
-            LogLevelTest(LogLevel.Verbose, new string[] { "verbose", "information", "warning", "error" }, new string[] { "debug" });
-        }
-
-        [TestMethod]
-        public void LogInformation()
-        {
-            LogLevelTest(LogLevel.Information, new string[] { "information", "warning", "error" }, new string[] { "debug", "verbose" });
-        }
-
-        [TestMethod]
-        public void LogWarning()
-        {
-            LogLevelTest(LogLevel.Warning, new string[] { "warning", "error" }, new string[] { "debug", "verbose", "information" });
-        }
-
-        [TestMethod]
-        public void LogError()
-        {
-            LogLevelTest(LogLevel.Error, new[] { "error" }, new string[] { "debug", "verbose", "information", "warning" });
-        }
-
-        //[Theory]
-        //[InlineData(LogLevel.Debug, new string[] { "debug", "verbose", "information", "warning", "error" }, new string[0])]
-        //[InlineData(LogLevel.Verbose, new string[] { "verbose", "information", "warning", "error" }, new string[] { "debug" })]
-        //[InlineData(LogLevel.Information, new string[] { "information", "warning", "error" }, new string[] { "debug", "verbose" })]
-        //[InlineData(LogLevel.Warning, new string[] { "warning", "error" }, new string[] { "debug", "verbose", "information" })]
-        //[InlineData(LogLevel.Error, new[] { "error" }, new string[] { "debug", "verbose", "information", "warning" })]
+        [Theory]
+        [InlineData(LogLevel.Debug, new string[] { "debug", "verbose", "information", "warning", "error" }, new string[0])]
+        [InlineData(LogLevel.Verbose, new string[] { "verbose", "information", "warning", "error" }, new string[] { "debug" })]
+        [InlineData(LogLevel.Information, new string[] { "information", "warning", "error" }, new string[] { "debug", "verbose" })]
+        [InlineData(LogLevel.Warning, new string[] { "warning", "error" }, new string[] { "debug", "verbose", "information" })]
+        [InlineData(LogLevel.Error, new[] { "error" }, new string[] { "debug", "verbose", "information", "warning" })]
         public void LogLevelTest(LogLevel level, string[] expected, string[] notExpected)
         {
             Log.Level = level;
@@ -152,11 +115,11 @@ namespace tests.Specs
             var text = _writer.ToString();
             foreach (var exp in expected)
             {
-                Assert.IsTrue(text.Contains(exp));
+                Assert.Contains(exp, text);
             }
             foreach (var exp in notExpected)
             {
-                Assert.IsFalse(text.Contains(exp));
+                Assert.DoesNotContain(exp, text);
             }
         }
     }

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -9,15 +9,15 @@ using System.Text.Json;
 using Cmf.Common.Cli.Commands;
 using Cmf.Common.Cli.Commands.New;
 using Cmf.Common.Cli.Enums;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using Xunit;
+using Assert = tests.AssertWithMessage;
 
 namespace tests.Specs
 {
-    [TestClass]
     public class New
     {
-        [TestInitialize]
-        public void Reset()
+        public New()
         {
             var newCommand = new NewCommand();
             var cmd = new Command("x");
@@ -29,7 +29,7 @@ namespace tests.Specs
             }, console);
         }
 
-        [TestMethod]
+        [Fact]
         public void Init()
         {
             var rnd = new Random();
@@ -72,13 +72,13 @@ namespace tests.Specs
 
                 var extractFileName = new Func<string, string>(s => s.Split(Path.DirectorySeparatorChar).LastOrDefault());
 
-                Assert.IsTrue(File.Exists(".project-config.json"), "project config is missing");
-                Assert.IsTrue(File.Exists("cmfpackage.json"), "root cmfpackage is missing");
-                Assert.IsTrue(File.Exists("global.json"), "global .NET versioning is missing");
-                Assert.IsTrue(File.Exists("NuGet.Config"), "global NuGet feeds config is missing");
+                Assert.True(File.Exists(".project-config.json"), "project config is missing");
+                Assert.True(File.Exists("cmfpackage.json"), "root cmfpackage is missing");
+                Assert.True(File.Exists("global.json"), "global .NET versioning is missing");
+                Assert.True(File.Exists("NuGet.Config"), "global NuGet feeds config is missing");
 
-                Assert.IsTrue(Directory.Exists(Path.Join(tmp, "Builds")), "pipelines are missing");
-                Assert.IsTrue(
+                Assert.True(Directory.Exists(Path.Join(tmp, "Builds")), "pipelines are missing");
+                Assert.True(
                     new[]{ "CI-Changes.json",
                         "CI-Package.json",
                         "CI-Publish.json",
@@ -90,7 +90,7 @@ namespace tests.Specs
                                 .GetFiles("Builds")
                                 .Select(extractFileName)
                                 .Contains(f)), "Missing pipeline metadata");
-                Assert.IsTrue(
+                Assert.True(
                     new[]{ "CI-Changes.yml",
                             "CI-Package.yml",
                             "CI-Publish.yml",
@@ -102,7 +102,7 @@ namespace tests.Specs
                             .GetFiles("Builds")
                             .Select(extractFileName)
                             .Contains(f)), "Missing pipeline source");
-                Assert.IsTrue(
+                Assert.True(
                     new[]{ "policies-master.json",
                             "policies-development.json" }
                         .ToList()
@@ -110,22 +110,22 @@ namespace tests.Specs
                             .GetFiles("Builds")
                             .Select(extractFileName)
                             .Contains(f)), "Missing policy metadata");
-                Assert.IsTrue(Directory.Exists(Path.Join(tmp, "EnvironmentConfigs")), "environment configs are missing");
-                Assert.IsTrue(
+                Assert.True(Directory.Exists(Path.Join(tmp, "EnvironmentConfigs")), "environment configs are missing");
+                Assert.True(
                     new[] { "GlobalVariables.yml" }
                         .ToList()
                         .All(f => Directory
                             .GetFiles("EnvironmentConfigs")
                             .Select(extractFileName)
                             .Contains(f)), "Missing global variables");
-                Assert.IsTrue(
+                Assert.True(
                     new[] { "config.json" } // this should be a constant when moving to a mock
                         .ToList()
                         .All(f => Directory
                             .GetFiles("EnvironmentConfigs")
                             .Select(extractFileName)
                             .Contains(f)), "Missing environment configuration");
-                Assert.IsTrue(Directory.Exists(Path.Join(tmp, "Libs")), "Libs are missing");
+                Assert.True(Directory.Exists(Path.Join(tmp, "Libs")), "Libs are missing");
             }
             finally
             {
@@ -134,7 +134,7 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Init_Fail_MissingMandatoryArgumentsAndOptions()
         {
             var console = new TestConsole();
@@ -145,18 +145,18 @@ namespace tests.Specs
 
             cmd.Invoke(Array.Empty<string>(), console);
             
-            Assert.IsTrue(console.Error.ToString()!.Contains("Required argument missing for command: x"));
+            Assert.Contains("Required argument missing for command: x", console.Error.ToString());
             foreach (var optionName in new[]
                  {
                      "repositoryUrl", "MESVersion", "DevTasksVersion", "HTMLStarterVersion", "yoGeneratorVersion",
                      "nugetVersion", "testScenariosNugetVersion", "deploymentDir"
                  })
             {
-                Assert.IsTrue(console.Error.ToString()!.Contains($"Option '--{optionName}' is required."));
+                Assert.Contains($"Option '--{optionName}' is required.", console.Error.ToString());
             }
         }
         
-        [TestMethod]
+        [Fact]
         public void Init_Fail_MissingInfra()
         {
             var console = new TestConsole();
@@ -190,7 +190,7 @@ namespace tests.Specs
                     "--deploymentDir", deploymentDir,
                 }, console);
                 
-                Assert.IsTrue(console.Error.ToString()!.Contains("Missing infrastructure options"));
+                Assert.Contains("Missing infrastructure options", console.Error.ToString());
             }
             finally
             {
@@ -200,7 +200,7 @@ namespace tests.Specs
         }
         
         
-        [TestMethod]
+        [Fact]
         public void Init_Containers()
         {
             var initCommand = new InitCommand();
@@ -249,13 +249,13 @@ namespace tests.Specs
 
                 var extractFileName = new Func<string, string>(s => s.Split(Path.DirectorySeparatorChar).LastOrDefault());
 
-                Assert.IsTrue(File.Exists(".project-config.json"), "project config is missing");
-                Assert.IsTrue(File.Exists("cmfpackage.json"), "root cmfpackage is missing");
-                Assert.IsTrue(File.Exists("global.json"), "global .NET versioning is missing");
-                Assert.IsTrue(File.Exists("NuGet.Config"), "global NuGet feeds config is missing");
+                Assert.True(File.Exists(".project-config.json"), "project config is missing");
+                Assert.True(File.Exists("cmfpackage.json"), "root cmfpackage is missing");
+                Assert.True(File.Exists("global.json"), "global .NET versioning is missing");
+                Assert.True(File.Exists("NuGet.Config"), "global NuGet feeds config is missing");
 
-                Assert.IsTrue(Directory.Exists(Path.Join(tmp, "Builds")), "pipelines are missing");
-                Assert.IsTrue(
+                Assert.True(Directory.Exists(Path.Join(tmp, "Builds")), "pipelines are missing");
+                Assert.True(
                     new[]{ "CI-Changes.json",
                         "CI-Package.json",
                         "CI-Publish.json",
@@ -267,7 +267,7 @@ namespace tests.Specs
                                 .GetFiles("Builds")
                                 .Select(extractFileName)
                                 .Contains(f)), "Missing pipeline metadata");
-                Assert.IsTrue(
+                Assert.True(
                     new[]{ "CI-Changes.yml",
                             "CI-Package.yml",
                             "CI-Publish.yml",
@@ -279,7 +279,7 @@ namespace tests.Specs
                             .GetFiles("Builds")
                             .Select(extractFileName)
                             .Contains(f)), "Missing pipeline source");
-                Assert.IsTrue(
+                Assert.True(
                     new[]{ "policies-master.json",
                             "policies-development.json" }
                         .ToList()
@@ -287,22 +287,22 @@ namespace tests.Specs
                             .GetFiles("Builds")
                             .Select(extractFileName)
                             .Contains(f)), "Missing policy metadata");
-                Assert.IsTrue(Directory.Exists(Path.Join(tmp, "EnvironmentConfigs")), "environment configs are missing");
-                Assert.IsTrue(
+                Assert.True(Directory.Exists(Path.Join(tmp, "EnvironmentConfigs")), "environment configs are missing");
+                Assert.True(
                     new[] { "GlobalVariables.yml" }
                         .ToList()
                         .All(f => Directory
                             .GetFiles("EnvironmentConfigs")
                             .Select(extractFileName)
                             .Contains(f)), "Missing global variables");
-                Assert.IsTrue(
+                Assert.True(
                     new[] { "config.json" } // this should be a constant when moving to a mock
                         .ToList()
                         .All(f => Directory
                             .GetFiles("EnvironmentConfigs")
                             .Select(extractFileName)
                             .Contains(f)), "Missing environment configuration");
-                Assert.IsTrue(Directory.Exists(Path.Join(tmp, "Libs")), "Libs are missing");
+                Assert.True(Directory.Exists(Path.Join(tmp, "Libs")), "Libs are missing");
             }
             finally
             {
@@ -311,28 +311,28 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Business()
         {
             RunNew(new BusinessCommand(), "Cmf.Custom.Business", extraAsserts: args =>
             {
                 var (pkgVersion, dir) = args;
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Business/Cmf.Custom.Common/tenantConstants.cs"), "Constants file is missing or has wrong name");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Business/Cmf.Custom.Common/Cmf.Custom.tenant.Common.csproj"), "Common project file is missing or has wrong name");
+                Assert.True(File.Exists($"Cmf.Custom.Business/Cmf.Custom.Common/tenantConstants.cs"), "Constants file is missing or has wrong name");
+                Assert.True(File.Exists($"Cmf.Custom.Business/Cmf.Custom.Common/Cmf.Custom.tenant.Common.csproj"), "Common project file is missing or has wrong name");
                 // namespace checks
-                Assert.IsTrue(File.ReadAllText("Cmf.Custom.Business/Cmf.Custom.Common/tenantConstants.cs").Contains("namespace Cmf.Custom.tenant.Common"), "Constants namespace is wrong name");
+                Assert.True(File.ReadAllText("Cmf.Custom.Business/Cmf.Custom.Common/tenantConstants.cs").Contains("namespace Cmf.Custom.tenant.Common"), "Constants namespace is wrong name");
                 // assembly name checks
-                Assert.IsTrue(File.ReadAllText("Cmf.Custom.Business/Cmf.Custom.Common/Cmf.Custom.tenant.Common.csproj").Contains("<AssemblyName>Cmf.Custom.tenant.Common</AssemblyName>"), "Constants assembly name is wrong name");
+                Assert.True(File.ReadAllText("Cmf.Custom.Business/Cmf.Custom.Common/Cmf.Custom.tenant.Common.csproj").Contains("<AssemblyName>Cmf.Custom.tenant.Common</AssemblyName>"), "Constants assembly name is wrong name");
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void Data()
         {
             RunNew(new DataCommand(), "Cmf.Custom.Data");
         }
 
-        [TestMethod, TestCategory("LongRunning")]
+        [Fact, Trait("TestCategory", "LongRunning")]
         public void UI()
         {
             RunNew(new HTMLCommand(), "Cmf.Custom.HTML", extraArguments: new string[]
@@ -340,54 +340,54 @@ namespace tests.Specs
                 "--htmlPkg", GetFixturePath("prodPkg", "Cmf.Presentation.HTML.9.9.9.zip"),
             }, extraAsserts: args =>
             {
-                Assert.IsTrue(File.Exists($"Cmf.Custom.HTML/.dev-tasks.json"), "dev-tasks file is missing or has wrong name. Was cloning HTML-starter unsuccessful?");
-                Assert.IsTrue(Directory.Exists($"Cmf.Custom.HTML/apps/customization.web"), "WebApp dir is missing or has wrong name. Was running the application generator unsuccessful?");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.HTML/apps/customization.web/config.json"), "Config file is missing or has wrong name");
-                Assert.IsTrue(File.ReadAllText("Cmf.Custom.HTML/apps/customization.web/config.json").Contains("test.package"), "Product package is not in config.json");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.HTML/apps/customization.web/index.html"), "Index file is missing or has wrong name");
+                Assert.True(File.Exists($"Cmf.Custom.HTML/.dev-tasks.json"), "dev-tasks file is missing or has wrong name. Was cloning HTML-starter unsuccessful?");
+                Assert.True(Directory.Exists($"Cmf.Custom.HTML/apps/customization.web"), "WebApp dir is missing or has wrong name. Was running the application generator unsuccessful?");
+                Assert.True(File.Exists($"Cmf.Custom.HTML/apps/customization.web/config.json"), "Config file is missing or has wrong name");
+                Assert.True(File.ReadAllText("Cmf.Custom.HTML/apps/customization.web/config.json").Contains("test.package"), "Product package is not in config.json");
+                Assert.True(File.Exists($"Cmf.Custom.HTML/apps/customization.web/index.html"), "Index file is missing or has wrong name");
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void UI_FailNoPackage()
         {
             var console = RunNew(new HTMLCommand(), "Cmf.Custom.HTML", defaultAsserts: false);
             var stderr = console.Error.ToString();
-            Assert.IsTrue(stderr.Trim().Equals("Option '--htmlPkg' is required."), "Should exit with missing package error");
+            Assert.True(stderr.Trim().Equals("Option '--htmlPkg' is required."), "Should exit with missing package error");
         }
 
-        [TestMethod, TestCategory("LongRunning")]
+        [Fact, Trait("TestCategory", "LongRunning")]
         public void Help()
         {
             RunNew(new Cmf.Common.Cli.Commands.New.HelpCommand(), "Cmf.Custom.Help", extraArguments: new string[] {
                 "--docPkg", GetFixturePath("prodPkg", "Cmf.Documentation.9.9.9.zip"),
             }, extraAsserts: args =>
             {
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Help/.dev-tasks.json"), "dev-tasks file is missing or has wrong name. Was cloning HTML-starter unsuccessful?");
-                Assert.IsTrue(Directory.Exists($"Cmf.Custom.Help/apps/cmf.docs.area.web"), "WebApp dir is missing or has wrong name. Was running the application generator unsuccessful?");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Help/apps/cmf.docs.area.web/config.json"), "Config file is missing or has wrong name");
-                Assert.IsTrue(File.ReadAllText("Cmf.Custom.Help/apps/cmf.docs.area.web/config.json").Contains("test.package"), "Product package is not in config.json");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Help/apps/cmf.docs.area.web/index.html"), "Index file is missing or has wrong name");
-                Assert.IsTrue(File.ReadAllText("Cmf.Custom.Help/apps/cmf.docs.area.web/index.html").Contains("Documentation website"), "Index content is not expected");
-                Assert.IsTrue(File.ReadAllText("Cmf.Custom.Help/apps/cmf.docs.area.web/index.html").Contains("<base href=\"/\">"), "Index base path was not changed correctly");
+                Assert.True(File.Exists($"Cmf.Custom.Help/.dev-tasks.json"), "dev-tasks file is missing or has wrong name. Was cloning HTML-starter unsuccessful?");
+                Assert.True(Directory.Exists($"Cmf.Custom.Help/apps/cmf.docs.area.web"), "WebApp dir is missing or has wrong name. Was running the application generator unsuccessful?");
+                Assert.True(File.Exists($"Cmf.Custom.Help/apps/cmf.docs.area.web/config.json"), "Config file is missing or has wrong name");
+                Assert.True(File.ReadAllText("Cmf.Custom.Help/apps/cmf.docs.area.web/config.json").Contains("test.package"), "Product package is not in config.json");
+                Assert.True(File.Exists($"Cmf.Custom.Help/apps/cmf.docs.area.web/index.html"), "Index file is missing or has wrong name");
+                Assert.True(File.ReadAllText("Cmf.Custom.Help/apps/cmf.docs.area.web/index.html").Contains("Documentation website"), "Index content is not expected");
+                Assert.True(File.ReadAllText("Cmf.Custom.Help/apps/cmf.docs.area.web/index.html").Contains("<base href=\"/\">"), "Index base path was not changed correctly");
             });
         }
 
-        [TestMethod]
+        [Fact]
         public void Help_FailNoPackage()
         {
             var console = RunNew(new Cmf.Common.Cli.Commands.New.HelpCommand(), "Cmf.Custom.Help", defaultAsserts: false);
             var stderr = console.Error.ToString();
-            Assert.IsTrue(stderr.Trim().Equals("Option '--docPkg' is required."), "Should exit with missing package error");
+            Assert.True(stderr.Trim().Equals("Option '--docPkg' is required."), "Should exit with missing package error");
         }
 
-        [TestMethod]
+        [Fact]
         public void IoT()
         {
             RunNew(new IoTCommand(), "Cmf.Custom.IoT");
         }
 
-        [TestMethod]
+        [Fact]
         public void IoTData()
         {
             string dir = GetTmpDirectory();
@@ -399,17 +399,17 @@ namespace tests.Specs
             RunNew(new IoTCommand(), packageId, dir);
 
             // Validate IoT Data
-            Assert.IsTrue(Directory.Exists($"{packageId}/{packageFolder}"), "Package folder is missing");
-            Assert.IsTrue(Directory.Exists($"{packageId}/{packageFolder}/MasterData"), "Folder MasterData is missing");
-            Assert.IsTrue(Directory.Exists($"{packageId}/{packageFolder}/AutomationWorkFlows"), "Folder AutomationWorkFlows is missing");
+            Assert.True(Directory.Exists($"{packageId}/{packageFolder}"), "Package folder is missing");
+            Assert.True(Directory.Exists($"{packageId}/{packageFolder}/MasterData"), "Folder MasterData is missing");
+            Assert.True(Directory.Exists($"{packageId}/{packageFolder}/AutomationWorkFlows"), "Folder AutomationWorkFlows is missing");
             
-            Assert.AreEqual(packageIdData, GetPackageProperty("packageId", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Id does not match expected");
-            Assert.AreEqual(PackageType.IoTData.ToString(), GetPackageProperty("packageType", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Type does not match expected");
-            Assert.AreEqual(GetPackageProperty("version", $"{packageId}/cmfpackage.json"), 
+            Assert.Equal(packageIdData, GetPackageProperty("packageId", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Id does not match expected");
+            Assert.Equal(PackageType.IoTData.ToString(), GetPackageProperty("packageType", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Type does not match expected");
+            Assert.Equal(GetPackageProperty("version", $"{packageId}/cmfpackage.json"), 
                 GetPackageProperty("version", $"{packageId}/{packageFolder}/cmfpackage.json"), "Version does not match expected");
         }
 
-        [TestMethod]
+        [Fact]
         public void IoTPackage()
         {
             string dir = GetTmpDirectory();
@@ -421,18 +421,18 @@ namespace tests.Specs
             RunNew(new IoTCommand(), packageId, dir);
 
             // Validate IoT Package
-            Assert.IsTrue(Directory.Exists($"{packageId}/{packageFolder}"), "Package folder is missing");
-            Assert.IsTrue(Directory.Exists($"{packageId}/{packageFolder}/src"), "Folder MasterData is missing");
-            Assert.IsTrue(File.Exists($"{packageId}/{packageFolder}/.dev-tasks.json"), "Folder AutomationWorkFlows is missing");
-            Assert.IsTrue(File.Exists($"{packageId}/{packageFolder}/package.json"), "Folder AutomationWorkFlows is missing");
+            Assert.True(Directory.Exists($"{packageId}/{packageFolder}"), "Package folder is missing");
+            Assert.True(Directory.Exists($"{packageId}/{packageFolder}/src"), "Folder MasterData is missing");
+            Assert.True(File.Exists($"{packageId}/{packageFolder}/.dev-tasks.json"), "Folder AutomationWorkFlows is missing");
+            Assert.True(File.Exists($"{packageId}/{packageFolder}/package.json"), "Folder AutomationWorkFlows is missing");
 
-            Assert.AreEqual(packageIdData, GetPackageProperty("packageId", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Id does not match expected");
-            Assert.AreEqual(PackageType.IoT.ToString(), GetPackageProperty("packageType", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Type does not match expected");
-            Assert.AreEqual(GetPackageProperty("version", $"{packageId}/cmfpackage.json"),
+            Assert.Equal(packageIdData, GetPackageProperty("packageId", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Id does not match expected");
+            Assert.Equal(PackageType.IoT.ToString(), GetPackageProperty("packageType", $"{packageId}/{packageFolder}/cmfpackage.json"), "Package Type does not match expected");
+            Assert.Equal(GetPackageProperty("version", $"{packageId}/cmfpackage.json"),
                 GetPackageProperty("version", $"{packageId}/{packageFolder}/cmfpackage.json"), "Version does not match expected");
         }
 
-        [TestMethod]
+        [Fact]
         public void Database()
         {
             RunDatabase(null);
@@ -443,24 +443,24 @@ namespace tests.Specs
             RunNew(new DatabaseCommand(), "Cmf.Custom.Database", scaffoldingDir: scaffoldingDir, defaultAsserts: false, extraAsserts: args =>
             {
                 var (packageVersion, _) = args;
-                Assert.IsTrue(Directory.Exists("Cmf.Custom.Database"), "Package folder is missing");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Database/Pre/cmfpackage.json"), "Pre Package cmfpackage.json is missing");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Database/Post/cmfpackage.json"), "Post Package cmfpackage.json is missing");
-                Assert.IsTrue(File.Exists($"Cmf.Custom.Database/Post/Reporting/cmfpackage.json"), "Reports Package cmfpackage.json is missing");
-                Assert.AreEqual("Cmf.Custom.Database.Pre", GetPackageProperty("packageId", $"Cmf.Custom.Database/Pre/cmfpackage.json"), "Pre Package Id does not match expected");
-                Assert.AreEqual(packageVersion, GetPackageProperty("version", $"Cmf.Custom.Database/Pre/cmfpackage.json"), "Pre Package version does not match expected");
-                Assert.AreEqual("Cmf.Custom.Database.Post", GetPackageProperty("packageId", $"Cmf.Custom.Database/Post/cmfpackage.json"), "Post Package Id does not match expected");
-                Assert.AreEqual(packageVersion, GetPackageProperty("version", $"Cmf.Custom.Database/Post/cmfpackage.json"), "Post Package version does not match expected");
-                Assert.AreEqual("Cmf.Custom.Reporting", GetPackageProperty("packageId", $"Cmf.Custom.Database/Post/Reporting/cmfpackage.json"), "Reporting Package Id does not match expected");
-                Assert.AreEqual(packageVersion, GetPackageProperty("version", $"Cmf.Custom.Database/Post/Reporting/cmfpackage.json"), "Reporting Package version does not match expected");
+                Assert.True(Directory.Exists("Cmf.Custom.Database"), "Package folder is missing");
+                Assert.True(File.Exists($"Cmf.Custom.Database/Pre/cmfpackage.json"), "Pre Package cmfpackage.json is missing");
+                Assert.True(File.Exists($"Cmf.Custom.Database/Post/cmfpackage.json"), "Post Package cmfpackage.json is missing");
+                Assert.True(File.Exists($"Cmf.Custom.Database/Post/Reporting/cmfpackage.json"), "Reports Package cmfpackage.json is missing");
+                Assert.Equal("Cmf.Custom.Database.Pre", GetPackageProperty("packageId", $"Cmf.Custom.Database/Pre/cmfpackage.json"), "Pre Package Id does not match expected");
+                Assert.Equal(packageVersion, GetPackageProperty("version", $"Cmf.Custom.Database/Pre/cmfpackage.json"), "Pre Package version does not match expected");
+                Assert.Equal("Cmf.Custom.Database.Post", GetPackageProperty("packageId", $"Cmf.Custom.Database/Post/cmfpackage.json"), "Post Package Id does not match expected");
+                Assert.Equal(packageVersion, GetPackageProperty("version", $"Cmf.Custom.Database/Post/cmfpackage.json"), "Post Package version does not match expected");
+                Assert.Equal("Cmf.Custom.Reporting", GetPackageProperty("packageId", $"Cmf.Custom.Database/Post/Reporting/cmfpackage.json"), "Reporting Package Id does not match expected");
+                Assert.Equal(packageVersion, GetPackageProperty("version", $"Cmf.Custom.Database/Post/Reporting/cmfpackage.json"), "Reporting Package version does not match expected");
                 var pkg = GetPackage("cmfpackage.json");
                 var search = pkg.GetProperty("dependencies").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == "Cmf.Custom.Database");
-                Assert.AreEqual(JsonValueKind.Undefined, search.ValueKind, "Package was found in root package dependencies");
+                Assert.Equal(JsonValueKind.Undefined, search.ValueKind, "Package was found in root package dependencies");
             });
         }
 
         // TODO: Tests doesn't work with RunNew (Execute is invoked on LayerTemplateCommand)
-        [TestMethod]
+        [Fact]
         public void Tests()
         {
             var packageId = "Cmf.Custom.Tests";
@@ -488,19 +488,15 @@ namespace tests.Specs
                 cmd.Invoke(args.ToArray(), console);
 
                 string errors = console.Error.ToString().Trim();
-                Assert.IsTrue(errors.Length == 0, "Errors found in console: {0}", errors);
-                Assert.IsTrue(Directory.Exists(packageId), "Package folder is missing");
-                Assert.IsTrue(File.Exists($"{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
-                Assert.AreEqual(packageId, GetPackageProperty("packageId", $"{packageId}/cmfpackage.json"), "Package Id does not match expected");
-                Assert.AreEqual(pkgVersion, GetPackageProperty("version", $"{packageId}/cmfpackage.json"), "Package version does not match expected");
+                Assert.True(errors.Length == 0, $"Errors found in console: {errors}");
+                Assert.True(Directory.Exists(packageId), "Package folder is missing");
+                Assert.True(File.Exists($"{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
+                Assert.Equal(packageId, GetPackageProperty("packageId", $"{packageId}/cmfpackage.json"), "Package Id does not match expected");
+                Assert.Equal(pkgVersion, GetPackageProperty("version", $"{packageId}/cmfpackage.json"), "Package version does not match expected");
                 var pkg = GetPackage("cmfpackage.json");
-                Assert.IsNotNull(pkg.GetProperty("testPackages").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == packageId), "Package not found in root package dependencies");
+                pkg.GetProperty("testPackages").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == packageId).Should().NotBeNull("Package not found in root package dependencies");
                 var masterDataPackageId = "Cmf.Custom.Tests.MasterData";
-                Assert.IsNotNull(pkg.GetProperty("testPackages").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == masterDataPackageId), "Package not found in root package dependencies");
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail(ex.ToString());
+                pkg.GetProperty("testPackages").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == masterDataPackageId).Should().NotBeNull("Package not found in root package dependencies");
             }
             finally
             {
@@ -521,7 +517,7 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Traditional()
         {
             var dir = GetTmpDirectory();
@@ -551,23 +547,23 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Feature_WithPrefix()
         {
             const string packageId = "Cmf.Custom.Feature";
             var console = RunNew(new FeatureCommand(), packageId, extraArguments: new[] { packageId }, defaultAsserts: false, extraAsserts: args =>
             {
                 var (packageVersion, _) = args;
-                Assert.IsTrue(Directory.Exists($"Features/{packageId}"), "Package folder is missing");
-                Assert.IsTrue(File.Exists($"Features/{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
-                Assert.AreEqual(packageId, GetPackageProperty("packageId", $"Features/{packageId}/cmfpackage.json"), "Package Id does not match expected");
-                Assert.AreEqual(packageVersion, GetPackageProperty("version", $"Features/{packageId}/cmfpackage.json"), "Package version does not match expected");
+                Assert.True(Directory.Exists($"Features/{packageId}"), "Package folder is missing");
+                Assert.True(File.Exists($"Features/{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
+                Assert.Equal(packageId, GetPackageProperty("packageId", $"Features/{packageId}/cmfpackage.json"), "Package Id does not match expected");
+                Assert.Equal(packageVersion, GetPackageProperty("version", $"Features/{packageId}/cmfpackage.json"), "Package version does not match expected");
             });
             string errors = console.Error.ToString().Trim();
-            Assert.IsTrue(errors.Length == 0, "Errors found in console: {0}", errors);
+            Assert.True(errors.Length == 0, $"Errors found in console: {errors}");
         }
 
-        [TestMethod]
+        [Fact]
         public void Feature_WithoutPrefix()
         {
             RunFeature_WithoutPrefix(null);
@@ -579,16 +575,16 @@ namespace tests.Specs
             var console = RunNew(new FeatureCommand(), packageId, scaffoldingDir: scaffoldingDir, extraArguments: new[] { packageId }, defaultAsserts: false, extraAsserts: args =>
             {
                 var (packageVersion, _) = args;
-                Assert.IsTrue(Directory.Exists($"Features/{packageId}"), "Package folder is missing");
-                Assert.IsTrue(File.Exists($"Features/{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
-                Assert.AreEqual(packageId, GetPackageProperty("packageId", $"Features/{packageId}/cmfpackage.json"), "Package Id does not match expected");
-                Assert.AreEqual(packageVersion, GetPackageProperty("version", $"Features/{packageId}/cmfpackage.json"), "Package version does not match expected");
+                Assert.True(Directory.Exists($"Features/{packageId}"), "Package folder is missing");
+                Assert.True(File.Exists($"Features/{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
+                Assert.Equal(packageId, GetPackageProperty("packageId", $"Features/{packageId}/cmfpackage.json"), "Package Id does not match expected");
+                Assert.Equal(packageVersion, GetPackageProperty("version", $"Features/{packageId}/cmfpackage.json"), "Package version does not match expected");
             });
             string errors = console.Error.ToString().Trim();
-            Assert.IsTrue(errors.Length == 0, "Errors found in console: {0}", errors);
+            Assert.True(errors.Length == 0, $"Errors found in console: {errors}");
         }
 
-        [TestMethod]
+        [Fact]
         public void Features_RootPackageWithFeature()
         {
             var dir = GetTmpDirectory();
@@ -607,9 +603,9 @@ namespace tests.Specs
                 var console = RunNew(new BusinessCommand(), "Cmf.Custom.Business", scaffoldingDir: dir, defaultAsserts: false);
                 // TODO: logger isn't using IConsole. This means we can only catch errors coming from Exception, which is not the case here
                 //string errors = console.Error.ToString().Trim();
-                //Assert.IsTrue(errors.Contains("Cannot create a root-level layer package when features already exist."), "Expected to find specific error in console but instead found: {0}", errors);
+                //Assert.True(errors.Contains("Cannot create a root-level layer package when features already exist."), "Expected to find specific error in console but instead found: {0}", errors);
                 // however we can test that the package was not created
-                Assert.IsFalse(Directory.Exists("Cmf.Custom.Business"), "Package folder is present and shouldn't have been created");
+                Directory.Exists("Cmf.Custom.Business").Should().BeFalse("Package folder is present and shouldn't have been created");
             }
             finally
             {
@@ -618,7 +614,7 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod]
+        [Fact]
         public void Features_Business()
         {
             var dir = GetTmpDirectory();
@@ -639,12 +635,12 @@ namespace tests.Specs
                 var console = RunNew(new BusinessCommand(), packageId, scaffoldingDir: pkgDir, extraAsserts: args =>
                 {
                     var (pkgVersion, _) = args;
-                    Assert.IsTrue(File.Exists(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/tenantConstants.cs")), "Constants file is missing or has wrong name");
-                    Assert.IsTrue(File.Exists(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/Cmf.Custom.tenant.TestFeature.Common.csproj")), "Common project file is missing or has wrong name");
+                    Assert.True(File.Exists(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/tenantConstants.cs")), "Constants file is missing or has wrong name");
+                    Assert.True(File.Exists(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/Cmf.Custom.tenant.TestFeature.Common.csproj")), "Common project file is missing or has wrong name");
                     // namespace checks
-                    Assert.IsTrue(File.ReadAllText(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/tenantConstants.cs")).Contains("namespace Cmf.Custom.tenant.TestFeature.Common"), "Constants namespace is wrong name");
+                    Assert.True(File.ReadAllText(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/tenantConstants.cs")).Contains("namespace Cmf.Custom.tenant.TestFeature.Common"), "Constants namespace is wrong name");
                     // assembly name checks
-                    Assert.IsTrue(File.ReadAllText(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/Cmf.Custom.tenant.TestFeature.Common.csproj")).Contains("<AssemblyName>Cmf.Custom.tenant.TestFeature.Common</AssemblyName>"), "Constants assembly name is wrong name");
+                    Assert.True(File.ReadAllText(Path.Join(dir, "Features/TestFeature", $"{packageId}/Cmf.Custom.Common/Cmf.Custom.tenant.TestFeature.Common.csproj")).Contains("<AssemblyName>Cmf.Custom.tenant.TestFeature.Common</AssemblyName>"), "Constants assembly name is wrong name");
                 });
             }
             finally
@@ -654,7 +650,7 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod, TestCategory("LongRunning")]
+        [Fact, Trait("TestCategory", "LongRunning")]
         public void Features_Help()
         {
             var dir = GetTmpDirectory();
@@ -677,7 +673,7 @@ namespace tests.Specs
                 }, scaffoldingDir: pkgDir, extraAsserts: args =>
                 {
                     var (pkgVersion, _) = args;
-                    Assert.IsTrue(Directory.Exists(Path.Join(dir, "Features/TestFeature", $"{packageId}/src/packages/cmf.docs.area.tenant")), "Help package is missing or has wrong name");
+                    Assert.True(Directory.Exists(Path.Join(dir, "Features/TestFeature", $"{packageId}/src/packages/cmf.docs.area.tenant")), "Help package is missing or has wrong name");
                 });
             }
             finally
@@ -699,7 +695,7 @@ namespace tests.Specs
             }
         }
 
-        [TestMethod, TestCategory("LongRunning")]
+        [Fact, Trait("TestCategory", "LongRunning")]
         public void Features_HTML()
         {
             var dir = GetTmpDirectory();
@@ -775,23 +771,19 @@ namespace tests.Specs
                 if (defaultAsserts)
                 {
                     string errors = console.Error.ToString().Trim();
-                    Assert.IsTrue(errors.Length == 0, "Errors found in console: {0}", errors);
-                    Assert.IsTrue(Directory.Exists(packageId), "Package folder is missing");
-                    Assert.IsTrue(File.Exists($"{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
-                    Assert.AreEqual(packageId, GetPackageProperty("packageId", $"{packageId}/cmfpackage.json"), "Package Id does not match expected");
-                    Assert.AreEqual(pkgVersion, GetPackageProperty("version", $"{packageId}/cmfpackage.json"), "Package version does not match expected");
+                    Assert.True(errors.Length == 0, $"Errors found in console: {errors}");
+                    Assert.True(Directory.Exists(packageId), "Package folder is missing");
+                    Assert.True(File.Exists($"{packageId}/cmfpackage.json"), "Package cmfpackage.json is missing");
+                    Assert.Equal(packageId, GetPackageProperty("packageId", $"{packageId}/cmfpackage.json"), "Package Id does not match expected");
+                    Assert.Equal(pkgVersion, GetPackageProperty("version", $"{packageId}/cmfpackage.json"), "Package version does not match expected");
                     var pkg = GetPackage("cmfpackage.json");
-                    Assert.IsNotNull(pkg.GetProperty("dependencies").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == packageId), "Package not found in root package dependencies");
+                    pkg.GetProperty("dependencies").EnumerateArray().ToArray().FirstOrDefault(d => d.GetProperty("id").GetString() == packageId).Should().NotBeNull("Package not found in root package dependencies");
                 }
 
                 if (extraAsserts != null)
                 {
                     extraAsserts((pkgVersion, dir));
                 }
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail(ex.ToString());
             }
             finally
             {

--- a/tests/Specs/Pack.cs
+++ b/tests/Specs/Pack.cs
@@ -1,5 +1,5 @@
 ﻿using Cmf.Common.Cli.Commands;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.CommandLine.IO;
@@ -8,10 +8,9 @@ using System.IO.Abstractions;
 
 namespace tests.Specs
 {
-    [TestClass]
     public class Pack
     {
-        [TestMethod]
+        [Fact]
         public void Args_Paths_BothSpecified()
         {
             string _workingDir = null;
@@ -35,13 +34,13 @@ namespace tests.Specs
                 "-o", "test_package_dir", "working_dir"
             }, console);
 
-            Assert.AreEqual("working_dir", _workingDir);
-            Assert.AreEqual("test_package_dir", _outputDir);
-            Assert.IsNotNull(_force);
-            Assert.IsFalse(_force ?? true);
+            Assert.Equal("working_dir", _workingDir);
+            Assert.Equal("test_package_dir", _outputDir);
+            Assert.NotNull(_force);
+            Assert.False(_force ?? true);
         }
 
-        [TestMethod]
+        [Fact]
         public void Args_Paths_WorkDirSpecified()
         {
             string _workingDir = null;
@@ -65,13 +64,13 @@ namespace tests.Specs
                 "working_dir"
             }, console);
 
-            Assert.AreEqual("working_dir", _workingDir);
-            Assert.AreEqual("Package", _outputDir);
-            Assert.IsNotNull(_force);
-            Assert.IsFalse(_force ?? true);
+            Assert.Equal("working_dir", _workingDir);
+            Assert.Equal("Package", _outputDir);
+            Assert.NotNull(_force);
+            Assert.False(_force ?? true);
         }
 
-        [TestMethod]
+        [Fact]
         public void Args_Paths_OutDirSpecified()
         {
             string _workingDir = null;
@@ -96,13 +95,13 @@ namespace tests.Specs
             }, console);
 
             var curDir = new DirectoryInfo(System.IO.Directory.GetCurrentDirectory());
-            Assert.AreEqual(curDir.Name, _workingDir);
-            Assert.AreEqual("test_package_dir", _outputDir);
-            Assert.IsNotNull(_force);
-            Assert.IsFalse(_force ?? true);
+            Assert.Equal(curDir.Name, _workingDir);
+            Assert.Equal("test_package_dir", _outputDir);
+            Assert.NotNull(_force);
+            Assert.False(_force ?? true);
         }
 
-        [TestMethod]
+        [Fact]
         public void Args_Paths_NoneSpecified()
         {
             string _workingDir = null;
@@ -127,10 +126,10 @@ namespace tests.Specs
 
             var curDir = new DirectoryInfo(System.IO.Directory.GetCurrentDirectory());
 
-            Assert.AreEqual(curDir.Name, _workingDir);
-            Assert.AreEqual("Package", _outputDir);
-            Assert.IsNotNull(_force);
-            Assert.IsFalse(_force ?? true);
+            Assert.Equal(curDir.Name, _workingDir);
+            Assert.Equal("Package", _outputDir);
+            Assert.NotNull(_force);
+            Assert.False(_force ?? true);
         }
     }
 }

--- a/tests/Specs/Restore.cs
+++ b/tests/Specs/Restore.cs
@@ -7,15 +7,15 @@ using Cmf.Common.Cli.Factories;
 using Cmf.Common.Cli.Interfaces;
 using Cmf.Common.Cli.Objects;
 using Cmf.Common.Cli.Utilities;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 using tests.Objects;
+using Assert = tests.AssertWithMessage;
 
 namespace tests.Specs
 {
-    [TestClass]
     public class Restore
     {
-        [TestMethod]
+        [Fact]
         public void RestoreDependencies()
         {
             var gitRepo = MockUnixSupport.Path(@"c:\test");
@@ -92,20 +92,20 @@ namespace tests.Specs
 
             var repo = new UriBuilder() { Scheme = Uri.UriSchemeFile, Host = "", Path = ciRepo }.Uri;
             
-            Assert.IsFalse(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\Dependencies")).Exists, "Dependencies folder already exists!");
+            Assert.False(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\Dependencies")).Exists, "Dependencies folder already exists!");
             
             packageTypeHandler.RestoreDependencies(new []{ repo });
             
-            Assert.IsTrue(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\test\\Dependencies")).Exists, "Dependencies folder not found");
-            Assert.IsTrue(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.HTML@1.1.0")).Exists, "HTML Dependency folder not found");
-            Assert.IsTrue(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.Business@1.1.0")).Exists, "Business Dependency folder not found");
-            Assert.IsTrue(fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.Business@1.1.0\\content.txt")).Exists, "Business Dependency content not found");
-            Assert.IsTrue(fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.HTML@1.1.0\\content.txt")).Exists, "HTML Dependency content not found");
-            Assert.AreEqual("business", fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.Business@1.1.0\\content.txt")).OpenText().ReadToEnd(), "Business Dependency content does not match");
-            Assert.AreEqual("HTML", fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.HTML@1.1.0\\content.txt")).OpenText().ReadToEnd(), "HTML Dependency content does not match");
+            Assert.True(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\test\\Dependencies")).Exists, "Dependencies folder not found");
+            Assert.True(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.HTML@1.1.0")).Exists, "HTML Dependency folder not found");
+            Assert.True(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.Business@1.1.0")).Exists, "Business Dependency folder not found");
+            Assert.True(fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.Business@1.1.0\\content.txt")).Exists, "Business Dependency content not found");
+            Assert.True(fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.HTML@1.1.0\\content.txt")).Exists, "HTML Dependency content not found");
+            Assert.Equal("business", fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.Business@1.1.0\\content.txt")).OpenText().ReadToEnd(), "Business Dependency content does not match");
+            Assert.Equal("HTML", fileSystem.FileInfo.FromFileName(MockUnixSupport.Path("c:\\test\\Dependencies\\Cmf.Custom.HTML@1.1.0\\content.txt")).OpenText().ReadToEnd(), "HTML Dependency content does not match");
         }
         
-        [TestMethod]
+        [Fact]
         public void RestoreDependencies_RepoNotFound()
         {
             var gitRepo = MockUnixSupport.Path(@"c:\test");
@@ -182,9 +182,9 @@ namespace tests.Specs
 
             var repo = new UriBuilder() { Scheme = Uri.UriSchemeFile, Host = "", Path = MockUnixSupport.Path(@"c:\missingRepo")}.Uri;
             
-            Assert.IsFalse(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\Dependencies")).Exists, "Dependencies folder already exists!");
+            Assert.False(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\Dependencies")).Exists, "Dependencies folder already exists!");
 
-            Assert.ThrowsException<CliException>(() => packageTypeHandler.RestoreDependencies(new[] { repo }));
+            Assert.Throws<CliException>(() => packageTypeHandler.RestoreDependencies(new[] { repo }));
         }
     }
 }

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -1,11 +1,12 @@
 using System.Threading.Tasks;
 using Cmf.Common.Cli.Objects;
+using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Xunit;
 
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
 namespace tests.Specs
 {
-    [TestClass]
     public class Startup
     {
         #region mock services
@@ -36,7 +37,7 @@ namespace tests.Specs
         }
         #endregion
 
-        [TestMethod]
+        [Fact]
         public async Task NotAtLatestVersion()
         {
             ExecutionContext.ServiceProvider = (new ServiceCollection())
@@ -48,10 +49,10 @@ namespace tests.Specs
             
             await Cmf.Common.Cli.Program.VersionChecks();
             
-            Assert.IsTrue(logWriter.ToString().Contains("Please update"));
+            logWriter.ToString().Should().Contain("Please update");
         }
         
-        [TestMethod]
+        [Fact]
         public async Task AtLatestVersion()
         {
             ExecutionContext.ServiceProvider = (new ServiceCollection())
@@ -63,10 +64,10 @@ namespace tests.Specs
             
             await Cmf.Common.Cli.Program.VersionChecks();
             
-            Assert.IsFalse(logWriter.ToString().Contains("Please update"));
+            logWriter.ToString().Should().NotContain("Please update");
         }
 
-        [TestMethod]
+        [Fact]
         public async Task InDevVersion()
         {
             ExecutionContext.ServiceProvider = (new ServiceCollection())
@@ -78,10 +79,10 @@ namespace tests.Specs
             
             await Cmf.Common.Cli.Program.VersionChecks();
             
-            Assert.IsTrue(logWriter.ToString().Contains("You are using development version"));
+            logWriter.ToString().Should().Contain("You are using development version");
         }
         
-        [TestMethod]
+        [Fact]
         public async Task InStableVersion()
         {
             ExecutionContext.ServiceProvider = (new ServiceCollection())
@@ -93,7 +94,7 @@ namespace tests.Specs
             
             await Cmf.Common.Cli.Program.VersionChecks();
             
-            Assert.IsFalse(logWriter.ToString().Contains("You are using development version"));
+            logWriter.ToString().Should().NotContain("You are using development version");
         }
     }
 }

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -7,13 +7,17 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
     <PackageReference Include="Spectre.Console.Testing" Version="0.43.0" />
     <PackageReference Include="System.IO.Abstractions" Version="13.2.38" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="13.2.38" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Migrate our test solution to xUnit. Due to our ExecutionContext implementation, we are disabling
parallel testing to be reviewed later