### PR TITLE
Add DependenciesDirectory property to cmfpackage.json

### DIFF
--- a/cmf-cli/Factories/PackageTypeFactory.cs
+++ b/cmf-cli/Factories/PackageTypeFactory.cs
@@ -1,12 +1,13 @@
 ﻿
 using System;
 using System.IO;
-using System.IO.Abstractions;
+using Cmf.CLI.Core;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Handlers;
 using Cmf.CLI.Interfaces;
 using Cmf.CLI.Utilities;
+using System.IO.Abstractions;
 
 namespace Cmf.CLI.Factories
 {
@@ -65,7 +66,7 @@ namespace Cmf.CLI.Factories
                 PackageType.Database => new DatabasePackageTypeHandler(cmfPackage),
                 PackageType.Tests => new TestPackageTypeHandler(cmfPackage),
                 PackageType.SecurityPortal => new SecurityPortalPackageTypeHandler(cmfPackage),
-                _ => throw new NotImplementedException()
+                _ => throw new CliException(string.Format(CoreMessages.PackageTypeHandlerNotImplemented, cmfPackage.PackageType.ToString()))
             };
 
             return packageTypeHandler;

--- a/cmf-cli/Handlers/PackageType/GenericPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/GenericPackageTypeHandler.cs
@@ -23,7 +23,7 @@ namespace Cmf.CLI.Handlers
                 isInstallable: false
             );
 
-            BuildSteps = cmfPackage.BuildSteps.Select(pbs => new SingleStepCommand() { BuildStep = pbs} as IBuildCommand).ToArray();
+            BuildSteps = cmfPackage.BuildSteps?.Select(pbs => new SingleStepCommand() { BuildStep = pbs} as IBuildCommand).ToArray();
         }
     }
 }

--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -114,7 +114,8 @@ namespace Cmf.CLI.Handlers
                 ".gitignore",
                 ".gitkeep",
                 ".cmfpackageignore",
-                "cmfpackage.json"
+                "cmfpackage.json",
+                "manifest.xml"
             };
 
             BuildSteps = Array.Empty<IBuildCommand>();

--- a/core/CoreMessages.Designer.cs
+++ b/core/CoreMessages.Designer.cs
@@ -124,6 +124,15 @@ namespace Cmf.CLI.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Handler for Package Type {0} not implemented!.
+        /// </summary>
+        public static string PackageTypeHandlerNotImplemented {
+            get {
+                return ResourceManager.GetString("PackageTypeHandlerNotImplemented", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Urls not supported yet.
         /// </summary>
         public static string UrlsNotSupported {

--- a/core/CoreMessages.resx
+++ b/core/CoreMessages.resx
@@ -51,4 +51,8 @@
     <value>{0} not found!</value>
     <comment>0 - Name</comment>
   </data>
+  <data name="PackageTypeHandlerNotImplemented" xml:space="preserve">
+    <value>Handler for Package Type {0} not implemented!</value>
+    <comment>0 - Package Type Name</comment>
+  </data>
 </root>

--- a/core/Enums/PackageType.cs
+++ b/core/Enums/PackageType.cs
@@ -76,8 +76,13 @@
         Tests = 13,
 
         /// <summary>
-        /// The test
+        /// The Security Portal
         /// </summary>
-        SecurityPortal = 14
+        SecurityPortal = 14,
+
+        /// <summary>
+        /// The specific product database
+        /// </summary>
+        ProductDatabase = 15,
     }
 }

--- a/core/Enums/StepType.cs
+++ b/core/Enums/StepType.cs
@@ -63,6 +63,11 @@
         /// <summary>
         /// Update the ConnectIoT Repository Index
         /// </summary>
-        GenerateRepositoryIndex = 11
+        GenerateRepositoryIndex = 11,
+        
+        /// <summary>
+        /// Generate Service History Id
+        /// </summary>
+        GenerateServiceHistoryId = 12
     }
 }

--- a/core/Objects/CmfPackage.cs
+++ b/core/Objects/CmfPackage.cs
@@ -1,21 +1,18 @@
-﻿using System;
+﻿using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Utilities;
+using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Linq;
 using System.Xml.Linq;
