### PR TITLE
3.3.0

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -68,4 +68,4 @@ jobs:
         uses: alirezanet/publish-nuget@v3.0.4
         with:
           PROJECT_FILE_PATH: core/core.csproj
-          NUGET_KEY: ${{secrets.NUGET_KEY}}
+          NUGET_KEY: ${{secrets.NUGET_API_KEY}}

--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,5 @@ launchSettings.json
 .history/**
 
 report/
+
+npm/*.tgz

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [3.3.0](https://github.com/criticalmanufacturing/cli/compare/3.3.0-1...3.3.0) (2022-12-14)
+
+## [3.3.0-1](https://github.com/criticalmanufacturing/cli/compare/3.3.0-0...3.3.0-1) (2022-12-06)
+
+## [3.3.0-0](https://github.com/criticalmanufacturing/cli/compare/3.2.0...3.3.0-0) (2022-12-05)
+
+
+### Features
+
+* **pipelines:** refactor pr and ci pipelines ([5b2c61c](https://github.com/criticalmanufacturing/cli/commits/5b2c61c15911cb191f258d7257241ab1ac117858))
+
+
+### Bug Fixes
+
+* **build help:** make legacy package check more permissive to style ([3d97c7f](https://github.com/criticalmanufacturing/cli/commits/3d97c7f7899efbeca25f3127992fcbd1b6ebfcdb))
+
 ## [3.2.0](https://github.com/criticalmanufacturing/cli/compare/3.2.0-5...3.2.0) (2022-11-29)
 
 ## [3.2.0-5](https://github.com/criticalmanufacturing/cli/compare/3.2.0-4...3.2.0-5) (2022-11-28)

--- a/cmf-cli/Commands/build/GenerateBasedOnTemplatesCommand.cs
+++ b/cmf-cli/Commands/build/GenerateBasedOnTemplatesCommand.cs
@@ -35,7 +35,7 @@ namespace Cmf.CLI.Commands
         /// </summary>
         public void Execute()
         {
-            var regex = new Regex("\"id\":\\s+\"(.*)\""); // match for menu item IDs
+            var regex = new Regex("\"?id\"?:\\s+[\"'](.*)[\"']"); // match for menu item IDs
             
             var helpRoot = FileSystemUtilities.GetPackageRootByType(Environment.CurrentDirectory, PackageType.Help, this.fileSystem).FullName;
             var project = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("Tenant").GetString();

--- a/cmf-cli/Commands/build/GenerateMenuItemsCommand.cs
+++ b/cmf-cli/Commands/build/GenerateMenuItemsCommand.cs
@@ -59,7 +59,7 @@ namespace Cmf.CLI.Commands
                 throw new CliException("Can't find Help package root, please run this command inside a Help package");
             }
 
-            var regex = new Regex("\"id\":\\s+\"(.*)\""); // match for menu item IDs
+            var regex = new Regex("\"?id\"?:\\s+[\"'](.*)[\"']"); // match for menu item IDs
 
             var packagesDir = this.fileSystem.DirectoryInfo.FromDirectoryName(this.fileSystem.Path.Join(helpRoot, "src", "packages"));
             var helpPackages = packagesDir.GetDirectories("cmf.docs.area.*");

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.3.0-0</Version>
+    <Version>3.3.0-1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.2.0</Version>
+    <Version>3.3.0-0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -79,6 +79,9 @@
     <None Include="resources\template_feed\database\**\*.sqlproj">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="resources\template_feed\**\.tasks\**">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -15,7 +15,7 @@
     <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
     <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
     <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>3.3.0-1</Version>
+    <Version>3.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/cmf-cli/resources/template_feed/init/Builds/.tasks/clean-agent-directories.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/.tasks/clean-agent-directories.yml
@@ -1,0 +1,16 @@
+steps:
+- pwsh: Remove-Item $(Build.SourcesDirectory)\* -Recurse -Force -Verbose
+  displayName: Clean Sources Directory
+  condition: always()
+
+- pwsh: Remove-Item $(Build.ArtifactStagingDirectory)\* -Recurse -Force -Verbose
+  displayName: Clean Artifact Staging Directory
+  condition: always()
+
+- pwsh: Remove-Item $(Build.BinariesDirectory)\* -Recurse -Force -Verbose
+  displayName: Clean Binaries Directory
+  condition: always()
+
+- pwsh: Remove-Item $(Common.TestResultsDirectory)\* -Recurse -Force -Verbose
+  displayName: Clean Test Results Directory
+  condition: always()

--- a/cmf-cli/resources/template_feed/init/Builds/.tasks/install-cli.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/.tasks/install-cli.yml
@@ -1,0 +1,4 @@
+steps:
+- pwsh: npm install --no-save @criticalmanufacturing/cli@$(CmfCliVersion) --registry $(CmfCliRepository)
+  displayName: Install cmf-cli@$(CmfCliVersion)
+  workingDirectory: $(Agent.TempDirectory)

--- a/cmf-cli/resources/template_feed/init/Builds/.tasks/install-cmf-pipeline.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/.tasks/install-cmf-pipeline.yml
@@ -1,0 +1,4 @@
+steps:
+- pwsh: npm install --no-save @criticalmanufacturing/cmf-pipeline@$(CmfPipelineVersion) --registry $(CmfPipelineRepository)
+  displayName: Install cmf-pipeline@$(CmfPipelineVersion)
+  workingDirectory: $(Agent.TempDirectory)

--- a/cmf-cli/resources/template_feed/init/Builds/.tasks/use-dotnet-version.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/.tasks/use-dotnet-version.yml
@@ -1,0 +1,20 @@
+steps:
+- task: UseDotNet@2
+  displayName: Use .NET Core specific version
+  inputs:
+    packageType: sdk
+    useGlobalJson: true
+
+//#if (nugetRegistryUsername != "" && nugetRegistryPassword != "") {
+- task: NuGetCommand@2
+  displayName: "Remove CMF NuGet source"
+  inputs:
+    command: 'custom'
+    arguments: 'sources remove -Name "CMF" -Config NuGet.Config'
+
+- task: NuGetCommand@2
+  displayName: "Add authenticated CMF NuGet source"
+  inputs:
+    command: 'custom'
+    arguments: 'sources Add -Name "CMF" -Source "<%= $CLI_PARAM_NuGetRegistry %>" -Username $(NuGetRegistryUsername) -password $(NuGetRegistryPassword) -StorePasswordInClearText -Config NuGet.Config'
+  //#endif

--- a/cmf-cli/resources/template_feed/init/Builds/.tasks/use-node-version.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/.tasks/use-node-version.yml
@@ -1,0 +1,5 @@
+steps:
+- task: NodeTool@0
+  displayName: Use Node $(NodeVersion)
+  inputs:
+    versionSpec: $(NodeVersion)

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Changes.yml
@@ -1,4 +1,7 @@
-# Changed Package detection pipeline
+# Critical Manufacturing Framework Continuous Integration Package detection pipeline
+# dependsOn:
+#             - cmf pipeline
+
 pool:
   name: <%= $CLI_PARAM_AgentPool %>
 //#if (agentType == "Cloud")
@@ -15,116 +18,28 @@ trigger:
 pr: none
 
 variables:
-- name: groupName
-  value: 'BuiltHEADs'
-- name: CIPipeline
-  value: 'CI-Package'
+- template: ../EnvironmentConfigs/GlobalVariables.yml  # Template reference to global variables
+- name: GroupName
+  value: BuiltHEADs
+- name: Pipeline
+  value: <%= $CLI_PARAM_PipelinesFolder %>\CI-Builds\CI-Package
 
+workspace:
+  clean: all
+
+name: $(Build.SourceBranchName)_$(Build.DefinitionName).$(Build.BuildId)
 steps:
-- task: PowerShell@2
-  displayName: "Find changes and trigger package builds"
-  inputs:
-    targetType: 'inline'
-    script: |
-      $packages = Get-ChildItem -Path .\ -Filter cmfpackage.json -Recurse -File | % {	
-          $pkgJson = Get-Content $_ | ConvertFrom-Json
-          @{
-              id = $pkgJson.packageId
-              version = $pkgJson.version
-              path = $_.DirectoryName
-              HEAD = $(git log -n 1 --pretty=format:%H $_.DirectoryName)
-              key = "$($pkgJson.packageId)@$(Build.SourceBranchName)"
-          }
-      }
-      $packages | % { Write-Host "Found package $($_.id)@$($_.version) at $($_.path) with current HEAD $($_.HEAD)" }
-      $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/distributedtask/variablegroups/{GROUP}?api-version=5.0-preview.1"
-      $headers = @{
-        Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"
-      }
-      
-      $vars = Invoke-RestMethod -Uri $url.Replace("{GROUP}", "") -Method Get -ContentType "application/json" -Headers $headers
-      $groupName = '${{ variables.groupName }}'
-      $createGroup = $false;
+- checkout: self
+  persistCredentials: true
 
-      $group = $vars.value | where { $_.Name -eq $groupName }
-      if ($null -eq $group) {
-        Write-Host "Variable group ${groupName} does not exist in project $(System.TeamProject). This will trigger CI for all found packages.";
-        $group = @{
-            type = "Vsts"
-            name= $groupName
-            variables = New-Object PSObject
-        }
-        $createGroup = $true
-      } 
-      
-      $changes = {@()}.Invoke()
-      $packages | % {
-        $key = $_.key
-        if ([bool]($group.variables.PSobject.Properties.name -match "^$key$")) {
-            $builtHEAD = $group.variables.$key.value
-            if ($builtHEAD -eq $_.HEAD) {
-                Write-Host "Current HEAD matches last built: $builtHEAD"
-            } else {
-                Write-Host "Last built HEAD for ${key} was $builtHEAD and HEAD is now $($_.HEAD). Triggering CI Pipeline for ${key}..."
-                $changes.Add($_)
-            }
-        } else {
-            Write-Host "No last built HEAD found for ${key}. Setting it to $($_.HEAD) and triggering CI Pipeline..."
-            $changes.Add($_)
-            # initialize (keep this commented in production)
-            # $group.variables | add-member -name $key -value @{value=$_.HEAD} -MemberType NoteProperty
-        }
-      }
+# install cmf-pipeline
+- template: .tasks/install-cmf-pipeline.yml
 
-      # initialize (keep this commented in production)
-      # $json = $group | ConvertTo-Json
-      # $pipeline = Invoke-RestMethod -Uri $url.Replace("{GROUP}", "") -Method Post -Body $json -ContentType "application/json" -Headers $headers
-
-      # get pipeline
-      $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
-      $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.CIPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "<%= $CLI_PARAM_PipelinesFolder %>\CI-Builds" }
-
-      if ($def -eq $null) {
-          Write-Host "Build definition '${{ variables.CIPipeline }}' not found in project $(System.TeamProject)"
-      } else {
-        $triggeredBuildIds = {@()}.Invoke()
-        $changes | % {
-          $relPath = [IO.Path]::GetRelativePath("$(Build.SourcesDirectory)", $_.path)
-          $params = @{
-            "system.debug" = @{ value = "$true" }
-          }
-          $body = @{
-            resources = @{
-              repositories = @{
-                self = @{
-                  refName = "$(Build.SourceBranch)"
-                }
-              }
-            }
-            templateParameters = @{
-              PackagePath = $relPath
-              PackageId = $_.id
-            }
-            variables = $params
-          }
-
-          $bodyString = $body | ConvertTo-Json -Depth 10
-          Write-Debug $bodyString
-          Write-Host "Queueing build for pipeline '${{ variables.CIPipeline }}' for package '$($_.id)' at '$relPath'"
-          $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/pipelines/$($def.id)/runs?api-version=5.1-preview.1"
-          $buildresponse = Invoke-RestMethod -Method Post -ContentType "application/json" -Uri $url -Body $bodyString -Headers $headers
-          # write-host $buildresponse
-          $triggeredBuildIds.Add($buildresponse.id)
-        }
-        Write-Host "##vso[task.setvariable variable=TriggeredBuildIds]$($triggeredBuildIds -join(","))"
-      }
-    pwsh: true
+# find changes and trigger pr-package build
+- pwsh: $(CmfPipelinePath)/cmf-pipeline repo findChangedPackages --targetType AzureDevOpsVariableGroup --target $(GroupName) --triggerAzureDevOpsPipeline $(Pipeline)
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: $(System.TeamFoundationCollectionUri)
-    SYSTEM_TEAMPROJECTID: $(System.TeamProject)
-- task: PostBuildCleanup@3
-  displayName: 'Clean Agent Directories'
-  condition: always()
+  displayName: Find changed packages and trigger $(Pipeline)
 
+# Clean Agent Directories
+- template: .tasks/clean-agent-directories.yml

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
@@ -25,11 +25,10 @@ variables:
    value: BuiltHEADs
  - name: packOutputDir
 //#if (agentType == "Cloud")
- value: $(Build.ArtifactStagingDirectory)
+  value: $(Build.ArtifactStagingDirectory)
 //#else
   value: $(CIPackages)/$(Build.SourceBranchName)
 //#endif
-
 
 workspace:
   clean: all

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
@@ -1,4 +1,8 @@
-# CM PI Continuous Integration Package Pipeline
+# Critical Manufacturing Framework Continuous Integration Package Pipeline
+# dependsOn:
+#             - cmf cli
+#             - cmf pipeline
+
 pool:
   name: <%= $CLI_PARAM_AgentPool %>
 //#if (agentType == "Cloud")
@@ -12,99 +16,56 @@ trigger: none
 pr: none
 
 parameters:
-- name: PackageId
-  displayName: Package
-  type: string
-- name: PackagePath
-  displayName: Package Path
-  type: string
+- name: packages
+  type: object
 
 variables:
  - template: ../EnvironmentConfigs/GlobalVariables.yml  # Template reference to global variables
- - name: groupName
-   value: 'BuiltHEADs'
+ - name: GroupName
+   value: BuiltHEADs
+ - name: packOutputDir
+//#if (agentType == "Cloud")
+ value: $(Build.ArtifactStagingDirectory)
+//#else
+  value: $(CIPackages)/$(Build.SourceBranchName)
+//#endif
+
 
 workspace:
-    clean: all
+  clean: all
 
-name: $(Build.SourceBranchName)_$(Build.DefinitionName)_${{ parameters.PackageId }}.$(Build.BuildId)
+name: $(Build.SourceBranchName)_$(Build.DefinitionName).$(Build.BuildId)
 steps:
 - checkout: self
-  persistCredentials: true
 
-# use Node Tool
-- task: NodeTool@0
-  displayName: 'Use Node ${{ variables.NodeVersion }}'
-  inputs:
-    versionSpec: ${{ variables.NodeVersion }}
+# set node version
+- template: .tasks/use-node-version.yml
 
-- task: UseDotNet@2
-  displayName: 'Use Repository specified .NET Core version'
-  inputs:
-    packageType: 'sdk'
-    useGlobalJson: true
+# set dotnet version
+- template: .tasks/use-dotnet-version.yml
 
-//#if (nugetRegistryUsername != "" && nugetRegistryPassword != "") {
-- task: NuGetCommand@2
-  displayName: "Remove CMF NuGet source"
-  inputs:
-    command: 'custom'
-    arguments: 'sources remove -Name "CMF" -Config NuGet.Config'
+# install cmf-cli
+- template: .tasks/install-cli.yml
 
-- task: NuGetCommand@2
-  displayName: "Add authenticated CMF NuGet source"
-  inputs:
-    command: 'custom'
-    arguments: 'sources Add -Name "CMF" -Source "<%= $CLI_PARAM_NuGetRegistry %>" -Username $(NuGetRegistryUsername) -password $(NuGetRegistryPassword) -StorePasswordInClearText -Config NuGet.Config'
-//#endif
+# install cmf-pipeline
+- template: .tasks/install-cmf-pipeline.yml
 
-# Install cmf-cli
-- task: PowerShell@2
-  displayName: 'Install cmf-cli@${{ variables.CmfCliVersion }}'
-  inputs:
-    pwsh: true
-    failOnStderr: false
-    workingDirectory: $(Agent.TempDirectory)
-    targetType: inline
-    script: |
-      npm install --no-save @criticalmanufacturing/cli@${{ variables.CmfCliVersion }} --registry ${{ variables.CmfCliRepository }}
+- ${{ each package in parameters.packages }}:
+  # cmf build
+  - pwsh: $(CmfCliPath)/cmf build
+    workingDirectory: ${{ package.path }}
+    displayName: Build ${{ package.packageId }} @ ${{ package.path }}
 
-# Cmf Build
-- task: PowerShell@2
-  displayName: 'Build ${{ parameters.PackageId }}'
-  env:
-    cmf_cli_enable_telemetry: true
-    cmf_cli_enable_extended_telemetry: true
-  inputs:
-    pwsh: true
-    failOnStderr: true
-    workingDirectory: ${{ parameters.PackagePath }}
-    targetType: inline
-    script: |
-//#if (agentType == "Cloud")
-      $(Agent.TempDirectory)/../node_modules/.bin/cmf-cli/cmf build
-//#else
-      $(Agent.TempDirectory)/node_modules/.bin/cmf-cli/cmf build
-//#endif
+  # cmf pack
+  - pwsh: $(CmfCliPath)/cmf pack --force --outputDir $(packOutputDir)
+    workingDirectory: ${{ package.path }}
+    displayName: Pack ${{ package.packageId }} @ ${{ package.path }}
 
-
-# Cmf Pack
-- task: PowerShell@2
-  displayName: 'Pack ${{ parameters.PackageId }}'
-  env:
-    cmf_cli_enable_telemetry: true
-    cmf_cli_enable_extended_telemetry: true
-  inputs:
-    pwsh: true
-    failOnStderr: true
-    workingDirectory: ${{ parameters.PackagePath }}
-    targetType: inline
-    script: |
-//#if (agentType == "Cloud")
-      $(Agent.TempDirectory)/../node_modules/.bin/cmf-cli/cmf pack --outputDir $(Build.ArtifactStagingDirectory)
-//#else
-      $(Agent.TempDirectory)/node_modules/.bin/cmf-cli/cmf pack --force --outputDir '${{ variables.CIPackages }}/$(Build.SourceBranchName)'
-//#endif
+  # set new built HEAD
+  - pwsh: $(CmfPipelinePath)/cmf-pipeline azureDevOps variableGroup updateVariable --group $(GroupName) --key ${{ package.packageId }}@$(Build.SourceBranchName) --value ${{ package.head }}
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+    displayName: Set variable ${{ package.packageId }}@$(Build.SourceBranchName):${{ package.head }} @ $(GroupName)
 
 //#if (agentType == "Cloud")
 # Publish Package Artifact
@@ -115,70 +76,5 @@ steps:
     publishLocation: 'Container'
 //#endif
 
-# set new built HEAD
-- task: PowerShell@2
-  displayName: 'Set Built HEAD'
-  inputs:
-    pwsh: true
-    failOnStderr: true
-    workingDirectory: ${{ parameters.PackagePath }}
-    targetType: inline
-    script: |
-      $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/distributedtask/variablegroups/{GROUP}?api-version=5.0-preview.1"
-      $headers = @{
-        Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"
-      }
-
-      $vars = Invoke-RestMethod -Uri $url.Replace("{GROUP}", "") -Method Get -ContentType "application/json" -Headers $headers
-      $groupName = '${{ variables.groupName }}'
-      $createGroup = $false;
-
-      $group = $vars.value | where { $_.Name -eq $groupName }
-      if ($null -eq $group) {
-        Write-Host "Variable group ${groupName} does not exist in project $(System.TeamProject). This will trigger CI for all found packages.";
-        $group = @{
-            type = "Vsts"
-            name= $groupName
-            variables = New-Object PSObject
-        }
-        $createGroup = $true
-      }
-
-      $HEAD = $(git log -n 1 --pretty=format:%H .)
-      $pkgId = "${{ parameters.PackageId }}"
-      $branch = "$(Build.SourceBranchName)"
-      $key = "${pkgId}@${branch}"
-
-      Write-Debug "Key: $key"
-
-      if ([bool]($group.variables.PSobject.Properties.name -match "^$key$")) { 
-        $builtHEAD = $group.variables.$key.value
-        if ($builtHEAD -eq $HEAD) {
-          Write-Host "Current HEAD matches last built: $builtHEAD"
-        } else {
-          Write-Host "Last built HEAD for ${key} was $builtHEAD. Setting to $HEAD"
-          $group.variables.$key.value = $HEAD
-        }
-      } else {
-        Write-Host "No last built HEAD found for ${key}. Setting it to $HEAD"
-        $group.variables | add-member -name $key -value @{value=$HEAD} -MemberType NoteProperty
-      }
-
-      $json = $group | ConvertTo-Json
-      Write-Debug $json
-
-      if ($createGroup) {
-        $pipeline = Invoke-RestMethod -Uri $url.Replace("{GROUP}", "") -Method Post -Body $json -ContentType "application/json" -Headers $headers
-      } else {
-        $pipeline = Invoke-RestMethod -Uri $url.Replace("{GROUP}", $group.id) -Method Put -Body $json -ContentType "application/json" -Headers $headers
-      }
-  name: SetBuiltHead
-  env:
-    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: $(System.TeamFoundationCollectionUri)
-    SYSTEM_TEAMPROJECTID: $(System.TeamProject)
-
-# Clean up
-- task: PostBuildCleanup@3
-  displayName: 'Clean Agent Directories'
-  condition: always()
+# Clean Agent Directories
+- template: .tasks/clean-agent-directories.yml

--- a/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/CI-Package.yml
@@ -25,9 +25,9 @@ variables:
    value: BuiltHEADs
  - name: packOutputDir
 //#if (agentType == "Cloud")
-  value: $(Build.ArtifactStagingDirectory)
+   value: $(Build.ArtifactStagingDirectory)
 //#else
-  value: $(CIPackages)/$(Build.SourceBranchName)
+   value: $(CIPackages)/$(Build.SourceBranchName)
 //#endif
 
 workspace:

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
@@ -17,7 +17,7 @@ pr: none
 variables:
 - template: ../EnvironmentConfigs/GlobalVariables.yml  # Template reference to global variables
 - name: Pipeline
-  value: \<%= $CLI_PARAM_PipelinesFolder %>\PR-Builds\PR-Package
+  value: <%= $CLI_PARAM_PipelinesFolder %>\PR-Builds\PR-Package
 
 workspace:
   clean: all

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Changes.yml
@@ -1,113 +1,52 @@
-# Changed Package detection pipeline
+# Critical Manufacturing Framework Pull Request Package detection pipeline
+# dependsOn:
+#             - cmf pipeline
+
 pool:
   name: <%= $CLI_PARAM_AgentPool %>
 //#if (agentType == "Cloud")
   vmImage: 'ubuntu-latest'
 //#endif
 
-# Trigger on any change in the included branches
+# A pipeline with no CI trigger
 trigger: none
 
 # A pipeline with no PR trigger
 pr: none
 
 variables:
-- name: PRPipeline
-  value: 'PR-Package'
+- template: ../EnvironmentConfigs/GlobalVariables.yml  # Template reference to global variables
+- name: Pipeline
+  value: \<%= $CLI_PARAM_PipelinesFolder %>\PR-Builds\PR-Package
 
+workspace:
+  clean: all
+
+name: $(Build.SourceBranchName)_$(Build.DefinitionName).$(Build.BuildId)
 steps:
 - checkout: self
   persistCredentials: true
-- task: PowerShell@2
-  displayName: "Find changes and trigger package builds"
-  inputs:
-    targetType: 'inline'
-    script: |
-      $headers = @{
-        Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN"
-      }
-      git fetch --all
-      $targetBranchName = $("$(System.PullRequest.TargetBranch)" -split "/")[-1]
-      $packages = Get-ChildItem -Path .\ -Filter cmfpackage.json -Recurse -File | % {	
-          $pkgJson = Get-Content $_ | ConvertFrom-Json
-          @{
-              id = $pkgJson.packageId
-              version = $pkgJson.version
-              path = $_.DirectoryName
-              NEW_HEAD = $(git log -n 1 --pretty=format:%H $_.DirectoryName)
-              OLD_HEAD = $(git log -n 1 --pretty=format:%H remotes/origin/$targetBranchName -- $_.DirectoryName)
-          }
-      }
-      $packages | % { Write-Host "Found package $($_.id)@$($_.version) at $($_.path) with current HEADs $($_.OLD_HEAD)..$($_.NEW_HEAD)" }
 
-      $changes = {@()}.Invoke()
-      $packages | % {
-        if ($_.NEW_HEAD -eq $_.OLD_HEAD) {
-            Write-Host "Package $($_.id)@$($_.version) wasn't changed: $($_.NEW_HEAD)"
-        } else {
-            Write-Host "Package $($_.id)@$($_.version) was changed: HEAD was $($_.OLD_HEAD) and HEAD is now $($_.NEW_HEAD). Triggering PR Pipeline..."
-            $changes.Add($_)
-        }
-      }
+# install cmf-pipeline
+- template: .tasks/install-cmf-pipeline.yml
 
-      # get pipeline
-      $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/build/definitions?api-version=4.1"
-      $defs = Invoke-RestMethod -Uri $url -Method Get -ContentType "application/json" -Headers $headers
-      $def = $defs.value | where { $_.name -eq '${{ variables.PRPipeline }}' -and $_.queueStatus -eq "enabled" -and $_.path -eq "<%= $CLI_PARAM_PipelinesFolder %>\PR-Builds" }
-
-      if ($def -eq $null) {
-          Write-Host "Build definition '${{ variables.PRPipeline }}' not found in project $(System.TeamProject)"
-      } else {
-        $triggeredBuildIds = {@()}.Invoke()
-        $changes | % {
-          $relPath = [IO.Path]::GetRelativePath("$(Build.SourcesDirectory)", $_.path)
-          $params = @{
-            "system.debug" = @{ value = "$true" }
-          }
-          $body = @{
-            resources = @{
-              repositories = @{
-                self = @{
-                  refName = "$(Build.SourceBranch)"
-                }
-              }
-            }
-            templateParameters = @{
-              PackagePath = $relPath
-              PackageId = $_.id
-            }
-            variables = $params
-          }
-
-          $bodyString = $body | ConvertTo-Json -Depth 10
-          Write-Debug $bodyString
-          Write-Host "Queueing build for pipeline '${{ variables.PRPipeline }}' for package '$($_.id)' at '$relPath'"
-          $url = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$env:SYSTEM_TEAMPROJECTID/_apis/pipelines/$($def.id)/runs?api-version=5.1-preview.1"
-          $buildresponse = Invoke-RestMethod -Method Post -ContentType "application/json" -Uri $url -Body $bodyString -Headers $headers
-          $triggeredBuildIds.Add($buildresponse.id)
-        }
-        Write-Host "##vso[task.setvariable variable=TriggeredBuildIds]$($triggeredBuildIds -join(","))"
-      }
-    pwsh: true
+# find changes and trigger pr-package build
+- pwsh: |
+    $targetBranchName = $("$(System.PullRequest.TargetBranch)" -split "/")[-1]
+    $(CmfPipelinePath)/cmf-pipeline repo findChangedPackages --targetType Git --target remotes/origin/$targetBranchName --triggerAzureDevOpsPipeline $(Pipeline)
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-    SYSTEM_TEAMFOUNDATIONCOLLECTIONURI: $(System.TeamFoundationCollectionUri)
-    SYSTEM_TEAMPROJECTID: $(System.TeamProject)
+    CMF_PIPELINE_WAIT_FOR_BUILD_FINISH: true
+    CMF_PIPELINE_WAIT_FOR_BUILD_FINISH_REFRESH_TIME: 30
+  displayName: Find changed packages and trigger $(Pipeline)
+  name: FindChangedPackages
 
-- task: WaitForBuildToFinish@2
-  inputs:
-    definitionIsInCurrentTeamProject: true
-    ignoreSslCertificateErrors: false
-    waitForQueuedBuildsToFinishRefreshTime: '60'
-    failTaskIfBuildsNotSuccessful: true
-    cancelBuildsIfAnyFails: false
-    treatPartiallySucceededBuildAsSuccessful: false
-    downloadBuildArtifacts: false
-    clearVariable: true
-    authenticationMethod: 'Personal Access Token'
-    password: $(System.AccessToken)
+# cancel triggered pipeline if canceled
+- pwsh: $(CmfPipelinePath)/cmf-pipeline azureDevOps pipeline cancel --pipeline $(Pipeline) --pipelineRunId $(FindChangedPackages.Cmf.Pipeline.Triggered.Build.Id)
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-- task: PostBuildCleanup@3
-  displayName: 'Clean Agent Directories'
-  condition: always()
+  displayName: Cancel $(Pipeline) if $(Build.DefinitionName) is cancelled
+  condition: canceled()
+
+# Clean Agent Directories
+- template: .tasks/clean-agent-directories.yml

--- a/cmf-cli/resources/template_feed/init/Builds/PR-Package.yml
+++ b/cmf-cli/resources/template_feed/init/Builds/PR-Package.yml
@@ -1,4 +1,8 @@
-# CM PI Continuous Integration Package Pipeline
+# Critical Manufacturing Framework Pull Request Package Pipeline
+# dependsOn:
+#             - cmf pipeline
+#             - cmf cli
+
 pool:
   name: <%= $CLI_PARAM_AgentPool %>
 //#if (agentType == "Cloud")
@@ -12,95 +16,42 @@ trigger: none
 pr: none
 
 parameters:
-- name: PackageId
-  displayName: Package
-  type: string
-- name: PackagePath
-  displayName: Package Path
-  type: string
+- name: packages
+  type: object
 
 variables:
  - template: ../EnvironmentConfigs/GlobalVariables.yml  # Template reference to global variables
 
 workspace:
-    clean: all
+  clean: all
 
-name: $(Build.SourceBranchName)_$(Build.DefinitionName)_${{ parameters.PackageId }}.$(Build.BuildId)
+name: $(Build.SourceBranchName)_$(Build.DefinitionName).$(Build.BuildId)
 steps:
 - checkout: self
-  persistCredentials: true
 
-# validate if the package version was already released
-- task: PowerShell@2
-  displayName: 'Validate Package Version'
-  inputs:
-    pwsh: true
-    failOnStderr: true
-    workingDirectory: ${{ parameters.PackagePath }}
-    targetType: inline
-    script: |
-      $CmfPackageJsonFile = Get-Item ".\cmfpackage.json"
-      $CmfPackageJson = Get-Content -Raw -Path $CmfPackageJsonFile | ConvertFrom-Json
-      $PackageName = ($CmfPackageJson.'packageId') + "." + ($CmfPackageJson.'version')
+# install cmf-pipeline
+- template: .tasks/install-cmf-pipeline.yml
 
-      # Validate if the package version was already released
-      $finalPackageFile = "${{ variables.ApprovedPackages }}/" + $PackageName + ".zip"
-      if(Test-Path $finalPackageFile) {
-          throw "Package " + $PackageName + " already released"
-      }
+- ${{ each package in parameters.packages }}:
+  # package existsInRepos
+  - pwsh: $(CmfPipelinePath)/cmf-pipeline package existsInRepos --repo $(ApprovedPackages)
+    displayName: Check if ${{ package.packageId }}@${{ package.version }} was not released
+    workingDirectory: ${{ package.path }}
 
-//#if (nugetRegistryUsername != "" && nugetRegistryPassword != "") {
-- task: NuGetCommand@2
-  displayName: "Remove CMF NuGet source"
-  inputs:
-    command: 'custom'
-    arguments: 'sources remove -Name "CMF" -Config NuGet.Config'
+# set node version
+- template: .tasks/use-node-version.yml
 
-- task: NuGetCommand@2
-  displayName: "Add authenticated CMF NuGet source"
-  inputs:
-    command: 'custom'
-    arguments: 'sources Add -Name "CMF" -Source "<%= $CLI_PARAM_NuGetRegistry %>" -Username $(NuGetRegistryUsername) -password $(NuGetRegistryPassword) -StorePasswordInClearText -Config NuGet.Config'
-//#endif
+# set dotnet version
+- template: .tasks/use-dotnet-version.yml
 
-# use Node Tool
-- task: NodeTool@0
-  displayName: 'Use Node ${{ variables.NodeVersion }}'
-  inputs:
-    versionSpec: ${{ variables.NodeVersion }}
+# install cmf-cli
+- template: .tasks/install-cli.yml
 
-- task: UseDotNet@2
-  inputs:
-    packageType: 'sdk'
-    useGlobalJson: true
+- ${{ each package in parameters.packages }}:
+  # cmf build
+  - pwsh: $(CmfCliPath)/cmf build
+    displayName: Build ${{ package.packageId }} @ ${{ package.path }}
+    workingDirectory: ${{ package.path }}
 
-# Install cmf-cli
-- task: PowerShell@2
-  displayName: 'Install cmf-cli@${{ variables.CmfCliVersion }}'
-  inputs:
-    pwsh: true
-    failOnStderr: false
-    targetType: inline
-    workingDirectory: $(Agent.TempDirectory)
-    script: |
-      npm install --no-save @criticalmanufacturing/cli@${{ variables.CmfCliVersion }} --registry ${{ variables.CmfCliRepository }}
-
-# Cmf Build
-- task: PowerShell@2
-  displayName: Build ${{ parameters.PackageId }}
-  inputs:
-    pwsh: true
-    failOnStderr: true
-    workingDirectory: ${{ parameters.PackagePath }}
-    targetType: inline
-    script: |
-//#if (agentType == "Cloud")
-      $(Agent.TempDirectory)/../node_modules/.bin/cmf-cli/cmf build --test
-//#else
-      $(Agent.TempDirectory)/node_modules/.bin/cmf-cli/cmf build --test
-//#endif
-
-# Cleanup
-- task: PostBuildCleanup@3
-  displayName: 'Clean Agent Directories'
-  condition: always()
+# Clean Agent Directories
+- template: .tasks/clean-agent-directories.yml

--- a/cmf-cli/resources/template_feed/init/EnvironmentConfigs/GlobalVariables.yml
+++ b/cmf-cli/resources/template_feed/init/EnvironmentConfigs/GlobalVariables.yml
@@ -9,10 +9,22 @@ variables:
   CmfCliRepository: '<%= $CLI_PARAM_CmfCliRepository %>'
   # cmf cli Version
   CmfCliVersion: '3.x.x'
+  # cmf cli Path
+//#if (agentType == "Cloud")
+  CmfCliPath: '$(Agent.TempDirectory)/../node_modules/.bin/cmf-cli'
+//#else
+  CmfCliPath: '$(Agent.TempDirectory)/node_modules/.bin/cmf-cli'
+//#endif
   # cmf pipeline Repository
   CmfPipelineRepository: '<%= $CLI_PARAM_CmfPipelineRepository %>'
   # cmf pipeline Version
   CmfPipelineVersion: '1.x.x'
+  # cmf pipeline Path
+//#if (agentType == "Cloud")
+  CmfPipelinePath: '$(Agent.TempDirectory)/../node_modules/@criticalmanufacturing/cmf-pipeline/dist/win-x64'
+//#else
+  CmfPipelinePath: '$(Agent.TempDirectory)/node_modules/@criticalmanufacturing/cmf-pipeline/dist/win-x64'
+//#endif
   # Iso Image Path
   ISOImagePath: '<%= $CLI_PARAM_ISOLocation %>'
   # Current refspec to get the tools for the package (by default, a tagged MES version release)

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.3.0-1</Version>
+        <Version>3.3.0</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.3.0-0</Version>
+        <Version>3.3.0-1</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -4,7 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <PackageId>CriticalManufacturing.CLI.Core</PackageId>
         <RootNamespace>Cmf.CLI.Core</RootNamespace>
-        <Version>3.2.0</Version>
+        <Version>3.3.0-0</Version>
         <Authors>CriticalManufacturing</Authors>
         <Company>CriticalManufacturing</Company>
         <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.3.0-0",
+  "version": "3.3.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.2.0",
+  "version": "3.3.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.3.0-1",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.2.0",
+  "version": "3.3.0-0",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.3.0-0",
+  "version": "3.3.0-1",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@criticalmanufacturing/cli",
-  "version": "3.3.0-1",
+  "version": "3.3.0",
   "description": "Critical Manufacturing command line client",
   "bin": {
     "cmf": "./run.js"


### PR DESCRIPTION
- migration pr and ci pipelines inline powershell to cmf-pipeline commands
- refactor re-used steps into templates
- change behaviour to support multiple packages in one single pipeline run
  - this will reduce the AzureDevOps build agents usage