### PR TITLE
CLI telemetry

### DIFF
--- a/cmf-cli/Commands/LayerTemplateCommand.cs
+++ b/cmf-cli/Commands/LayerTemplateCommand.cs
@@ -6,7 +6,9 @@ using System.Text.Json;
 using System.Linq;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -141,6 +143,7 @@ namespace Cmf.CLI.Commands
         /// <param name="version">the package version</param>
         public void Execute(IDirectoryInfo workingDir, string version)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             if (workingDir == null)
             {
                 Log.Error("This command needs to run inside a project. Run `cmf init` to create a new project.");

--- a/cmf-cli/Commands/assemble/AssembleCommand.cs
+++ b/cmf-cli/Commands/assemble/AssembleCommand.cs
@@ -12,6 +12,7 @@ using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -95,6 +96,7 @@ namespace Cmf.CLI.Commands
         /// <returns></returns>
         public void Execute(IDirectoryInfo workingDir, IDirectoryInfo outputDir, Uri ciRepo, Uri[] repos, bool includeTestPackages)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             if (ciRepo == null)
             {
                 ciRepo = ExecutionContext.Instance.RepositoriesConfig.CIRepository;

--- a/cmf-cli/Commands/build/BuildCommand.cs
+++ b/cmf-cli/Commands/build/BuildCommand.cs
@@ -4,9 +4,11 @@ using System.IO;
 using System.IO.Abstractions;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Factories;
 using Cmf.CLI.Interfaces;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -69,6 +71,7 @@ namespace Cmf.CLI.Commands
         /// <param name="packagePath">The package path.</param>
         public void Execute(IDirectoryInfo packagePath, bool test = false)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.FromFileName($"{packagePath}/{CliConstants.CmfPackageFileName}");
 
             IPackageTypeHandler packageTypeHandler = PackageTypeFactory.GetPackageTypeHandler(cmfpackageFile, setDefaultValues: false);

--- a/cmf-cli/Commands/bump/BumpCommand.cs
+++ b/cmf-cli/Commands/bump/BumpCommand.cs
@@ -1,4 +1,3 @@
-using Cmf.CLI.Objects;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
@@ -10,6 +9,7 @@ using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Factories;
 using Cmf.CLI.Interfaces;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -58,6 +58,7 @@ namespace Cmf.CLI.Commands
         /// <exception cref="CliException"></exception>
         public void Execute(DirectoryInfo packagePath, string version, string buildNr, string root)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.FromFileName($"{packagePath}/{CliConstants.CmfPackageFileName}");
 
             if (string.IsNullOrEmpty(version) && string.IsNullOrEmpty(buildNr))

--- a/cmf-cli/Commands/bump/BumpIoTConfigurationCommand.cs
+++ b/cmf-cli/Commands/bump/BumpIoTConfigurationCommand.cs
@@ -2,12 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -99,6 +100,8 @@ namespace Cmf.CLI.Commands
         /// <returns></returns>
         public void Execute(IDirectoryInfo path, string version, string buildNr, bool isToBumpMasterdata, bool isToBumpIoT, string packageNames, string root, string group, string workflowName, bool isToTag, bool onlyMdCustomization)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
+            
             // Get All AutomationWorkflowFiles Folders
             List<string> automationWorkflowDirectories = this.fileSystem.Directory.GetDirectories(path.FullName, "AutomationWorkflowFiles").ToList();
 

--- a/cmf-cli/Commands/bump/BumpIoTCustomizationCommand.cs
+++ b/cmf-cli/Commands/bump/BumpIoTCustomizationCommand.cs
@@ -1,7 +1,5 @@
-using Cmf.CLI.Objects;
 using System.CommandLine;
 using System.CommandLine.Invocation;
-using System.IO;
 using System.IO.Abstractions;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
@@ -9,6 +7,7 @@ using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -66,6 +65,7 @@ namespace Cmf.CLI.Commands
         /// <exception cref="CliException"></exception>
         public void Execute(IDirectoryInfo packagePath, string version, string buildNr, string packageNames, bool isToTag)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.FromFileName($"{packagePath}/{CliConstants.CmfPackageFileName}");
 
             if (string.IsNullOrEmpty(version))

--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -438,7 +438,7 @@ namespace Cmf.CLI.Commands
             #region version-specific bits
 
             var version = Version.Parse(x.MESVersion);
-            args.AddRange(new []{ "--dotnetSDKVersion", version.Major > 8 ? "6.0.x" : "3.1.102" });
+            args.AddRange(new []{ "--dotnetSDKVersion", version.Major > 8 ? "6.0.201" : "3.1.102" });
             #endregion
             
             if (x.config != null)

--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -5,7 +5,9 @@ using System.CommandLine.Invocation;
 using System.IO.Abstractions;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
 namespace Cmf.CLI.Commands
@@ -259,6 +261,7 @@ namespace Cmf.CLI.Commands
         /// </summary>
         internal void Execute(InitArguments x)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             var args = new List<string>()
             {
                 // engine options

--- a/cmf-cli/Commands/list/ListDependenciesCommand.cs
+++ b/cmf-cli/Commands/list/ListDependenciesCommand.cs
@@ -13,6 +13,7 @@ using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -67,6 +68,7 @@ namespace Cmf.CLI.Commands
         /// <param name="repos">a set of repositories for remote packages</param>
         public void Execute(IDirectoryInfo workingDir, Uri[] repos)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.FromFileName($"{workingDir}/{CliConstants.CmfPackageFileName}");
 
             // Reading cmfPackage

--- a/cmf-cli/Commands/local/GenerateLBOsCommand.cs
+++ b/cmf-cli/Commands/local/GenerateLBOsCommand.cs
@@ -4,7 +4,9 @@ using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
 using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -29,6 +31,7 @@ namespace Cmf.CLI.Commands
         /// </summary>
         public void Execute()
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             var toolsPath = this.fileSystem.Path.Join(Utilities.FileSystemUtilities.GetProjectRoot(this.fileSystem).FullName, "Tools");
             var pars = new Dictionary<string, string>
             {

--- a/cmf-cli/Commands/local/GetLocalEnvironmentCommand.cs
+++ b/cmf-cli/Commands/local/GetLocalEnvironmentCommand.cs
@@ -5,7 +5,9 @@ using System.CommandLine.Invocation;
 using System.IO;
 using System.Linq;
 using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using Utils = Cmf.CLI.Utilities.FileSystemUtilities;
 
 namespace Cmf.CLI.Commands
@@ -44,6 +46,7 @@ namespace Cmf.CLI.Commands
         /// <param name="target">The target.</param>
         public void Execute(DirectoryInfo target)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             var config = FileSystemUtilities.ReadProjectConfig(this.fileSystem);
             var x = config.RootElement.EnumerateObject();
             var hostname = x.FirstOrDefault(y => y.NameEquals("vmHostname"));

--- a/cmf-cli/Commands/pack/PackCommand.cs
+++ b/cmf-cli/Commands/pack/PackCommand.cs
@@ -9,6 +9,7 @@ using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Factories;
 using Cmf.CLI.Interfaces;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands
 {
@@ -72,6 +73,7 @@ namespace Cmf.CLI.Commands
         /// <returns></returns>
         public void Execute(IDirectoryInfo workingDir, IDirectoryInfo outputDir, bool force)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.FromFileName($"{workingDir}/{CliConstants.CmfPackageFileName}");
 
             // Reading cmfPackage

--- a/cmf-cli/Commands/restore/RestoreCommand.cs
+++ b/cmf-cli/Commands/restore/RestoreCommand.cs
@@ -11,6 +11,7 @@ using Cmf.CLI.Factories;
 using Cmf.CLI.Interfaces;
 using Cmf.CLI.Utilities;
 using Cmf.CLI.Objects;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Cmf.CLI.Commands.restore
 {
@@ -51,6 +52,7 @@ namespace Cmf.CLI.Commands.restore
         /// <param name="repos">The package repositories URI/path</param>
         public void Execute(IDirectoryInfo packagePath, Uri[] repos)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.FromFileName($"{packagePath}/{CliConstants.CmfPackageFileName}");
 
             IPackageTypeHandler packageTypeHandler = PackageTypeFactory.GetPackageTypeHandler(cmfpackageFile, setDefaultValues: false);

--- a/cmf-cli/Program.cs
+++ b/cmf-cli/Program.cs
@@ -106,7 +106,6 @@ namespace Cmf.CLI
             
             using var activity = ExecutionContext.ServiceProvider.GetService<ITelemetryService>()!
                 .StartActivity("CLIVersion");
-            activity?.SetTag("version", ExecutionContext.CurrentVersion);
 
             var npmClient = ExecutionContext.ServiceProvider.GetService<INPMClient>();
             
@@ -114,16 +113,16 @@ namespace Cmf.CLI
             {
                 Log.Information(
                     $"You are using development version {ExecutionContext.CurrentVersion}. This in unsupported in production and should only be used for testing.");
-                activity?.SetTag("isDev", ExecutionContext.IsDevVersion);
             }
 
-            var latestVersion = await npmClient!.GetLatestVersion(ExecutionContext.IsDevVersion);
-            if (latestVersion != ExecutionContext.CurrentVersion)
+            ExecutionContext.LatestVersion = await npmClient!.GetLatestVersion(ExecutionContext.IsDevVersion);
+            if (ExecutionContext.LatestVersion != ExecutionContext.CurrentVersion)
             {
                 Log.Warning(
-                    $"Using version {ExecutionContext.CurrentVersion} while {latestVersion} is available. Please update.");
+                    $"Using version {ExecutionContext.CurrentVersion} while {ExecutionContext.LatestVersion} is available. Please update.");
+                // after this run, every activity will have these tags (check TelemetryService)
                 activity?.SetTag("isOutdated", true);
-                activity?.SetTag("latestVersion", latestVersion);
+                activity?.SetTag("latestVersion", ExecutionContext.LatestVersion);
             }
 
             #endregion

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
@@ -72,6 +72,9 @@ steps:
 # Cmf Build
 - task: PowerShell@2
   displayName: 'Build ${{ parameters.PackageId }}'
+  env:
+    cmf_cli_enable_telemetry: true
+    cmf_cli_enable_extended_telemetry: true
   inputs:
     pwsh: true
     failOnStderr: true
@@ -88,6 +91,9 @@ steps:
 # Cmf Pack
 - task: PowerShell@2
   displayName: 'Pack ${{ parameters.PackageId }}'
+  env:
+    cmf_cli_enable_telemetry: true
+    cmf_cli_enable_extended_telemetry: true
   inputs:
     pwsh: true
     failOnStderr: true

--- a/core/Objects/CmfPackage.cs
+++ b/core/Objects/CmfPackage.cs
@@ -9,6 +9,7 @@ using Cmf.CLI.Core.Constants;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI;
 using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
@@ -509,6 +510,8 @@ namespace Cmf.CLI.Core.Objects
         /// <returns>this CmfPackage for chaining, but the method itself is mutable</returns>
         public void LoadDependencies(IEnumerable<Uri> repoUris, StatusContext ctx, bool recurse = false)
         {
+            using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity("CmfPackage LoadDependencies");
+            activity?.SetTag("cmfPackage", $"{this.PackageId}.{this.Version}");
             List<CmfPackage> loadedPackages = new();
             loadedPackages.Add(this);
             ctx?.Status($"Working on {this.Name ?? (this.PackageId + "@" + this.Version)}");

--- a/core/Objects/ExecutionContext.cs
+++ b/core/Objects/ExecutionContext.cs
@@ -33,6 +33,11 @@ namespace Cmf.CLI.Core.Objects
         public static string CurrentVersion => (ServiceProvider.GetService<IVersionService>()!.CurrentVersion) ?? "dev";
         
         /// <summary>
+        /// Get or set the latest vetsion of the CLI. Use this if the CLI checks for new versions
+        /// </summary>
+        public static string LatestVersion { get; set; }
+        
+        /// <summary>
         /// Get the package id of the current running application
         /// </summary>
         public static string PackageId => (ServiceProvider.GetService<IVersionService>()!.PackageId) ?? "unknown";
@@ -47,6 +52,12 @@ namespace Cmf.CLI.Core.Objects
         /// NOTE: As we already have this ExecutionContext object, we're not enabling Hosting, but instead we are hosting the container in the execution context
         /// </summary>
         public static ServiceProvider ServiceProvider { get; set; }
+
+        /// <summary>
+        /// Is the current CLI outdated.
+        /// True if LatestVersion is not null (meaning a check was performed) and if the LatestVersion does not match the CurrentVersion
+        /// </summary>
+        public static bool IsOutdated => ExecutionContext.LatestVersion != null && ExecutionContext.CurrentVersion != ExecutionContext.LatestVersion;
 
         private ExecutionContext(IFileSystem fileSystem)
         {

--- a/core/Objects/TelemetryService.cs
+++ b/core/Objects/TelemetryService.cs
@@ -18,6 +18,7 @@ public interface ITelemetryService
     ActivitySource InitializeActivitySource(string name);
     Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal);
     Activity StartBareActivity(string name, ActivityKind kind = ActivityKind.Internal);
+    Activity StartExtendedActivity(string name, ActivityKind kind = ActivityKind.Internal);
 }
 
 public class TelemetryService : ITelemetryService
@@ -46,7 +47,7 @@ public class TelemetryService : ITelemetryService
         }
         builder = builder.AddOtlpExporter(opt =>
         {
-            opt.Endpoint = new Uri(telemetryHostname ?? "https://telemetry.criticalmanufacturing.dev");
+            opt.Endpoint = new Uri(telemetryHostname ?? "http://telemetry.criticalmanufacturing.dev:4317");
             opt.Protocol = OtlpExportProtocol.Grpc;
             opt.ExportProcessorType = ExportProcessorType.Simple;
         });
@@ -75,6 +76,8 @@ public class TelemetryService : ITelemetryService
         }
         return activity;
     }
+
+    public Activity StartExtendedActivity(string name, ActivityKind kind = ActivityKind.Internal) => GenericUtilities.IsEnvVarTruthy("cmf_cli_enable_extended_telemetry") ? this.StartActivity(name, kind) : null;
 
     public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
     {

--- a/core/Objects/TelemetryService.cs
+++ b/core/Objects/TelemetryService.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Diagnostics;
+using Cmf.CLI.Utilities;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Cmf.CLI.Core.Objects;
+
+public interface ITelemetryService
+{
+    public TracerProvider Provider { get; }
+    TracerProvider InitializeTracerProvider(string serviceName, string version);
+    ActivitySource InitializeActivitySource(string name);
+    Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal);
+}
+
+public class TelemetryService : ITelemetryService
+{
+    public TracerProvider Provider { get; private set; }
+
+    private ActivitySource activitySource = null;
+    
+    public TracerProvider InitializeTracerProvider(string serviceName, string version)
+    {
+        if (GenericUtilities.IsEnvVarTruthy("cmf_cli_disable_telemetry"))
+        {
+            return null;
+        }
+        
+        var telemetryHostname = System.Environment.GetEnvironmentVariable("cmf_cli_telemetry_host");
+
+        var builder = Sdk.CreateTracerProviderBuilder()
+            .AddSource(serviceName)
+            .SetResourceBuilder(
+                ResourceBuilder.CreateDefault()
+                    .AddService(serviceName: serviceName, serviceVersion: version));
+        if (GenericUtilities.IsEnvVarTruthy("cmf_cli_telemetry_enable_console_exporter"))
+        {
+            builder = builder.AddConsoleExporter();    
+        }
+        builder = builder.AddOtlpExporter(opt =>
+        {
+            opt.Endpoint = new Uri(telemetryHostname ?? "https://cli-telemetry.criticalmanufacturing.dev");
+            opt.Protocol = OtlpExportProtocol.Grpc;
+            opt.ExportProcessorType = ExportProcessorType.Simple;
+        });
+        builder = builder.AddZipkinExporter(o =>
+        {
+            o.Endpoint = new Uri("http://ubuntu.wsl:9411");
+        });
+        Provider = builder.Build();
+        return Provider;
+    }
+
+    public ActivitySource InitializeActivitySource(string name)
+    {
+        activitySource = new ActivitySource(name);
+        return activitySource;
+    }
+
+    public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal)
+    {
+        return this.activitySource.StartActivity(name, kind);
+    }
+}

--- a/core/Utilities/GenericUtilities.cs
+++ b/core/Utilities/GenericUtilities.cs
@@ -218,7 +218,16 @@ namespace Cmf.CLI.Utilities
             return tree;
         }
 
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="envVarName"></param>
+        /// <returns></returns>
+        public static bool IsEnvVarTruthy(string envVarName)
+        {
+            var enableConsoleExporter = System.Environment.GetEnvironmentVariable(envVarName);
+            return enableConsoleExporter is "1" or "true" or "TRUE" or "True";
+        }
         #endregion Public Methods
 
         #region Private Methods

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -21,7 +21,6 @@
       <PackageReference Include="OpenTelemetry" Version="1.2.0" />
       <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0" />
