### PR TITLE
fix: downgrade global-dirs to 3.0.0

### DIFF
--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.2.0-4</Version>
+    <Version>3.2.0-5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.2.0-4</Version>
+        <Version>3.2.0-5</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.2.0-4",
+  "version": "3.2.0-5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.2.0-4",
+  "version": "3.2.0-5",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"
@@ -32,6 +32,7 @@
     "axios": "^1.1.3",
     "debug": "^4.3.4",
     "env-paths": "^2.2.1",
+    "global-dirs": "3.0.0",
     "is-installed-globally": "^0.4.0",
     "is-path-inside": "^3.0.3",
     "mkdirp": "^1.0.4",


### PR DESCRIPTION
global-dirs 3.0.1 breaks execution if we are using node version managers. It assumes $APPDATA
pm is
the default prefix, which is not the case when managers are used.