-using Cmf.CLI.Core.Constants;
-using Cmf.CLI.Core.Enums;
-using Cmf.CLI;
-using Cmf.CLI.Utilities;
-using Microsoft.Extensions.DependencyInjection;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
-using Newtonsoft.Json.Linq;
-using Cmf.CLI.Core.Objects;
-using Cmf.CLI.Core.Utilities;
 
 namespace Cmf.CLI.Core.Objects
 {
@@ -279,9 +276,7 @@ namespace Cmf.CLI.Core.Objects
         /// The dependencies target directory.
         /// </value>
         [JsonProperty(Order = 23)]
-#nullable enable
-        public string? DependenciesDirectory { get; set; }
-#nullable disable
+        public string DependenciesDirectory { get; set; }
 
         #endregion Public Properties
 

--- a/core/Objects/CmfPackage.cs
+++ b/core/Objects/CmfPackage.cs
@@ -271,6 +271,18 @@ namespace Cmf.CLI.Core.Objects
         [JsonConverter(typeof(ListAbstractionsDirectoryConverter))]
         public List<IDirectoryInfo> BuildablePackages { get; set; }
 
+        /// <summary>
+        /// Gets or sets the target directory where the dependencies contents should be extracted.
+        /// This is used when the package dependencies are restored in the restore and build commands.
+        /// </summary>
+        /// <value>
+        /// The dependencies target directory.
+        /// </value>
+        [JsonProperty(Order = 23)]
+#nullable enable
+        public string? DependenciesDirectory { get; set; }
+#nullable disable
+
         #endregion Public Properties
 
         #region Private Methods
@@ -593,9 +605,9 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Shoulds the serialize d f package type.
+        /// Shoulds the serialize DF package type.
         /// </summary>
-        /// <returns>returns false if handler version is 0 otherwise true</returns>
+        /// <returns>returns false if DF Package Type is null and Package Type is different then Generic, otherwise true</returns>
         public bool ShouldSerializeDFPackageType()
         {
             return DFPackageType != null && PackageType == PackageType.Generic;
@@ -608,6 +620,15 @@ namespace Cmf.CLI.Core.Objects
         public bool ShouldSerializeBuildablePackages()
         {
             return BuildablePackages.HasAny();
+        }
+
+        /// <summary>
+        /// Should the Dependencies Directory be serialized
+        /// </summary>
+        /// <returns>returns false if Dependencies Directory is null or empty</returns>
+        public bool ShouldSerializeDependenciesDirectory()
+        {
+            return !string.IsNullOrWhiteSpace(DependenciesDirectory);
         }
 
         #region Static Methods

--- a/core/Objects/Step.cs
+++ b/core/Objects/Step.cs
@@ -136,6 +136,18 @@ namespace Cmf.CLI.Core.Objects
         [JsonProperty(Order = 1)]
         public int Order { get; set; }
 
+        /// <summary>
+        /// Whether it is to run script against master database
+        /// ProductDabatase Package Type specific
+        /// </summary>
+        public bool? RunInMaster { get; set; }
+
+        /// <summary>
+        /// Whether it is to run script against all product databases
+        /// ProductDabatase Package Type specific
+        /// </summary>
+        public bool? TargetAll { get; set; }
+
         #endregion
 
         #region Constructors

--- a/tests/Objects/MockPackage.cs
+++ b/tests/Objects/MockPackage.cs
@@ -37,7 +37,7 @@ namespace tests.Objects
                 }}
               ]
             }}")}});
-        
+
         internal static readonly MockFileSystem Html_OnlyLBOs = new MockFileSystem(new Dictionary<string, MockFileData>
         {
           { MockUnixSupport.Path(@"c:\Libs\LBOs\TypeScript\APIReference.js"), new MockFileData(@"dummy")},
@@ -79,7 +79,7 @@ namespace tests.Objects
                 }}
               ]
             }}")}});
-        
+
         internal static readonly MockFileSystem Html_MissingDeclaredContent = new MockFileSystem(new Dictionary<string, MockFileData>
         {
           { MockUnixSupport.Path(@"c:\ui\package.json"), new MockFileData(
@@ -107,7 +107,7 @@ namespace tests.Objects
            }}")
           }
         });
-        
+
         internal static readonly MockFileSystem Html_EmptyContentToPack = new MockFileSystem(new Dictionary<string, MockFileData>
         {
           { MockUnixSupport.Path(@"c:\ui\package.json"), new MockFileData(
@@ -128,7 +128,7 @@ namespace tests.Objects
            }}")
           }
         });
