### PR TITLE
fix(ls): correct printed tree found package labels

### DIFF
--- a/core/Utilities/GenericUtilities.cs
+++ b/core/Utilities/GenericUtilities.cs
@@ -199,7 +199,7 @@ namespace Cmf.CLI.Utilities
 
                     if (!dep.IsMissing)
                     {
-                        var curNode = tree.AddNode($"{pkg.PackageId}@{pkg.Version} [[{pkg.Location.ToString()}]]");
+                        var curNode = tree.AddNode($"{dep.CmfPackage.PackageId}@{dep.CmfPackage.Version} [[{dep.CmfPackage.Location.ToString()}]]");
                         BuildTreeNodes(dep.CmfPackage, curNode);
                     }
                     else if (dep.IsMissing)
@@ -232,18 +232,18 @@ namespace Cmf.CLI.Utilities
                     Dependency dep = pkg.Dependencies[i];
 
                     if (!dep.IsMissing)
-        {
-                        var curNode = node.AddNode($"{pkg.PackageId}@{pkg.Version} [[{pkg.Location.ToString()}]]");
+                    {
+                        var curNode = node.AddNode($"{dep.CmfPackage.PackageId}@{dep.CmfPackage.Version} [[{dep.CmfPackage.Location.ToString()}]]");
                         BuildTreeNodes(dep.CmfPackage, curNode);
                     }
                     else if (dep.IsMissing)
-            {
+                    {
                         if (dep.Mandatory)
-                {
+                        {
                             node.AddNode($"[red]MISSING {dep.Id}@{dep.Version}[/]");
-                }
-                else
-                {
+                        }
+                        else
+                        {
                             node.AddNode($"[yellow]MISSING {dep.Id}@{dep.Version}[/]");
                         }
                     }


### PR DESCRIPTION
`cmf ls` is printing the parent package instead of the current level package when printing the dependency tree. The dependency tree itself is correct, only the printed tree is wrong.