-      <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0" />
       <PackageReference Include="Spectre.Console" Version="0.43.0" />
       <PackageReference Include="System.IO.Abstractions" Version="13.2.38" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -18,6 +18,10 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="OpenTelemetry" Version="1.2.0" />
+      <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.2.0" />
+      <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.2.0" />
+      <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.2.0" />
       <PackageReference Include="Spectre.Console" Version="0.43.0" />
       <PackageReference Include="System.IO.Abstractions" Version="13.2.38" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />

--- a/tests/Mocks/MockNPMClient.cs
+++ b/tests/Mocks/MockNPMClient.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Objects;
+
+namespace tests.Mocks;
+
+public class MockNPMClient : INPMClient
+{
+    public Task<string> GetLatestVersion(bool preRelease = false)
+    {
+        return Task.FromResult("");
+    }
+}

--- a/tests/Mocks/MockTelemetryService.cs
+++ b/tests/Mocks/MockTelemetryService.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using Cmf.CLI.Core.Objects;
+using OpenTelemetry.Trace;
+
+namespace tests.Mocks;
+
+public class MockTelemetryService : ITelemetryService
+{
+    public TracerProvider Provider => null;
+    private ActivitySource activitySource = null;
+    public TracerProvider InitializeTracerProvider(string serviceName, string version) => null;
+
+    public ActivitySource InitializeActivitySource(string name)
+    {
+        activitySource = new ActivitySource(name);
+        return activitySource;
+    }
+
+    public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
+    public Activity StartBareActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
+    public Activity StartExtendedActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
+}

