### PR TITLE
development fix bump quotes

### DIFF
--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -58,6 +58,7 @@ namespace Cmf.CLI.Commands
         public string nugetRegistryPassword { get; set; }
         public string cmfPipelineRepository { get; set; }
         public string cmfCliRepository { get; set; }
+        public string pipelinesFolder { get; set; }
         public string releaseCustomerEnvironment { get; set; }
         public string releaseSite { get; set; }
         public string releaseDeploymentPackage { get; set; }
@@ -206,6 +207,11 @@ namespace Cmf.CLI.Commands
                 aliases: new[] { "--cmfPipelineRepository" },
                 description: "NPM registry that contains the CLI Pipeline Plugin"
             ));
+            cmd.AddOption(new Option<string>(
+                aliases: new[] { "--pipelinesFolder" },
+                getDefaultValue: () => "",
+                description: "Folder where we should put the pipelines in. Empty means the root folder"
+            ));
             
             // container-specific switches
             cmd.AddOption(new Option<string>(
@@ -326,6 +332,16 @@ namespace Cmf.CLI.Commands
             if (x.testScenariosNugetVersion != null)
             {
                 args.AddRange(new [] {"--testScenariosNugetVersion", x.testScenariosNugetVersion});
+            }
+
+            if (!string.IsNullOrWhiteSpace(x.pipelinesFolder))
+            {
+                var folder = x.pipelinesFolder.Replace("/", "\\");
+                if (!folder.StartsWith("\\"))
+                {
+                    folder = "\\" + folder;
+                }
+                args.AddRange(new []{"--pipelinesFolder", folder});   
             }
 
             #region infrastructure

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.1.2</Version>
+    <Version>3.2.0-0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cmf-cli/resources/template_feed/init/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/init/.template.config/template.json
@@ -173,6 +173,23 @@
       "datatype": "string",
       "replaces": "<%= $CLI_PARAM_TestScenariosNugetVersion %>"
     },
+    "pipelinesFolder": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "<%= $CLI_PARAM_PipelinesFolder %>",
+      "defaultValue": ""
+    },
+    "pipelinesFolderJSON-withquotes": {
+      "type": "derived",
+      "valueSource": "PipelinesFolder",
+      "valueTransform": "jsonEncode"
+    },
+    "pipelinesFolderJSON": {
+      "type": "derived",
+      "replaces": "<%= $CLI_PARAM_PipelinesFolderJSON %>",
+      "valueSource": "pipelinesFolderJSON-withquotes",
+      "valueTransform": "stripQuotes"
+    },
     
     // from infra
     "nugetRegistry": {
@@ -427,6 +444,11 @@
       "identifier": "replace",
       "pattern": "(\\d+)\\.(\\d+)\\.(\\d+)",
       "replacement": "$1.$2.x"
+    },
+    "stripQuotes": {
+      "identifier": "replace",
+      "pattern": "\"([^\"]*)\"",
+      "replacement": "$1"
     }
   }
 }

--- a/cmf-cli/resources/template_feed/init/Builds/CD-Containers.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CD-Containers.json
@@ -84,7 +84,7 @@
   "name": "CD-Containers",
   "url": "<%= $CLI_PARAM_AzureDevopsCollectionURL %>/d659bbbd-b8f0-4d06-b2a9-1a161455189f/_apis/build/Definitions/1063?revision=14",
   "uri": "vstfs:///Build/Definition/1063",
-  "path": "\\Releases",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\Releases",
   "type": 2,
   "queueStatus": 2,
   "revision": 14,

--- a/cmf-cli/resources/template_feed/init/Builds/CD-Containers.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CD-Containers.yml
@@ -1,6 +1,9 @@
 # CM PI Continuous Deployment Containers Pipeline
 pool:
-  name: Releases
+  name: <%= $CLI_PARAM_AgentPool %>
+//#if (agentType == "Cloud")
+  vmImage: 'ubuntu-latest'
+//#endif
 
 # A pipeline with no CI trigger
 trigger: none

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.json
@@ -94,7 +94,7 @@
   "name": "CI-Changes",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1841?revision=1",
   "uri": "vstfs:///Build/Definition/1841",
-  "path": "\\CI-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\CI-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 1,

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.yml
@@ -83,7 +83,7 @@ steps:
       # get pipeline
       $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
       $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.CIPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "\CI-Builds" }
