### PR TITLE
Add brotli compression

### DIFF
--- a/cmf-cli/Handlers/PackageType/HtmlPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlPackageTypeHandler.cs
@@ -67,7 +67,7 @@ namespace Cmf.Common.Cli.Handlers
                     Task = "build",
                     DisplayName = "Gulp Build",
                     GulpJS = "node_modules/gulp/bin/gulp.js",
-                    Args = new [] { "--production" , "--dist"},
+                    Args = new [] { "--production" , "--dist", "--brotli"},
                     WorkingDirectory = cmfPackage.GetFileInfo().Directory
                 },
             };


### PR DESCRIPTION
Dev-tasks were updated to support brotli compression when building in production mode. This PR adds brotli to the cmf cli build command.