### PR TITLE
fix(pack): additional contentToPack check

### DIFF
--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -487,7 +487,7 @@ namespace Cmf.Common.Cli.Handlers
         public virtual void Pack(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir)
         {
             var filesToPack = GetContentToPack(packageOutputDir);
-            if (!filesToPack.HasAny())
+            if (CmfPackage.ContentToPack.HasAny() && !filesToPack.HasAny())
             {
                 throw new Exception(string.Format(CliMessages.ContentToPackNotFound, CmfPackage.PackageId, CmfPackage.Version));
             }

--- a/tests/Objects/MockPackage.cs
+++ b/tests/Objects/MockPackage.cs
@@ -37,5 +37,71 @@ namespace tests.Objects
                 }}
               ]
             }}")}});
+        
+        internal static readonly MockFileSystem Html_MissingDeclaredContent = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+          { MockUnixSupport.Path(@"c:\ui\package.json"), new MockFileData(
+            @"{
+              ""name"": ""customization.package""
+            }")
+          },
+          { MockUnixSupport.Path(@"c:\ui\cmfpackage.json"), new MockFileData(
+            $@"{{
+              ""packageId"": ""Cmf.Custom.HTML"",
+              ""version"": ""1.1.0"",
+              ""description"": ""Cmf Custom HTML Package"",
+              ""packageType"": ""Html"",
+              ""isInstallable"": true,
+              ""isUniqueInstall"": false,
+              ""contentToPack"": [
+                {{
+                  ""source"": ""{MockUnixSupport.Path("src\\packages\\*").Replace("\\", "\\\\")}"",
+                  ""target"": ""node_modules"",
+                  ""ignoreFiles"": [
+                    "".npmignore""
+                  ]
+                }}
+              ]
+           }}")
+          }
+        });
+        
+        internal static readonly MockFileSystem Html_EmptyContentToPack = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+          { MockUnixSupport.Path(@"c:\ui\package.json"), new MockFileData(
+            @"{
+              ""name"": ""customization.package""
+            }")
+          },
+          { MockUnixSupport.Path(@"c:\ui\cmfpackage.json"), new MockFileData(
+            $@"{{
+              ""packageId"": ""Cmf.Custom.HTML"",
+              ""version"": ""1.1.0"",
+              ""description"": ""Cmf Custom HTML Package"",
+              ""packageType"": ""Html"",
+              ""isInstallable"": true,
+              ""isUniqueInstall"": false,
+              ""contentToPack"": [
+              ]
+           }}")
+          }
+        });
+        
+        internal static readonly MockFileSystem Root_Empty = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+         { MockUnixSupport.Path(@"c:\repo\cmfpackage.json"), new MockFileData(
+            $@"{{
+              ""packageId"": ""Cmf.Custom.Root"",
+              ""version"": ""1.1.0"",
+              ""description"": ""Cmf Custom Root Package"",
+              ""packageType"": ""Root"",
+              ""isInstallable"": true,
+              ""isUniqueInstall"": false,
+              ""dependencies"": [
+                {{ ""id"": ""Cmf.Environment"", ""version"": ""0.0.0"" }}
+              ]
+           }}")
+          }
+        });
     }
 }

--- a/tests/Specs/Pack.cs
+++ b/tests/Specs/Pack.cs
@@ -10,6 +10,8 @@ using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.IO.Compression;
 using System.Linq;
+using Cmf.Common.Cli.Utilities;
+using FluentAssertions;
 using tests.Objects;
 
 namespace tests.Specs
@@ -171,6 +173,35 @@ namespace tests.Specs
                     }
                 }
             }
+        }
+
+        [Fact]
+        public void CheckThatContentWasPacked_FailBecauseNoContentFound()
+        {
+            var fileSystem = MockPackage.Html_MissingDeclaredContent;
+            
+            var packCommand = new PackCommand(fileSystem);
+            var exception = Assert.Throws<CliException>(() => packCommand.Execute(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\ui")), fileSystem.DirectoryInfo.FromDirectoryName("output"), false));
+            exception.Message.Should().Contain("Nothing was found on ContentToPack Sources");
+        }
+        
+        [Fact]
+        public void DontCheckThatContentWasPacked_IfMeta()
+        {
+            var fileSystem = MockPackage.Root_Empty;
+            
+            var packCommand = new PackCommand(fileSystem);
+            packCommand.Execute(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\repo")), fileSystem.DirectoryInfo.FromDirectoryName("output"), false);
+        }
+        
+        [Fact]
+        public void DontCheckThatContentWasPacked_IfContentToPackIsEmpty()
+        {
+            var fileSystem = MockPackage.Html_EmptyContentToPack;
+            
+            var packCommand = new PackCommand(fileSystem);
+            var exception = Assert.Throws<CliException>(() => packCommand.Execute(fileSystem.DirectoryInfo.FromDirectoryName(MockUnixSupport.Path("c:\\ui")), fileSystem.DirectoryInfo.FromDirectoryName("output"), false));
+            exception.Message.Should().Contain("Missing mandatory property ContentToPack in file");
         }
     }
 }


### PR DESCRIPTION
check if there was any content packed only if the package manifest contains contentToPack entries

test(pack): add test cases for contentToPack variations