--- a/tests/Mocks/MockVersionService.cs
+++ b/tests/Mocks/MockVersionService.cs
@@ -1,0 +1,9 @@
+using Cmf.CLI.Core.Objects;
+
+namespace tests.Mocks;
+
+public class MockVersionService : IVersionService
+{
+    public string PackageId => "test";
+    public string CurrentVersion => "1.0.0";
+}

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -5,6 +5,7 @@ using Cmf.CLI.Objects;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Trace;
+using tests.Mocks;
 using Xunit;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
@@ -29,34 +30,13 @@ namespace tests.Specs
             }
         }
 
-        class MockVersionService : IVersionService
-        {
-            public string PackageId => "test";
-            public string CurrentVersion => "1.0.0";
-        }
-        
         class MockVersionServiceDev : IVersionService
         {
             public string PackageId => "test";
             public string CurrentVersion => "1.0.0-0";
         }
 
-        class MockTelemetryService : ITelemetryService
-        {
-            public TracerProvider Provider => null;
-            private ActivitySource activitySource = null;
-            public TracerProvider InitializeTracerProvider(string serviceName, string version) => null;
 
-            public ActivitySource InitializeActivitySource(string name)
-            {
-                activitySource = new ActivitySource(name);
-                return activitySource;
-            }
-
-            public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
-            public Activity StartBareActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
-            public Activity StartExtendedActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
-        }
         #endregion
 
         [Fact]

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -54,6 +54,7 @@ namespace tests.Specs
             }
 
             public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
