### PR TITLE
refactor: make telemetry service parameterized to be used in plugins chore: make startup warning state which app they relate to

### DIFF
--- a/cmf-cli/Program.cs
+++ b/cmf-cli/Program.cs
@@ -112,14 +112,14 @@ namespace Cmf.CLI
             if (ExecutionContext.IsDevVersion)
             {
                 Log.Information(
-                    $"You are using development version {ExecutionContext.CurrentVersion}. This in unsupported in production and should only be used for testing.");
+                    $"You are using {ExecutionContext.PackageId} development version {ExecutionContext.CurrentVersion}. This in unsupported in production and should only be used for testing.");
             }
 
             ExecutionContext.LatestVersion = await npmClient!.GetLatestVersion(ExecutionContext.IsDevVersion);
             if (ExecutionContext.LatestVersion != null && ExecutionContext.LatestVersion != ExecutionContext.CurrentVersion)
             {
                 Log.Warning(
-                    $"Using version {ExecutionContext.CurrentVersion} while {ExecutionContext.LatestVersion} is available. Please update.");
+                    $"Using {ExecutionContext.PackageId} version {ExecutionContext.CurrentVersion} while {ExecutionContext.LatestVersion} is available. Please update.");
                 // after this run, every activity will have these tags (check TelemetryService)
                 activity?.SetTag("isOutdated", true);
                 activity?.SetTag("latestVersion", ExecutionContext.LatestVersion);

--- a/core/Objects/NPMClient.cs
+++ b/core/Objects/NPMClient.cs
@@ -102,7 +102,7 @@ namespace Cmf.CLI.Core.Objects
             catch (Exception e)
             {
                 Log.Debug(e.Message);
-                Log.Warning("Could not retrieve latest version information. Try again later.");
+                Log.Warning($"Could not retrieve {ExecutionContext.PackageId} latest version information. Try again later.");
             }
 
             return null;

--- a/tests/Specs/Startup.cs
+++ b/tests/Specs/Startup.cs
@@ -98,7 +98,7 @@ namespace tests.Specs
             
             await Cmf.CLI.Program.VersionChecks();
             
-            logWriter.ToString().Should().Contain("You are using development version");
+            logWriter.ToString().Should().Contain("You are using test development version");
         }
         
         [Fact]
@@ -114,7 +114,7 @@ namespace tests.Specs
             
             await Cmf.CLI.Program.VersionChecks();
             
-            logWriter.ToString().Should().NotContain("You are using development version");
+            logWriter.ToString().Should().NotContain("You are using test development version");
         }
         
         [Fact]
@@ -148,7 +148,7 @@ namespace tests.Specs
 
             await npmClient.GetLatestVersion();
             
-            logWriter.ToString().Should().Contain("Could not retrieve latest version information");
+            logWriter.ToString().Should().Contain("Could not retrieve test latest version information");
         }
         
         [Theory]


### PR DESCRIPTION
refactor: make telemetry service parameterized to be used in plugins 
chore: make startup warning state which app they relate to