+      $def = $defs.value | where { $_.name -eq '${{ variables.CIPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "<%= $CLI_PARAM_PipelinesFolder %>\CI-Builds" }
 
       if ($def -eq $null) {
           Write-Host "Build definition '${{ variables.CIPipeline }}' not found in project $(System.TeamProject)"

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.json
@@ -94,7 +94,7 @@
   "name": "CI-Package",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1840?revision=4",
   "uri": "vstfs:///Build/Definition/1840",
-  "path": "\\CI-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\CI-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 4,

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Publish.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Publish.json
@@ -117,7 +117,7 @@
   "name": "CI-Publish",
   "url": "<%= $CLI_PARAM_AzureDevopsCollectionURL %>/d659bbbd-b8f0-4d06-b2a9-1a161455189f/_apis/build/Definitions/504?revision=14",
   "uri": "vstfs:///Build/Definition/504",
-  "path": "\\CI-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\CI-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 14,

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Release.json
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Release.json
@@ -84,7 +84,7 @@
   "name": "CI-Release",
   "url": "<%= $CLI_PARAM_AzureDevopsCollectionURL %>/d659bbbd-b8f0-4d06-b2a9-1a161455189f/_apis/build/Definitions/1063?revision=14",
   "uri": "vstfs:///Build/Definition/1063",
-  "path": "\\Releases",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\Releases",
   "type": 2,
   "queueStatus": 2,
   "revision": 14,

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.json
@@ -94,7 +94,7 @@
   "name": "PR-Changes",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1894?revision=2",
   "uri": "vstfs:///Build/Definition/1894",
-  "path": "\\PR-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\PR-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 2,

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
@@ -53,7 +53,7 @@ steps:
       # get pipeline
       $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
       $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "\PR-Builds" }
+      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "<%= $CLI_PARAM_PipelinesFolder %>\PR-Builds" }
 
       if ($def -eq $null) {
           Write-Host "Build definition '${{ variables.PRPipeline }}' not found in project $(System.TeamProject)"

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Package.json
@@ -94,7 +94,7 @@
   "name": "PR-Package",
   "url": "https://tfs-projects.cmf.criticalmanufacturing.com/ImplementationProjects/8a17a15f-cb8d-46f0-9b3c-d40ff4ac3438/_apis/build/Definitions/1896?revision=1",
   "uri": "vstfs:///Build/Definition/1896",
-  "path": "\\PR-Builds",
+  "path": "<%= $CLI_PARAM_PipelinesFolderJSON %>\\PR-Builds",
   "type": 2,
   "queueStatus": 0,
   "revision": 1,

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.1.2</Version>
+        <Version>3.2.0-0</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.1.2",
+  "version": "3.2.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.1.2",
+  "version": "3.2.0-0",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -372,7 +372,12 @@ namespace tests.Specs
         [Fact, Trait("TestCategory", "LongRunning")]
         public void UI()
         {
-            RunNew(new HTMLCommand(), "Cmf.Custom.HTML", extraArguments: new string[]
+            UI_internal(null);
+        }
+        
+        private void UI_internal(string scaffoldingDir)
+        {
+            RunNew(new HTMLCommand(), "Cmf.Custom.HTML", scaffoldingDir: scaffoldingDir, extraArguments: new string[]
             {
                 "--htmlPkg", TestUtilities.GetFixturePath("prodPkg", "Cmf.Presentation.HTML.9.9.9.zip"),
             }, extraAsserts: args =>
@@ -382,6 +387,27 @@ namespace tests.Specs
                 Assert.True(Directory.Exists($"Cmf.Custom.HTML/apps/customization.web"), "WebApp dir is missing or has wrong name. Was running the application generator unsuccessful?");
                 Assert.True(File.Exists($"Cmf.Custom.HTML/apps/customization.web/config.json"), "Config file is missing or has wrong name");
                 Assert.True(File.ReadAllText("Cmf.Custom.HTML/apps/customization.web/config.json").Contains("test.package"), "Product package is not in config.json");
+                Assert.True(File.Exists($"Cmf.Custom.HTML/apps/customization.web/index.html"), "Index file is missing or has wrong name");
+            });
+        }
+        
+        [Theory, Trait("TestCategory", "LongRunning")]
+        [InlineData("8.2.0", false)]
+        [InlineData("9.1.0", true)]
+        public void UI_WithAppsPackage(string mesVersion, bool isCoreAppPresent)
+        {
+            RunNew(new HTMLCommand(), "Cmf.Custom.HTML", mesVersion: mesVersion, extraArguments: new string[]
+            {
+                "--htmlPkg", TestUtilities.GetFixturePath("prodPkg", "Cmf.Presentation.HTML.9.9.9.zip"),
+            }, extraAsserts: args =>
+            {
+                Assert.True(File.Exists($"Cmf.Custom.HTML/.dev-tasks.json"), "dev-tasks file is missing or has wrong name. Was cloning HTML-starter unsuccessful?");
+                Assert.True(File.ReadAllText("Cmf.Custom.HTML/.dev-tasks.json").Contains("\"isWebAppCompilable\": true"), "Web app is not compilable");
+                Assert.True(Directory.Exists($"Cmf.Custom.HTML/apps/customization.web"), "WebApp dir is missing or has wrong name. Was running the application generator unsuccessful?");
+                Assert.True(File.Exists($"Cmf.Custom.HTML/apps/customization.web/config.json"), "Config file is missing or has wrong name");
+                Assert.True(File.ReadAllText("Cmf.Custom.HTML/apps/customization.web/config.json").Contains("test.package"), "Product package is not in config.json");
+                File.ReadAllText("Cmf.Custom.HTML/apps/customization.web/config.json").Contains("cmf.core.app").Should()
+                    .Be(isCoreAppPresent, $"Apps package {(isCoreAppPresent ? "is not" : "is")} in config.json even though we are targeting {mesVersion}");
                 Assert.True(File.Exists($"Cmf.Custom.HTML/apps/customization.web/index.html"), "Index file is missing or has wrong name");
             });
         }
@@ -397,7 +423,12 @@ namespace tests.Specs
         [Fact, Trait("TestCategory", "LongRunning")]
         public void Help()
         {
-            RunNew(new Cmf.CLI.Commands.New.HelpCommand(), "Cmf.Custom.Help", extraArguments: new string[] {
+            Help_internal();
+        }
+
+        private void Help_internal(string scaffoldingDir = null)
+        {
+            RunNew(new Cmf.CLI.Commands.New.HelpCommand(), "Cmf.Custom.Help", scaffoldingDir: scaffoldingDir, extraArguments: new string[] {
                 "--docPkg", TestUtilities.GetFixturePath("prodPkg", "Cmf.Documentation.9.9.9.zip"),
             }, extraAsserts: args =>
             {
@@ -497,12 +528,17 @@ namespace tests.Specs
             });
         }
 
-        // TODO: Tests doesn't work with RunNew (Execute is invoked on LayerTemplateCommand)
+        // Tests doesn't work with RunNew (Execute is invoked on LayerTemplateCommand)
         [Fact]
         public void Tests()
         {
+            Tests_internal(null);
+        }
+
+        private void Tests_internal(string scaffoldingDir = null)
+        {
             var packageId = "Cmf.Custom.Tests";
-            var dir = TestUtilities.GetTmpDirectory();
+            var dir = scaffoldingDir ?? TestUtilities.GetTmpDirectory();
 
             var rnd = new Random();
             var pkgVersion = $"{rnd.Next(10)}.{rnd.Next(10)}.{rnd.Next(10)}";
@@ -555,7 +591,7 @@ namespace tests.Specs
             }
         }
 
-        [Fact]
+        [Fact, Trait("TestCategory", "LongRunning")]
         public void Traditional()
         {
             var dir = TestUtilities.GetTmpDirectory();
@@ -572,11 +608,11 @@ namespace tests.Specs
 
                 RunNew(new BusinessCommand(), "Cmf.Custom.Business", scaffoldingDir: dir);
                 RunNew(new DataCommand(), "Cmf.Custom.Data", scaffoldingDir: dir);
-                //UI(dir);
-                //Help(dir);
+                // UI_internal(dir);
+                // Help_internal(dir);
                 RunNew(new IoTCommand(), "Cmf.Custom.IoT", scaffoldingDir: dir);
                 RunDatabase(dir);
-                //Tests(dir);
+                // Tests_internal(dir);
             }
             finally
             {
@@ -792,7 +828,7 @@ namespace tests.Specs
             Assert.True(File.Exists($"{dir}/Cmf.Custom.SecurityPortal/config.json"), "Package config.json is missing");
         }
 
-        private TestConsole RunNew<T>(T newCommand, string packageId, string scaffoldingDir = null, string[] extraArguments = null, bool defaultAsserts = true, Action<(string, string)> extraAsserts = null) where T : TemplateCommand
+        private TestConsole RunNew<T>(T newCommand, string packageId, string scaffoldingDir = null, string[] extraArguments = null, bool defaultAsserts = true, Action<(string, string)> extraAsserts = null, string mesVersion = "8.2.0") where T : TemplateCommand
         {
             var dir = scaffoldingDir ?? TestUtilities.GetTmpDirectory();
 
@@ -809,6 +845,11 @@ namespace tests.Specs
                 if (scaffoldingDir == null)
                 {
                     TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+                    var projCfg = Path.Join(dir, ".project-config.json");
+                    if (File.Exists(projCfg))
+                    {
+                        File.WriteAllText(projCfg, File.ReadAllText(projCfg).Replace(@"""MESVersion"": ""8.2.0""", $@"""MESVersion"": ""{mesVersion}"""));
+                    }
                 }
 
                 var cmd = new Command("x");


### PR DESCRIPTION
- fix: append cmf.core.app to HTML packages, isn't used in ISO but is needed in bundles for containers
- fix: change CD-Containers: had an hardcoded agent pool
- feat(init): allow namespacing the pipelines for multi-site projects
- chore: bump to 3.2.0-0