-        
+
         internal static readonly MockFileSystem Root_Empty = new MockFileSystem(new Dictionary<string, MockFileData>
         {
          { MockUnixSupport.Path(@"c:\repo\cmfpackage.json"), new MockFileData(
@@ -141,6 +141,26 @@ namespace tests.Objects
               ""isUniqueInstall"": false,
               ""dependencies"": [
                 {{ ""id"": ""Cmf.Environment"", ""version"": ""0.0.0"" }}
+              ]
+           }}")
+          }
+        });
+
+        internal static readonly MockFileSystem ProductDatabase_Empty = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+         { MockUnixSupport.Path(@"c:\repo\cmfpackage.json"), new MockFileData(
+            $@"{{
+              ""packageId"": ""Cmf.Custom.ProductDatabase"",
+              ""version"": ""1.1.0"",
+              ""description"": ""Cmf Custom ProductDatabase Package"",
+              ""packageType"": ""ProductDatabase"",
+              ""isInstallable"": true,
+              ""isUniqueInstall"": false,
+              ""contentToPack"": [
+                {{
+                  ""source"": ""{MockUnixSupport.Path("src\\packages\\*").Replace("\\", "\\\\")}"",
+                  ""target"": ""test""
+                }}
               ]
            }}")
           }

--- a/tests/Specs/PackageTypeHandler.cs
+++ b/tests/Specs/PackageTypeHandler.cs
@@ -1,12 +1,13 @@
-﻿using Xunit;
-using System;
-using System.IO;
-using System.IO.Abstractions.TestingHelpers;
-using Cmf.CLI.Constants;
+﻿using Cmf.CLI.Constants;
+using Cmf.CLI.Core;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Factories;
 using Cmf.CLI.Handlers;
+using System;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
 using tests.Objects;
+using Xunit;
 
 namespace tests.Specs
 {
@@ -18,11 +19,11 @@ namespace tests.Specs
             var fileSystem = MockPackage.Html;
 
             ExecutionContext.Initialize(fileSystem);
-            
+
             fileSystem.Directory.SetCurrentDirectory(MockUnixSupport.Path("c:\\ui"));
 
             StringWriter standardOutput = (new Logging()).GetLogStringWriter();
-            
+
             string exceptionMessage = string.Empty;
             try
             {
@@ -37,7 +38,35 @@ namespace tests.Specs
             }
 
             Assert.Equal(string.Empty, exceptionMessage);
-            Assert.Contains($"{ MockUnixSupport.Path(@"c:\ui\src\packages\customization.common\") }.npmignore not found!", standardOutput.ToString().Trim());
+            Assert.Contains($"{MockUnixSupport.Path(@"c:\ui\src\packages\customization.common\")}.npmignore not found!", standardOutput.ToString().Trim());
+        }
+
+        /// <summary>
+        /// NotImplementedPackageTypeHandler
+        /// Checks whether it throws a controlled exception when it does not have the desired Package Type Handler implemented.
+        /// </summary>
+        [Fact]
+        public void NotImplementedPackageTypeHandler()
+        {
+            var fileSystem = MockPackage.ProductDatabase_Empty;
+
+            ExecutionContext.Initialize(fileSystem);
+
+            fileSystem.Directory.SetCurrentDirectory(MockUnixSupport.Path("c:\\repo"));
+
+            string exceptionMessage = string.Empty;
+            try
+            {
+                var cmfPackage = fileSystem.FileInfo.FromFileName(CliConstants.CmfPackageFileName);
+                var packageTypeHandler = PackageTypeFactory.GetPackageTypeHandler(cmfPackage);
+            }
+            catch (Exception ex)
+            {
+                exceptionMessage = ex.Message;
+            }
+
+            Assert.False(string.IsNullOrWhiteSpace(exceptionMessage));
+            Assert.Equal(string.Format(CoreMessages.PackageTypeHandlerNotImplemented, "ProductDatabase"), exceptionMessage);
         }
     }
 }


### PR DESCRIPTION
feat(restore dependencies): CoreBiz - move CopyLibs to cmf-cli restore dependencies
chore(restore): Added dependenciesDirectory property to allow to choose path where to extract package dependencies
chore(bug fix): fixed bug in which cli package with Generic type with no build steps would throw error when running cmf pack
chore(bug fix): fixed bug when trying to cmf pack to path '.' it would include cmfpackage.json, so it was added to default exceptions
chore: bump to 3.4.1-0