+            public Activity StartBareActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
         }
         #endregion
 

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Objects;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Trace;
 using Xunit;
 
 [assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly)]
@@ -38,6 +40,21 @@ namespace tests.Specs
             public string PackageId => "test";
             public string CurrentVersion => "1.0.0-0";
         }
+
+        class MockTelemetryService : ITelemetryService
+        {
+            public TracerProvider Provider => null;
+            private ActivitySource activitySource = null;
+            public TracerProvider InitializeTracerProvider(string serviceName, string version) => null;
+
+            public ActivitySource InitializeActivitySource(string name)
+            {
+                activitySource = new ActivitySource(name);
+                return activitySource;
+            }
+
+            public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
+        }
         #endregion
 
         [Fact]
@@ -46,6 +63,7 @@ namespace tests.Specs
             ExecutionContext.ServiceProvider = (new ServiceCollection())
                 .AddSingleton<INPMClient, MockNPMClient999>()
                 .AddSingleton<IVersionService, MockVersionService>()
+                .AddSingleton<ITelemetryService, MockTelemetryService>()
                 .BuildServiceProvider();
 
             var logWriter = (new Logging()).GetLogStringWriter();
@@ -61,6 +79,7 @@ namespace tests.Specs
             ExecutionContext.ServiceProvider = (new ServiceCollection())
                 .AddSingleton<INPMClient, MockNPMClientCurrent>()
                 .AddSingleton<IVersionService, MockVersionService>()
