### PR TITLE
Allow namespacing pipelines

### DIFF
--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -58,6 +58,7 @@ namespace Cmf.CLI.Commands
         public string nugetRegistryPassword { get; set; }
         public string cmfPipelineRepository { get; set; }
         public string cmfCliRepository { get; set; }
+        public string pipelinesFolder { get; set; }
         public string releaseCustomerEnvironment { get; set; }
         public string releaseSite { get; set; }
         public string releaseDeploymentPackage { get; set; }
@@ -206,6 +207,11 @@ namespace Cmf.CLI.Commands
                 aliases: new[] { "--cmfPipelineRepository" },
                 description: "NPM registry that contains the CLI Pipeline Plugin"
             ));
+            cmd.AddOption(new Option<string>(
+                aliases: new[] { "--pipelinesFolder" },
+                getDefaultValue: () => "",
+                description: "Folder where we should put the pipelines in. Empty means the root folder"
+            ));
             
             // container-specific switches
             cmd.AddOption(new Option<string>(
@@ -326,6 +332,16 @@ namespace Cmf.CLI.Commands
             if (x.testScenariosNugetVersion != null)
             {
                 args.AddRange(new [] {"--testScenariosNugetVersion", x.testScenariosNugetVersion});
+            }
+
+            if (!string.IsNullOrWhiteSpace(x.pipelinesFolder))
+            {
+                var folder = x.pipelinesFolder.Replace("/", "\\");
+                if (!folder.StartsWith("\\"))
+                {
+                    folder = "\\" + folder;
+                }
+                args.AddRange(new []{"--pipelinesFolder", folder});   
             }
 
             #region infrastructure

--- a/cmf-cli/resources/template_feed/init/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/init/.template.config/template.json
@@ -173,6 +173,23 @@
       "datatype": "string",
       "replaces": "<%= $CLI_PARAM_TestScenariosNugetVersion %>"
     },
+    "pipelinesFolder": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "<%= $CLI_PARAM_PipelinesFolder %>",
+      "defaultValue": ""
+    },
+    "pipelinesFolderJSON-withquotes": {
+      "type": "derived",
+      "valueSource": "PipelinesFolder",
+      "valueTransform": "jsonEncode"
+    },
+    "pipelinesFolderJSON": {
+      "type": "derived",
+      "replaces": "<%= $CLI_PARAM_PipelinesFolderJSON %>",
+      "valueSource": "pipelinesFolderJSON-withquotes",
+      "valueTransform": "stripQuotes"
+    },
     
     // from infra
     "nugetRegistry": {
@@ -427,6 +444,11 @@
       "identifier": "replace",
       "pattern": "(\\d+)\\.(\\d+)\\.(\\d+)",
       "replacement": "$1.$2.x"
+    },
+    "stripQuotes": {
+      "identifier": "replace",
+      "pattern": "\"([^\"]*)\"",
+      "replacement": "$1"
     }
   }
 }

--- a/cmf-cli/resources/template_feed/init/Builds/CD-Containers.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CD-Containers.json
@@ -84,7 +84,7 @@
   "name": "CD-Containers",
   "url": "<%= $CLI_PARAM_AzureDevopsCollectionURL %>/d659bbbd-b8f0-4d06-b2a9-1a161455189f/_apis/build/Definitions/1063?revision=14",
   "uri": "vstfs:///Build/Definition/1063",
-  "path": "\\Releases",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\Releases",
   "type": 2,
   "queueStatus": 2,
   "revision": 14,

--- a/cmf-cli/resources/template_feed/init/Builds/CD-Containers.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CD-Containers.yml
@@ -1,6 +1,9 @@
 # CM PI Continuous Deployment Containers Pipeline
 pool:
-  name: Releases
+  name: <%= $CLI_PARAM_AgentPool %>
+//#if (agentType == "Cloud")
+  vmImage: 'ubuntu-latest'
+//#endif
 
 # A pipeline with no CI trigger
 trigger: none

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
@@ -94,7 +94,7 @@
   "name": "CI-Changes",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1841?revision=1",
   "uri": "vstfs:///Build/Definition/1841",
-  "path": "\\CI-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\CI-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 1,

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.yml
@@ -83,7 +83,7 @@ steps:
       # get pipeline
       $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
       $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.CIPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "\CI-Builds" }
+      $def = $defs.value | where { $_.name -eq '${{ variables.CIPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "<%= $CLI_PARAM_PipelinesFolder %>\CI-Builds" }
 
       if ($def -eq $null) {
           Write-Host "Build definition '${{ variables.CIPipeline }}' not found in project $(System.TeamProject)"

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
@@ -94,7 +94,7 @@
   "name": "CI-Package",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1840?revision=4",
   "uri": "vstfs:///Build/Definition/1840",
-  "path": "\\CI-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\CI-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 4,

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Publish.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Publish.json
@@ -117,7 +117,7 @@
   "name": "CI-Publish",
   "url": "<%= $CLI_PARAM_AzureDevopsCollectionURL %>/d659bbbd-b8f0-4d06-b2a9-1a161455189f/_apis/build/Definitions/504?revision=14",
   "uri": "vstfs:///Build/Definition/504",
-  "path": "\\CI-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\CI-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 14,

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Release.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Release.json
@@ -84,7 +84,7 @@
   "name": "CI-Release",
   "url": "<%= $CLI_PARAM_AzureDevopsCollectionURL %>/d659bbbd-b8f0-4d06-b2a9-1a161455189f/_apis/build/Definitions/1063?revision=14",
   "uri": "vstfs:///Build/Definition/1063",
-  "path": "\\Releases",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\Releases",
   "type": 2,
   "queueStatus": 2,
   "revision": 14,

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
@@ -94,7 +94,7 @@
   "name": "PR-Changes",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1894?revision=2",
   "uri": "vstfs:///Build/Definition/1894",
-  "path": "\\PR-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\PR-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 2,

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
@@ -53,7 +53,7 @@ steps:
       # get pipeline
       $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
       $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "\PR-Builds" }
+      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "<%= $CLI_PARAM_PipelinesFolder %>\PR-Builds" }
 
       if ($def -eq $null) {
           Write-Host "Build definition '${{ variables.PRPipeline }}' not found in project $(System.TeamProject)"

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
@@ -94,7 +94,7 @@
   "name": "PR-Package",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1896?revision=1",
   "uri": "vstfs:///Build/Definition/1896",
-  "path": "\\PR-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\PR-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 1,


### PR DESCRIPTION
Provides an extra option to `init`, `--pipelinesFolder`, which will create all pipelines inside the folder specified by the option value. If not specified, `init` will create all pipelines in the root, as at present.

- fix: change CD-Containers: had an hardcoded agent pool
- feat(init): allow namespacing the pipelines for multi-site projects
