### PR TITLE
development new pr pipeline

### DIFF
--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
@@ -25,11 +25,10 @@ variables:
    value: BuiltHEADs
  - name: packOutputDir
 //#if (agentType == "Cloud")
- value: $(Build.ArtifactStagingDirectory)
+  value: $(Build.ArtifactStagingDirectory)
 //#else
   value: $(CIPackages)/$(Build.SourceBranchName)
 //#endif
-
 
 workspace:
   clean: all

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
@@ -17,7 +17,7 @@ pr: none
 variables:
 - template: ../EnvironmentConfigs/GlobalVariables.yml  # Template reference to global variables
 - name: Pipeline
-  value: \<%= $CLI_PARAM_PipelinesFolder %>\PR-Builds\PR-Package
+  value: <%= $CLI_PARAM_PipelinesFolder %>\PR-Builds\PR-Package
 
 workspace:
   clean: all


### PR DESCRIPTION
- fix: support BuildablePackages on data packages closes #66
- chore: bump 3.1.3-1
- fix: set dependencies folder based on the context package
- test: support BuildablePackages on data packages
- chore: bump 3.1.3
- fix(bump): support single and double quotes on metadata ts file
- feat: add command for plugin discovery
- fix: fail gracefully when there's no internet to check new versions (fixes #218)
- chore: move tests to correct namespace
- chore(builds): use another publish-nuget action that is compatible with .NET 6
- chore: make NPMClient testable
- test: add tests for plugin command
- test(version check): add fail scenario for version check test(version check): add response structure validation for version check
- fixup! feat(init): allow namespacing the pipelines for multi-site projects
- fix(pipeline namespacing): namespace triggers in release pipelines
- fix(new feature): add MES dependencies to root feature scaffolding, they are mandatory
- chore: allow criticalmanufacturing as dependency to ignore
- chore: bump to 3.2.0-1
- fix(builds): fixed issues caused by azuredevops update
- refactor: make telemetry service parameterized to be used in plugins chore: make startup warning state which app they relate to
- chore(cleanup): remove local command and respective tools
- chore: bump to 3.2.0-2
- chore: update npm dependencies fix: use the LOCALAPPDATA env var to check for global execution
- chore: bump to 3.2.0-3
- chore: revert part of 6029930910fb696a420024cd5b6f2873e58ea8de
- chore: bump to 3.2.0-4
- feat: add node tooling version to UI packages
- fix: downgrade global-dirs to 3.0.0
- chore: bump to 3.2.0
- feat(pipelines): refactor pr and ci pipelines - migration pr and ci pipelines inline powershell to cmf-pipeline commands - refactor re-used steps into templates - change behaviour to support multiple packages in one single pipeline run   - this will reduce the AzureDevOps build agents usage
- chore: bump to 3.3.0-0
