### PR TITLE
fix(builds): fixed issues caused by azuredevops update

### DIFF
--- a/cmf-cli/resources/template_feed/init/Builds/CI-Release.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Release.yml
@@ -117,7 +117,7 @@ stages:
           - task: ExtractFiles@1
             displayName: "Extract files - Pre-Package"
             inputs:
-              archiveFilePatterns: "Cmf.BackupRestore.Tools.*.zip"
+              archiveFilePatterns: "DownloadPackages/Cmf.BackupRestore.Tools/Cmf.BackupRestore.Tools.*.zip"
               destinationFolder: "BackupRestoreTools"
               cleanDestinationFolder: true
             continueOnError: false

--- a/cmf-cli/resources/template_feed/init/Builds/Environment-BackupRestore.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/Environment-BackupRestore.yml
@@ -69,7 +69,7 @@ stages:
              downloadPath: '_CommonTools'
           - task: ExtractFiles@1
             inputs:
-             archiveFilePatterns: '_CommonTools/*.zip'
+             archiveFilePatterns: '_CommonTools/Cmf.BackupRestore.Tools/*.zip'
              destinationFolder: 'Package'
              cleanDestinationFolder: true
           - task: CopyFiles@2
@@ -108,7 +108,7 @@ stages:
              downloadPath: '_CommonTools'
           - task: ExtractFiles@1
             inputs:
-             archiveFilePatterns: '_CommonTools/*.zip'
+             archiveFilePatterns: '_CommonTools/Cmf.BackupRestore.Tools/*.zip'
              destinationFolder: 'Package'
              cleanDestinationFolder: true
           - task: CopyFiles@2
@@ -151,7 +151,7 @@ stages:
              downloadPath: '_CommonTools'
           - task: ExtractFiles@1
             inputs:
-             archiveFilePatterns: '_CommonTools/*.zip'
+             archiveFilePatterns: '_CommonTools/Cmf.BackupRestore.Tools/*.zip'
              destinationFolder: 'Package'
              cleanDestinationFolder: true
           - task: CopyFiles@2
@@ -190,7 +190,7 @@ stages:
              downloadPath: '_CommonTools'
           - task: ExtractFiles@1
             inputs:
-             archiveFilePatterns: '_CommonTools/*.zip'
+             archiveFilePatterns: '_CommonTools/Cmf.BackupRestore.Tools/*.zip'
              destinationFolder: 'Package'
              cleanDestinationFolder: true
           - task: CopyFiles@2


### PR DESCRIPTION
in Azure DevOps Server 2020 Update 1.2, the extract task has changed behaviour and now does not deep match, requiring more complete paths to do the extractions