### PR TITLE
fix(init): derive repository name from valid repository url

### DIFF
--- a/cmf-cli/Commands/TemplateCommand.cs
+++ b/cmf-cli/Commands/TemplateCommand.cs
@@ -43,7 +43,7 @@ namespace Cmf.CLI.Commands
         /// Execute the command
         /// </summary>
         /// <param name="args">the template engine arguments</param>
-        public void RunCommand(IReadOnlyCollection<string> args)
+        public virtual void RunCommand(IReadOnlyCollection<string> args)
         {
             this.ExecuteTemplate(this.CommandName, args);
         }

--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -287,9 +287,20 @@ namespace Cmf.CLI.Commands
                 args.AddRange(new [] {"--DeliveredRepo", $"{x.deploymentDir.FullName}\\Delivered"});
             }
 
+            var repoName = x.projectName;
             if (x.repositoryUrl != null)
             {
                 args.AddRange(new [] {"--repositoryUrl", x.repositoryUrl.AbsoluteUri});
+                var match = CliConstants.RepoRegex.Match(x.repositoryUrl.AbsoluteUri);
+                if ((match?.Success ?? false) && match.Groups.ContainsKey("repo"))
+                {
+                    repoName = match.Groups["repo"].Value;
+                }
+            }
+
+            if (repoName != null)
+            {
+                args.AddRange(new [] {"--repositoryName", repoName});
             }
 
             if (x.MESVersion != null)

--- a/cmf-cli/Constants/CliConstants.cs
+++ b/cmf-cli/Constants/CliConstants.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Cmf.CLI.Constants
 {
     public static class CliConstants
@@ -80,6 +82,8 @@ namespace Cmf.CLI.Constants
         /// Security Portal Path for deployment of strategies
         /// </summary>
         public const string DefaultStrategyPath = "$.tenants.config.$(tenant).strategies";
+
+        public static readonly Regex RepoRegex = new Regex(@"^(?<proto>\w+):\/\/(?<host>[^\/]+)\/(?<collection>[^/]+)\/(?<project>[^\/]+\/)?_git\/(?<repo>.+)\/?$", RegexOptions.ExplicitCapture | RegexOptions.IgnoreCase);
 
         #endregion
 

--- a/cmf-cli/resources/template_feed/init/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/init/.template.config/template.json
@@ -53,6 +53,11 @@
       "datatype": "string",
       "replaces": "<%= $CLI_PARAM_RepositoryURL %>"
     },
+    "repositoryName": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "<%= $CLI_PARAM_RepositoryName %>"
+    },
     "deploymentDir-JSON": {
       "type": "derived",
       "replaces": "\"<%= $CLI_PARAM_DeploymentDir %>\"",

--- a/cmf-cli/resources/template_feed/init/Builds/CD-Containers.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CD-Containers.json
@@ -51,7 +51,7 @@
   "repository": {
     "properties": {
       "cloneUrl": "<%= $CLI_PARAM_RepositoryURL %>",
-      "fullName": "<%= $CLI_PARAM_ProjectName %>",
+      "fullName": "<%= $CLI_PARAM_RepositoryName %>",
       "defaultBranch": "refs/heads/development",
       "isFork": "False",
       "safeRepository": "e8c523b0-e52d-4698-ac78-a79f6e0487a3",
@@ -65,7 +65,7 @@
       "labelSourcesFormat": "$(build.buildNumber)"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
@@ -75,7 +75,7 @@
       "fetchDepth": "0"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
@@ -75,7 +75,7 @@
       "fetchDepth": "0"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Publish.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Publish.json
@@ -98,7 +98,7 @@
       "fetchDepth": "0"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Release.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Release.json
@@ -51,7 +51,7 @@
   "repository": {
     "properties": {
       "cloneUrl": "<%= $CLI_PARAM_RepositoryURL %>",
-      "fullName": "<%= $CLI_PARAM_ProjectName %>",
+      "fullName": "<%= $CLI_PARAM_RepositoryName %>",
       "defaultBranch": "refs/heads/development",
       "isFork": "False",
       "safeRepository": "e8c523b0-e52d-4698-ac78-a79f6e0487a3",
@@ -65,7 +65,7 @@
       "labelSourcesFormat": "$(build.buildNumber)"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/Environment-BackupRestore.json
+++ b/cmf-cli/resources/template_feed/init/Builds/Environment-BackupRestore.json
@@ -52,7 +52,7 @@
   "repository": {
     "properties": {
       "cloneUrl": "<%= $CLI_PARAM_RepositoryURL %>",
-      "fullName": "<%= $CLI_PARAM_ProjectName %>",
+      "fullName": "<%= $CLI_PARAM_RepositoryName %>",
       "defaultBranch": "refs/heads/development",
       "isFork": "False",
       "safeRepository": "e8c523b0-e52d-4698-ac78-a79f6e0487a3",
@@ -66,7 +66,7 @@
       "labelSourcesFormat": "$(build.buildNumber)"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": null,

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
@@ -75,7 +75,7 @@
       "fetchDepth": "0"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
@@ -75,7 +75,7 @@
       "fetchDepth": "0"
     },
     "type": "TfsGit",
-    "name": "<%= $CLI_PARAM_ProjectName %>",
+    "name": "<%= $CLI_PARAM_RepositoryName %>",
     "url": "<%= $CLI_PARAM_RepositoryURL %>",
     "defaultBranch": "refs/heads/development",
     "clean": "true",

--- a/cmf-cli/resources/template_feed/init/Builds/policies-development.json
+++ b/cmf-cli/resources/template_feed/init/Builds/policies-development.json
@@ -8,7 +8,7 @@
         {
           "refName": "refs/heads/development",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },
@@ -27,7 +27,7 @@
         {
           "refName": "refs/heads/development",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },
@@ -51,7 +51,7 @@
         {
           "refName": "refs/heads/development",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },
@@ -75,7 +75,7 @@
         {
           "refName": "refs/heads/development",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ],
       "__buildDefinitionName": "PR-Changes"
@@ -96,7 +96,7 @@
         {
           "refName": "refs/heads/development",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },

--- a/cmf-cli/resources/template_feed/init/Builds/policies-master.json
+++ b/cmf-cli/resources/template_feed/init/Builds/policies-master.json
@@ -9,7 +9,7 @@
         {
           "refName": "refs/heads/master",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },
@@ -32,7 +32,7 @@
         {
           "refName": "refs/heads/master",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },
@@ -51,7 +51,7 @@
         {
           "refName": "refs/heads/master",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },
@@ -70,7 +70,7 @@
         {
           "refName": "refs/heads/master",
           "matchKind": "Exact",
-          "__repositoryName": "<%= $CLI_PARAM_ProjectName %>"
+          "__repositoryName": "<%= $CLI_PARAM_RepositoryName %>"
         }
       ]
     },


### PR DESCRIPTION
As a convention, we assumed the repository url is the same as the project name. However, for
multi-repo projects this may not be true. As such, if the repository url is a valid Azure DevOps
repository, we can and should extract the repository name from there.

fixes #160