+                .AddSingleton<ITelemetryService, MockTelemetryService>()
                 .BuildServiceProvider();
 
             var logWriter = (new Logging()).GetLogStringWriter();
@@ -76,6 +95,7 @@ namespace tests.Specs
             ExecutionContext.ServiceProvider = (new ServiceCollection())
                 .AddSingleton<INPMClient, MockNPMClientCurrent>()
                 .AddSingleton<IVersionService, MockVersionServiceDev>()
+                .AddSingleton<ITelemetryService, MockTelemetryService>()
                 .BuildServiceProvider();
             
             var logWriter = (new Logging()).GetLogStringWriter();
@@ -91,6 +111,7 @@ namespace tests.Specs
             ExecutionContext.ServiceProvider = (new ServiceCollection())
                 .AddSingleton<INPMClient, MockNPMClientCurrent>()
                 .AddSingleton<IVersionService, MockVersionService>()
+                .AddSingleton<ITelemetryService, MockTelemetryService>()
                 .BuildServiceProvider();
             
             var logWriter = (new Logging()).GetLogStringWriter();

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -55,6 +55,7 @@ namespace tests.Specs
 
             public Activity StartActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
             public Activity StartBareActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
+            public Activity StartExtendedActivity(string name, ActivityKind kind = ActivityKind.Internal) => null;
         }
         #endregion
 

