### PR TITLE
Release 3.1.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [3.1.2](https://github.com/criticalmanufacturing/cli/compare/3.1.2-0...3.1.2) (2022-10-17)
+
+### [3.1.2-0](https://github.com/criticalmanufacturing/cli/compare/3.1.1...3.1.2-0) (2022-09-23)
+
+
+### Bug Fixes
+
+* build dotnet projects on data package build ([66443bf](https://github.com/criticalmanufacturing/cli/commits/66443bffee1560869a43375be16a731869127503))
+* iot package changing html config.json with wrong version ([74fe8e8](https://github.com/criticalmanufacturing/cli/commits/74fe8e89da5d9b2ffe10b25dc0a58b5c766ebd08)), closes [#202](https://github.com/criticalmanufacturing/cli/issues/202)
+* serialization changing workingDirectory>buildSteps ([3fc8b18](https://github.com/criticalmanufacturing/cli/commits/3fc8b181908dff52dcdb3bb188f204929688f4ee)), closes [#190](https://github.com/criticalmanufacturing/cli/issues/190)
+
 ### [3.1.1](https://github.com/criticalmanufacturing/cli/compare/3.1.1-0...3.1.1) (2022-09-23)
 
 ### [3.1.1-0](https://github.com/criticalmanufacturing/cli/compare/3.1.0...3.1.1-0) (2022-09-15)

--- a/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
+++ b/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
@@ -64,6 +64,39 @@ namespace Cmf.CLI.Handlers
                 }
             };
 
+            IFileInfo[] deeActionProjects = cmfPackage.GetFileInfo().Directory.GetFiles("*.csproj", SearchOption.AllDirectories);
+
+            foreach (IFileInfo project in deeActionProjects)
+            {
+                if (project.Exists)
+                {
+                    BuildSteps = BuildSteps.Union(new IBuildCommand[]
+                    {
+                        new DotnetCommand()
+                        {
+                            Command = "restore",
+                            DisplayName = $"NuGet restore {project.Name}",
+                            Solution = project,
+                            NuGetConfig = this.fileSystem.FileInfo.FromFileName(Path.Join(FileSystemUtilities.GetProjectRoot(this.fileSystem, throwException: true).FullName, "NuGet.Config")),
+                            WorkingDirectory = cmfPackage.GetFileInfo().Directory
+                        },
+                        new DotnetCommand()
+                        {
+                            Command = "build",
+                            DisplayName = $"Build {project.Name}",
+                            Solution = project,
+                            Configuration = "Release",
+                            WorkingDirectory = cmfPackage.GetFileInfo().Directory,
+                            Args = new[] { "--no-restore " }
+                        }
+                    }).ToArray();
+                }
+                else
+                {
+                    Log.Warning(string.Format(CoreMessages.NotFound, project.FullName));
+                }
+            }
+
             cmfPackage.DFPackageType = PackageType.Business; // necessary because we restart the host during installation
         }
 

--- a/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
+++ b/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
@@ -52,14 +52,6 @@ namespace Cmf.CLI.Handlers
                         new Step(StepType.Generic)
                         {
                             OnExecute = "$(Agent.Root)/agent/scripts/start_host.ps1"
-                        },
-                        new Step(StepType.Generic)
-                        {
-                            ContentPath = "GenerateLBOs.ps1"
-                        },
-                        new Step(StepType.Generic)
-                        {
-                            OnExecute = $"$(Package[{cmfPackage.PackageId}].TargetDirectory)/GenerateLBOs.ps1"
                         }
                      });
 
@@ -154,18 +146,6 @@ namespace Cmf.CLI.Handlers
             // Get Template
             string fileContent = ResourceUtilities.GetEmbeddedResourceContent($"{CliConstants.FolderTemplates}/Data/{CliConstants.CmfPackageHostConfig}");
             this.fileSystem.File.WriteAllText(path, fileContent);
-        }
-
-        /// <summary>
-        /// Copies the install dependencies.
-        /// </summary>
-        /// <param name="packageOutputDir">The package output dir.</param>
-        protected override void CopyInstallDependencies(IDirectoryInfo packageOutputDir)
-        {
-            IDirectoryInfo dir = fileSystem.DirectoryInfo.FromDirectoryName(fileSystem.Path.Join(AppDomain.CurrentDomain.BaseDirectory, CliConstants.FolderInstallDependencies, "Data"));
-            IFileInfo generateLBOsFile = dir.GetFiles("GenerateLBOs.ps1")[0];
-            string tempPath = fileSystem.Path.Combine(packageOutputDir.FullName, generateLBOsFile.Name);
-            generateLBOsFile.CopyTo(tempPath, true);
         }
     }
 }

--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -471,7 +471,7 @@ namespace Cmf.CLI.Handlers
         /// <summary>
         /// Builds this instance.
         /// </summary>
-        public virtual void Build(bool test = false)
+        public virtual void Build(bool test)
         {
             foreach (var step in BuildSteps)
             {

--- a/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PresentationPackageTypeHandler.cs
@@ -26,7 +26,7 @@ namespace Cmf.CLI.Handlers
         /// Generates the presentation configuration file.
         /// </summary>
         /// <param name="packageOutputDir">The package output dir.</param>
-        private void GeneratePresentationConfigFile(IDirectoryInfo packageOutputDir)
+        public void GeneratePresentationConfigFile(IDirectoryInfo packageOutputDir)
         {
             Log.Debug("Generating Presentation config.json");
             string path = $"{packageOutputDir.FullName}/{CliConstants.CmfPackagePresentationConfig}";
@@ -124,7 +124,7 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        #endregion
+        #endregion Private Methods
 
         #region Public Methods
 
@@ -223,6 +223,6 @@ namespace Cmf.CLI.Handlers
             base.Pack(packageOutputDir, outputDir);
         }
 
-        #endregion
+        #endregion Public Methods
     }
 }

