### PR TITLE
feat(): Add ConnectIoT deployment steps to IoT Package

### DIFF
--- a/cmf-cli/Handlers/PackageType/IoTPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/IoTPackageTypeHandler.cs
@@ -61,7 +61,12 @@ namespace Cmf.CLI.Handlers
                         new Step(StepType.Generic)
                         {
                             OnExecute = $"$(Package[{cmfPackage.PackageId}].TargetDirectory)/runtimePackages/PublishToDirectory.ps1"
-                        }
+                        },
+                        new Step(StepType.DeployRepositoryFiles)
+                        {
+                            ContentPath = "runtimePackages/**"
+                        },
+                        new Step(StepType.GenerateRepositoryIndex)
                     }
             );
 

--- a/core/Enums/StepType.cs
+++ b/core/Enums/StepType.cs
@@ -53,6 +53,16 @@
         /// <summary>
         /// The enqueue SQL
         /// </summary>
-        EnqueueSql = 9
+        EnqueueSql = 9,
+
+        /// <summary>
+        /// Deploy ConnectIoT packages to Repository
+        /// </summary>
+        DeployRepositoryFiles = 10,
+
+        /// <summary>
+        /// Update the ConnectIoT Repository Index
+        /// </summary>
+        GenerateRepositoryIndex = 11
     }
 }


### PR DESCRIPTION
This PR adds the steps DeployRepositoryFiles and GenerateRepositoryIndex to allow the envmanager to deploy the runtime packages and update the index.

These are the resulting steps:

```xml
  <steps>
    <step type="DeployFiles" contentPath="runtimePackages/**" />
    <step type="DeployFiles" contentPath="*.ps1" />
    <step type="DeployFiles" contentPath="*.bat" />
    <step type="Generic" onExecute="$(Package[Cmf.FEC.IoT.Packages].TargetDirectory)/runtimePackages/ValidateIoTInstall.ps1" />
    <step type="Generic" onExecute="$(Package[Cmf.FEC.IoT.Packages].TargetDirectory)/runtimePackages/PublishToRepository.ps1" />
    <step type="Generic" onExecute="$(Package[Cmf.FEC.IoT.Packages].TargetDirectory)/runtimePackages/PublishToDirectory.ps1" />
    <step type="DeployRepositoryFiles" contentPath="runtimePackages/**" />
    <step type="GenerateRepositoryIndex" />
    <step type="DeployFiles" contentPath="node_modules/**" />
    <step type="TransformFile" file="config.json" tagFile="true" />
  </steps>
```