--- a/tests/Specs/Telemetry.cs
+++ b/tests/Specs/Telemetry.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Objects;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using tests.Mocks;
+using Xunit;
+
+namespace tests.Specs;
+
+public class Telemetry
+{
+    [Theory]
+    [InlineData(null)] // default value, no env var set
+    [InlineData("false")]
+    [InlineData("False")]
+    [InlineData("FALSE")]
+    [InlineData("0")]
+    [InlineData("unrecognizedValue")]
+    public void NoTelemetryByDefaultOrWhenOff(string telemetrySetting)
+    {
+        Environment.SetEnvironmentVariable("cmf_cli_enable_telemetry", telemetrySetting);
+        
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<INPMClient, MockNPMClient>()
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<ITelemetryService, TelemetryService>()
+            .BuildServiceProvider();
+        
+        
+        var telemetryService = ExecutionContext.ServiceProvider.GetService<ITelemetryService>();
+        var tracerProvider = telemetryService!.InitializeTracerProvider("test_A", "0.0.0");
+        var activitySource = telemetryService.InitializeActivitySource("test_A");
+        var activity = telemetryService.StartActivity("test_A");
+        
+        telemetryService.Should().NotBeNull();
+        tracerProvider.Should().BeNull("TelemetryService should not provide a TracerProvider if telemetry if off");
+        activitySource.Should().NotBeNull();
+        activity.Should().BeNull();
+    }
+    
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("True")]
+    [InlineData("TRUE")]
+    public void OnlyBasicTelemetry(string telemetrySetting)
+    {
+        Environment.SetEnvironmentVariable("cmf_cli_enable_telemetry", telemetrySetting);
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<INPMClient, MockNPMClient>()
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<ITelemetryService, TelemetryService>()
+            .BuildServiceProvider();
+        
+        
+        var telemetryService = ExecutionContext.ServiceProvider.GetService<ITelemetryService>();
+        // service name must match
+        var tracerProvider = telemetryService!.InitializeTracerProvider("test_B", "0.0.0");
+        var activitySource = telemetryService.InitializeActivitySource("test_B");
+        var activity = telemetryService.StartActivity("test_B");
+        
+
+        telemetryService.Should().NotBeNull();
+        tracerProvider.Should().NotBeNull();
+        activitySource.Should().NotBeNull();
+        activity.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void NoExtendedActivitiesIfExtendedTelemetryIsOff()
+    {
+        Environment.SetEnvironmentVariable("cmf_cli_enable_telemetry", "1");
+        // not specifying the cmf_cli_enable_extended_telemetry env var defaults to off
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<INPMClient, MockNPMClient>()
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<ITelemetryService, TelemetryService>()
+            .BuildServiceProvider();
+        
+        var telemetryService = ExecutionContext.ServiceProvider.GetService<ITelemetryService>();
+        var tracerProvider = telemetryService!.InitializeTracerProvider("test_NoExtended", "0.0.0");
+        var activitySource = telemetryService.InitializeActivitySource("test_NoExtended");
+        var activity = telemetryService.StartExtendedActivity("test_NoExtended");
+        
+        activity.Should().BeNull();
+    }
+
+    [Fact]
+    public void ActivitiesShouldNotIncludeIdentifiableInfoIfExtendedTelemetryIsOff()
+    {
+        var allowedTags = new[] { "latestVersion", "isOutdated", "isDev", "version" };
+        Environment.SetEnvironmentVariable("cmf_cli_enable_telemetry", "1");
+        // not specifying the cmf_cli_enable_extended_telemetry env var defaults to off
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<INPMClient, MockNPMClient>()
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<ITelemetryService, TelemetryService>()
+            .BuildServiceProvider();
+        
+        var telemetryService = ExecutionContext.ServiceProvider.GetService<ITelemetryService>();
+        var tracerProvider = telemetryService!.InitializeTracerProvider("test_Extended", "0.0.0");
+        var activitySource = telemetryService.InitializeActivitySource("test_Extended");
+        var activity = telemetryService.StartActivity("test_Extended");
+
+        activity.Should().NotBeNull();
+        var tagNames = activity.Tags.Select(kv => kv.Key);
+        tagNames.All(tagName => allowedTags.Contains(tagName)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData(false, false, false, new [] { "version" })]
+    [InlineData(false, true, false, new [] { "version", "isDev" })]
+    [InlineData(false, false, true, new [] { "version", "isOutdated", "latestVersion" })]
+    [InlineData(false, true, true, new [] { "version", "isDev", "isOutdated", "latestVersion" })]
+    [InlineData(true, false, false, new [] { "version", "ip", "hostname", "username", "cwd" })]
+    [InlineData(true, true, false, new [] { "version", "isDev", "ip", "hostname", "username", "cwd" })]
+    [InlineData(true, false, true, new [] { "version", "isOutdated", "latestVersion", "ip", "hostname", "username", "cwd" })]
+    [InlineData(true, true, true, new [] { "version", "isDev", "isOutdated", "latestVersion", "ip", "hostname", "username", "cwd" })]
+    public async void ValidateExpectedBareTags(bool includeExtendedTelemetry, bool isDevVersion, bool isOutdatedVersion, string[] expectedTags)
+    {
+        Environment.SetEnvironmentVariable("cmf_cli_enable_telemetry", "1");
+        Environment.SetEnvironmentVariable("cmf_cli_enable_extended_telemetry", includeExtendedTelemetry ? "1" : null);
+
+        var mockVersionService = new Mock<IVersionService>();
+        mockVersionService.SetupGet(service => service.CurrentVersion).Returns(isDevVersion ? "2.0.0-0" : "2.0.0");
+
+        var mockNPMClient = new Mock<INPMClient>();
+        mockNPMClient.Setup(mock => mock.GetLatestVersion(true))
+            .Returns(() => Task.FromResult(isOutdatedVersion ? "3.0.0-0" : "2.0.0-0"));
+        mockNPMClient.Setup(mock => mock.GetLatestVersion(false))
+            .Returns(() => Task.FromResult(isOutdatedVersion ? "3.0.0" : "2.0.0"));
+        ExecutionContext.LatestVersion = await mockNPMClient.Object.GetLatestVersion(isDevVersion);
+
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton(mockNPMClient.Object)
+            .AddSingleton(mockVersionService.Object)
+            .AddSingleton<ITelemetryService, TelemetryService>()
+            .BuildServiceProvider();
+        
+        var telemetryService = ExecutionContext.ServiceProvider.GetService<ITelemetryService>();
+        var tracerProvider = telemetryService!.InitializeTracerProvider("test_Bare", "0.0.0");
+        var activitySource = telemetryService.InitializeActivitySource("test_Bare");
+        var activity = telemetryService.StartActivity("test_Bare");
+        
+        var tagNames = activity.TagObjects.Select(kv => kv.Key).ToList();
+        tagNames.Distinct().Count().Should().Be(expectedTags.Length);
+        tagNames.All(expectedTags.Contains).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
This PR contains opt-in telemetry for CLI and CLI plugins. There are two levels: basic and extended telemetry.

## Telemetry implementation
Basic telemetry currently only tracks the CLI startup and logs:
- CLI name and version
- latest version available in NPM
- if the CLI version is stable or testing
- if the CLI is outdated

**no identifiable information is collected in basic telemetry**

However, any user can optionally enable extended telemetry, which might help with troubleshooting. **Extended telemetry includes identifiable information** and as such should be used with care. This includes the basic telemetry, plus:
- for the version (startup) log, it also includes
  - current working directory
  - hostname
  - IP
  - username

It also tracks and logs the package tree if, for any command, the tree must be computed. This includes all of the above information plus the package name, for each package in the tree.

Enabling telemetry can be done via environment variables:
- `cmf_cli_enable_telemetry` - enable basic telemetry. If this is off (the default), no telemetry will be collected, even if extended telemetry is on. To enable, set to `true` or `1`, do not set or set to `false` or `0` to disable.
- `cmf_cli_enable_extended_telemetry` - enable extended telemetry. Note the above warnings regarding the impact of keeping this on. To enable, set to `true` or `1`, do not set or set to `false` or `0` to disable.
- `cmf_cli_telemetry_enable_console_exporter` - also print the telemetry information to the console. This is for auditing or troubleshooting as it makes the console output extremely verbose
- `cmf_cli_telemetry_host` - specify an alternate telemetry endpoint (if you're hosting your own)

## Pipelines
**NOTE: The CI-Package pipeline is shipped with telemetry ON**. The provided pipelines are built for Critical Manufacturing use and provided as an example for the user to build their own. As at CM we keep telemetry on for troubleshooting, the generated pipelines have telemetry on. To disable, search for the `cmf_cli_enable_telemetry` environment variable in the pipeline YAML and disable it.

## Highlights:
- feat: add basic telemetry
- refactor: make telemetry opt-in feat: introduce extended telemetry options
- feat: add extended telemetry for commands
- chore: enable telemetry in CI-Package