--- a/cmf-cli/Interfaces/IPackageTypeHandler.cs
+++ b/cmf-cli/Interfaces/IPackageTypeHandler.cs
@@ -29,7 +29,7 @@ namespace Cmf.CLI.Interfaces
         /// <summary>
         /// Builds this instance.
         /// </summary>
-        public void Build(bool test);
+        public void Build(bool test = false);
 
         /// <summary>
         /// Packs the specified package output dir.
@@ -37,7 +37,7 @@ namespace Cmf.CLI.Interfaces
         /// <param name="packageOutputDir">The package output dir.</param>
         /// <param name="outputDir">The output dir.</param>
         public void Pack(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir);
-        
+
         /// <summary>
         /// Restore package dependencies (declared in cmfpackage.json) from repository packages
         /// </summary>

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.1.1</Version>
+    <Version>3.1.2-0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.1.2-0</Version>
+    <Version>3.1.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cmf-cli/resources/templateFiles/IoT/config.json
+++ b/cmf-cli/resources/templateFiles/IoT/config.json
@@ -8,6 +8,5 @@
       "@jdt.value": [ $(packagesToAdd) ]
     }
   ],
-  "cacheId": "$(Product.Presentation.CacheToken)",
-  "customizationVersion": "$(version)"
+  "cacheId": "$(Product.Presentation.CacheToken)"
 }

--- a/core/Objects/ProcessBuildStep.cs
+++ b/core/Objects/ProcessBuildStep.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 namespace Cmf.CLI.Core.Objects;
 
 /// <summary>
-/// An atomic (from tool perspective) build step 
+/// An atomic (from tool perspective) build step
 /// </summary>
 [JsonObject]
 public class ProcessBuildStep : IEquatable<ProcessBuildStep>
@@ -38,7 +38,7 @@ public class ProcessBuildStep : IEquatable<ProcessBuildStep>
     [JsonConverter(typeof(AbstractionsDirectoryConverter))]
     [JsonProperty(Order = 3)]
     public IDirectoryInfo WorkingDirectory { get; set; }
-    
+
     #region IEquatable
 
     /// <inheritdoc />
@@ -66,12 +66,12 @@ public class ProcessBuildStep : IEquatable<ProcessBuildStep>
     /// <inheritdoc />
     public override int GetHashCode()
     {
-        return (this.Command?.GetHashCode() ?? 0) 
-            + (this.Args?.GetHashCode() ?? 0) 
+        return (this.Command?.GetHashCode() ?? 0)
+            + (this.Args?.GetHashCode() ?? 0)
             + (this.WorkingDirectory?.GetHashCode() ?? 0);
     }
 
-    #endregion
+    #endregion IEquatable
 }
 
 /// <summary>
@@ -82,7 +82,7 @@ public class AbstractionsDirectoryConverter : JsonConverter
     /// <inheritdoc />
     public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
     {
-        writer.WriteValue((value as IDirectoryInfo).FullName);
+        writer.WriteValue((value as IDirectoryInfo).ToString());
     }
 
     /// <inheritdoc />

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.1.1</Version>
+        <Version>3.1.2-0</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.1.2-0</Version>
+        <Version>3.1.2</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.1.2-0",
+  "version": "3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.1.1",
+  "version": "3.1.2-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.1.2-0",
+  "version": "3.1.2",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.1.1",
+  "version": "3.1.2-0",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"

--- a/testenvironments.json
+++ b/testenvironments.json
@@ -1,0 +1,10 @@
+{
+    "version": "1",
+    "environments": [
+        {
+            "name": "Ubuntu-20.04",
+            "type": "wsl",
+            "wslDistribution": "Ubuntu-20.04"
+        }
+    ]
+}

--- a/tests/Specs/Build.cs
+++ b/tests/Specs/Build.cs
@@ -41,7 +41,7 @@ public class Build
         var dirInfo = fileSystem.DirectoryInfo.FromDirectoryName("/test");
         converter.WriteJson(writer, dirInfo, JsonSerializer.Create());
 
-        txtWriter.ToString().Should().Be($"\"{MockUnixSupport.Path("C:\\test").Replace("\\", "\\\\")}\"", "directory path does not match");
+        txtWriter.ToString().Should().Be(@"""/test""", "directory path does not match");
     }
 
     [Fact]
@@ -156,7 +156,7 @@ public class Build
 
         string serializedStep = JsonConvert.SerializeObject(step, jsonSerializerSettings);
 
-        serializedStep.Should().Be(@$"{{""args"":[""run"",""build:clean""],""command"":""npm.cmd"",""workingDirectory"":""{MockUnixSupport.Path("C:\\").Replace("\\", "\\\\")}""}}");
+        serializedStep.Should().Be(@$"{{""args"":[""run"",""build:clean""],""command"":""npm.cmd"",""workingDirectory"":"".""}}");
     }
 
     [Fact]


### PR DESCRIPTION
- fix: iot package changing html config.json with wrong version fixes #202
- chore: add testenvironments.json file to support debug on wsl
- chore: remove LBOGeneration from default steps closes #213
- fix: serialization changing workingDirectory>buildSteps fixes #190
- chore: move optional parameter to interface class
- fix: build dotnet projects on data package build
- test(build): add data package build closes #66
- chore: bump to 3.1.2-0
- chore: release 3.1.2
