### PR TITLE
better error handling #33

### DIFF
--- a/cmf-cli/Builders/JSONValidatorCommand.cs
+++ b/cmf-cli/Builders/JSONValidatorCommand.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
 
 namespace Cmf.CLI.Builders
 {
@@ -64,7 +65,7 @@ namespace Cmf.CLI.Builders
                 }
                 catch (Exception)
                 {
-                    throw new Exception($"File {file.Source.FullName} is not a valid json");
+                    throw new CliException($"File {file.Source.FullName} is not a valid json");
                 }
             }
             return null;

--- a/cmf-cli/Commands/LayerTemplateCommand.cs
+++ b/cmf-cli/Commands/LayerTemplateCommand.cs
@@ -113,8 +113,7 @@ namespace Cmf.CLI.Commands
                 var featuresPath = this.fileSystem.Path.Join(projectRoot.FullName, "Features");
                 if (this.fileSystem.Directory.Exists(featuresPath))
                 {
-                    Log.Error($"Cannot create a root-level layer package when features already exist.");
-                    return null;
+                    throw new CliException($"Cannot create a root-level layer package when features already exist.");
                 }
             }
             else
@@ -146,8 +145,7 @@ namespace Cmf.CLI.Commands
             using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             if (workingDir == null)
             {
-                Log.Error("This command needs to run inside a project. Run `cmf init` to create a new project.");
-                return;
+                throw new CliException("This command needs to run inside a project. Run `cmf init` to create a new project.");
             }
 
             var names = this.GeneratePackageName(workingDir);

--- a/cmf-cli/Commands/UILayerTemplateCommand.cs
+++ b/cmf-cli/Commands/UILayerTemplateCommand.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Cmf.CLI.Builders;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Utilities;
 
 namespace Cmf.CLI.Commands
 {
@@ -33,7 +34,7 @@ namespace Cmf.CLI.Commands
         {
             if (target?.Exists != true)
             {
-                throw new Exception("Target clone directory doesn't exist");
+                throw new CliException("Target clone directory doesn't exist");
             }
 
             // delete .gitkeep if it exists

--- a/cmf-cli/Commands/assemble/AssembleCommand.cs
+++ b/cmf-cli/Commands/assemble/AssembleCommand.cs
@@ -222,7 +222,7 @@ namespace Cmf.CLI.Commands
                         }
                         else
                         {
-                            throw new Exception(string.Format(CliMessages.SomePackagesNotFound, _dependencyFileName));
+                            throw new CliException(string.Format(CliMessages.SomePackagesNotFound, _dependencyFileName));
                         }
                     }
 
@@ -254,7 +254,7 @@ namespace Cmf.CLI.Commands
                         if (dependency.CmfPackage == null)
                         {
                             string errorMessage = string.Format(CoreMessages.MissingMandatoryDependency, dependency.Id, dependency.Version);
-                            throw new Exception(errorMessage);
+                            throw new CliException(errorMessage);
                         }
 
                         string dependencyPath = dependency.CmfPackage.Uri.GetFile().Directory.FullName;
@@ -297,7 +297,7 @@ namespace Cmf.CLI.Commands
                 if(cmfPackage == null)
                 {
                     string errorMessage = string.Format(CoreMessages.NotFound, packageName);
-                    throw new Exception(errorMessage);
+                    throw new CliException(errorMessage);
                 }
             }
 

--- a/cmf-cli/Commands/bump/BumpIoTCustomizationCommand.cs
+++ b/cmf-cli/Commands/bump/BumpIoTCustomizationCommand.cs
@@ -70,8 +70,7 @@ namespace Cmf.CLI.Commands
 
             if (string.IsNullOrEmpty(version))
             {
-                Log.Error(string.Format(CliMessages.MissingMandatoryProperty, "version"));
-                return;
+                throw new CliException(string.Format(CliMessages.MissingMandatoryProperty, "version"));
             }
 
             // Reading cmfPackage

--- a/cmf-cli/Commands/new/DataCommand.cs
+++ b/cmf-cli/Commands/new/DataCommand.cs
@@ -77,8 +77,7 @@ namespace Cmf.CLI.Commands.New
         {
             if (businessPackage != null && !businessPackage.Exists)
             {
-                Log.Error($"Target business package does not exist");
-                return;
+                throw new CliException($"Target business package does not exist");
             }
             
             base.Execute(workingDir, version);

--- a/cmf-cli/Commands/new/FeatureCommand.cs
+++ b/cmf-cli/Commands/new/FeatureCommand.cs
@@ -68,8 +68,7 @@ namespace Cmf.CLI.Commands.New
         {
             if (workingDir == null)
             {
-                Log.Error("This command needs to run inside a project. Run `cmf init` to create a new project.");
-                return;
+                throw new CliException("This command needs to run inside a project. Run `cmf init` to create a new project.");
             }
             var featurePath = this.fileSystem.Path.Join(workingDir.FullName, "Features");
             var args = new List<string>()

--- a/cmf-cli/Commands/new/HTMLCommand.cs
+++ b/cmf-cli/Commands/new/HTMLCommand.cs
@@ -86,7 +86,7 @@ namespace Cmf.CLI.Commands.New
             var pkgFolder = workingDir.GetDirectories(pkgName).FirstOrDefault();
             if (!pkgFolder?.Exists ?? false)
             {
-                throw new Exception($"Package folder {pkgFolder.Name} does not exist. This is a template error. Please open an issue on GitHub.");
+                throw new CliException($"Package folder {pkgFolder.Name} does not exist. This is a template error. Please open an issue on GitHub.");
             }
             this.CloneHTMLStarter(htmlStarterVersion, pkgFolder);
 
@@ -96,7 +96,7 @@ namespace Cmf.CLI.Commands.New
             dynamic rootPkgJson = JsonConvert.DeserializeObject(json);
             if (rootPkgJson == null)
             {
-                throw new Exception("Could not load package.json");
+                throw new CliException("Could not load package.json");
             }
             var devTasksVersion = projectConfig.RootElement.GetProperty("DevTasksVersion").GetString();
             var yoGeneratorVersion = projectConfig.RootElement.GetProperty("YoGeneratorVersion").GetString();
@@ -118,7 +118,7 @@ namespace Cmf.CLI.Commands.New
             dynamic devTasksJson = JsonConvert.DeserializeObject(devTasksStr);
             if (devTasksJson == null)
             {
-                throw new Exception("Could not load .dev-tasks.json");
+                throw new CliException("Could not load .dev-tasks.json");
             }
             var npmRegistry = projectConfig.RootElement.GetProperty("NPMRegistry").GetString();
             var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
@@ -201,7 +201,7 @@ $@"{{
             dynamic configJsonJson = JsonConvert.DeserializeObject(configJsonStr);
             if (configJsonJson == null)
             {
-                throw new Exception("Could not load config.json");
+                throw new CliException("Could not load config.json");
             }
             var restPort = int.Parse(projectConfig.RootElement.GetProperty("RESTPort").GetString());
             configJsonJson.host.rest.enableSsl = false;

--- a/cmf-cli/Commands/new/HelpCommand.cs
+++ b/cmf-cli/Commands/new/HelpCommand.cs
@@ -84,7 +84,7 @@ namespace Cmf.CLI.Commands.New
             var pkgFolder = workingDir.GetDirectories(pkgName).FirstOrDefault();
             if (!pkgFolder?.Exists ?? false)
             {
-                throw new Exception($"Package folder {pkgFolder.Name} does not exist. This is a template error. Please open an issue on GitHub.");
+                throw new CliException($"Package folder {pkgFolder.Name} does not exist. This is a template error. Please open an issue on GitHub.");
             }
             this.CloneHTMLStarter(htmlStarterVersion, pkgFolder);
             
@@ -94,7 +94,7 @@ namespace Cmf.CLI.Commands.New
             dynamic rootPkgJson = JsonConvert.DeserializeObject(json);
             if (rootPkgJson == null)
             {
-                throw new Exception("Could not load package.json");
+                throw new CliException("Could not load package.json");
             }
             var devTasksVersion = projectConfig.RootElement.GetProperty("DevTasksVersion").GetString();
             var yoGeneratorVersion = projectConfig.RootElement.GetProperty("YoGeneratorVersion").GetString();
@@ -115,7 +115,7 @@ namespace Cmf.CLI.Commands.New
             dynamic devTasksJson = JsonConvert.DeserializeObject(devTasksStr);
             if (devTasksJson == null)
             {
-                throw new Exception("Could not load .dev-tasks.json");
+                throw new CliException("Could not load .dev-tasks.json");
             }
             var npmRegistry = projectConfig.RootElement.GetProperty("NPMRegistry").GetString();
             var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
@@ -193,7 +193,7 @@ $@"{{
             dynamic configJsonJson = JsonConvert.DeserializeObject(configJsonStr);
             if (configJsonJson == null)
             {
-                throw new Exception("Could not load config.json");
+                throw new CliException("Could not load config.json");
             }
             var restPort = int.Parse(projectConfig.RootElement.GetProperty("RESTPort").GetString());
             configJsonJson.host.rest.enableSsl = false;

--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -501,7 +501,7 @@ namespace Cmf.CLI.Handlers
             var filesToPack = GetContentToPack(packageOutputDir);
             if (CmfPackage.ContentToPack.HasAny() && !filesToPack.HasAny())
             {
-                throw new Exception(string.Format(CoreMessages.ContentToPackNotFound, CmfPackage.PackageId, CmfPackage.Version));
+                throw new CliException(string.Format(CoreMessages.ContentToPackNotFound, CmfPackage.PackageId, CmfPackage.Version));
             }
 
             if (filesToPack != null)

--- a/cmf-cli/Program.cs
+++ b/cmf-cli/Program.cs
@@ -8,6 +8,7 @@ using Cmf.CLI.Core;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Objects;
 using Microsoft.Extensions.DependencyInjection;
+using Cmf.CLI.Core.Enums;
 
 namespace Cmf.CLI
 {
@@ -16,38 +17,8 @@ namespace Cmf.CLI
     /// </summary>
     public static class Program
     {
-        private static System.CommandLine.Parsing.ParseArgument<LogLevel> parseLogLevel = argResult =>
-        {
-            var loglevel = LogLevel.Verbose;
-            string loglevelStr = "verbose";
-            if (argResult.Tokens.Any())
-            {
-                loglevelStr = argResult.Tokens.First().Value;
-            }
-            else if (System.Environment.GetEnvironmentVariable("cmf_cli_loglevel") != null)
-            {
-                loglevelStr = System.Environment.GetEnvironmentVariable("cmf_cli_loglevel");
-            }
 
-            if (Enum.TryParse(typeof(LogLevel), loglevelStr, ignoreCase: true, out var loglevelObj))
-            {
-                loglevel = (LogLevel)loglevelObj!;
-            }
-            Log.Level = loglevel;
-            return loglevel;
-        };
-
-        /// <summary>
-        /// Root Command log verbosity option
-        /// </summary>
-        public static Option<LogLevel> logLevelOption = new Option<LogLevel>(
-                aliases: new[] { "--loglevel", "-l" },
-                description: "Log Verbosity",
-                parseArgument: parseLogLevel,
-                isDefault: true
-            );
-
-        /// <summary>
+       /// <summary>
         /// program entry point
         /// </summary>
         /// <param name="args"></param>
@@ -67,7 +38,8 @@ namespace Cmf.CLI
                     Description = "Critical Manufacturing CLI"
                 };
 
-                rootCommand.AddOption(logLevelOption);
+                // add logleveloption
+                rootCommand.AddOption(LoggerHelpers.LogLevelOption);
 
                 if (args.Length == 1 && args.Has("-v"))
                 {
@@ -79,10 +51,16 @@ namespace Cmf.CLI
 
                 return rootCommand.Invoke(args);
             }
+            catch (CliException e)
+            {
+                Log.Error(e.Message);
+                Log.Debug(e.StackTrace);
+                return (int)e.ErrorCode;
+            }
             catch (Exception e)
             {
                 Log.Exception(e);
-                return -1; // TODO: set exception error codes
+                return (int)ErrorCode.Default;
             }
         }
 

--- a/core/Enums/ErrorCode.cs
+++ b/core/Enums/ErrorCode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cmf.CLI.Core.Enums
+{
+    public enum ErrorCode
+    {
+        Default = -1
+    }
+}

--- a/core/Enums/ErrorCode.cs
+++ b/core/Enums/ErrorCode.cs
@@ -8,6 +8,7 @@ namespace Cmf.CLI.Core.Enums
 {
     public enum ErrorCode
     {
-        Default = -1
+        Default = -1,
+        Success = 0
     }
 }

--- a/core/Enums/ErrorCode.cs
+++ b/core/Enums/ErrorCode.cs
@@ -9,6 +9,7 @@ namespace Cmf.CLI.Core.Enums
     public enum ErrorCode
     {
         Default = -1,
-        Success = 0
+        Success = 0,
+        InvalidArgument = 22 // 22 is invalid argument in bash
     }
 }

--- a/core/LoggerHelpers.cs
+++ b/core/LoggerHelpers.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using System.Linq;
+using Cmf.CLI.Utilities;
+
+namespace Cmf.CLI.Core
+{
+    public static class LoggerHelpers
+    {
+
+        /// <summary>
+        /// Parse log level based on input option or environment variables
+        /// </summary>
+        private static ParseArgument<LogLevel> parseLogLevel = argResult =>
+        {
+            var loglevel = LogLevel.Verbose;
+            string loglevelStr = "verbose";
+            if (argResult.Tokens.Any())
+            {
+                loglevelStr = argResult.Tokens[0].Value;
+            }
+            else if (Environment.GetEnvironmentVariable("cmf_cli_loglevel") != null)
+            {
+                loglevelStr = Environment.GetEnvironmentVariable("cmf_cli_loglevel");
+            }
+            if (Environment.GetEnvironmentVariable("SYSTEM_DEBUG")?.ToBool() ?? false)
+            {
+                loglevelStr = "debug";
+            }
+
+            if (Enum.TryParse(typeof(LogLevel), loglevelStr, ignoreCase: true, out var loglevelObj))
+            {
+                loglevel = (LogLevel)loglevelObj!;
+            }
+            Log.Level = loglevel;
+            return loglevel;
+        };
+
+        /// <summary>
+        /// Log verbosity option that can be used in root commands
+        /// </summary>
+        public static Option<LogLevel> LogLevelOption = new Option<LogLevel>(
+            aliases: new[] { "--loglevel", "-l" },
+            description: "Log Verbosity",
+            parseArgument: parseLogLevel,
+            isDefault: true
+        );
+    }
+}

--- a/core/Objects/CmfPackage.cs
+++ b/core/Objects/CmfPackage.cs
@@ -534,8 +534,7 @@ namespace Cmf.CLI.Core.Objects
                 var allDirectories = repoUris?.All(r => r.IsDirectory());
                 if (allDirectories == false)
                 {
-                    Log.Error(CoreMessages.UrlsNotSupported);
-                    return;
+                    throw new CliException(CoreMessages.UrlsNotSupported);
                 }
 
                 IDirectoryInfo[] repoDirectories = repoUris?.Select(r => r.GetDirectory()).ToArray();

--- a/core/Utilities/CliException.cs
+++ b/core/Utilities/CliException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cmf.CLI.Core;
+using Cmf.CLI.Core.Enums;
 
 namespace Cmf.CLI.Utilities
 {
@@ -11,18 +12,25 @@ namespace Cmf.CLI.Utilities
     public class CliException : Exception
     {
         /// <summary>
+        /// The output ErrorCode of the application
+        /// </summary>
+        public ErrorCode ErrorCode = ErrorCode.Default;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="CliException"/> class.
         /// </summary>
-        public CliException()
+        public CliException(ErrorCode errorCode = ErrorCode.Default)
         {
+            ErrorCode = errorCode;
         }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CliException"/> class.
         /// </summary>
         /// <param name="message">The message that describes the error.</param>
-        public CliException(string message) : base(message)
+        public CliException(string message, ErrorCode errorCode = ErrorCode.Default) : base(message)
         {
+            ErrorCode = errorCode;
             Log.Error(message);
         }
 
@@ -31,8 +39,9 @@ namespace Cmf.CLI.Utilities
         /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (<see langword="Nothing" /> in Visual Basic) if no inner exception is specified.</param>
-        public CliException(string message, Exception innerException) : base(message, innerException)
+        public CliException(string message, Exception innerException, ErrorCode errorCode = ErrorCode.Default) : base(message, innerException)
         {
+            ErrorCode = errorCode;
             Log.Error($"{message} | InnerException: {innerException.Message}");
         }
 

--- a/core/Utilities/CliException.cs
+++ b/core/Utilities/CliException.cs
@@ -31,7 +31,6 @@ namespace Cmf.CLI.Utilities
         public CliException(string message, ErrorCode errorCode = ErrorCode.Default) : base(message)
         {
             ErrorCode = errorCode;
-            Log.Error(message);
         }
 
         /// <summary>
@@ -42,7 +41,6 @@ namespace Cmf.CLI.Utilities
         public CliException(string message, Exception innerException, ErrorCode errorCode = ErrorCode.Default) : base(message, innerException)
         {
             ErrorCode = errorCode;
-            Log.Error($"{message} | InnerException: {innerException.Message}");
         }
 
         // A constructor is needed for serialization when an

--- a/core/Utilities/CliException.cs
+++ b/core/Utilities/CliException.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Enums;
 
@@ -41,6 +42,24 @@ namespace Cmf.CLI.Utilities
         public CliException(string message, Exception innerException, ErrorCode errorCode = ErrorCode.Default) : base(message, innerException)
         {
             ErrorCode = errorCode;
+        }
+
+        /// <summary>
+        /// Method to handle exception when is coming from Reflection
+        /// in that case the CliException is wrapped into a TargetInvocationException
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        public static void Handler(Exception exception)
+        {
+            if (exception is TargetInvocationException
+                && exception.InnerException is CliException)
+            {
+                throw exception.InnerException;
+            }
+            else
+            {
+                throw exception;
+            }
         }
 
         // A constructor is needed for serialization when an

--- a/core/Utilities/ExtensionMethods.cs
+++ b/core/Utilities/ExtensionMethods.cs
@@ -272,6 +272,21 @@ namespace Cmf.CLI.Utilities
             fileSystem.File.SetLastWriteTime(destinationFileName, source.LastWriteTime.DateTime);
         }
 
+        /// <summary>
+        /// Converts string true, yes, 1, false, no, 0 to bool.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <returns></returns>
+        public static bool ToBool(this string str)
+        {
+            return (str.ToLowerInvariant()) switch
+            {
+                "true" or "yes" or "1" => true,
+                "false" or "no" or "0" or null => false,
+                _ => throw new ArgumentException("string was not true or false", str)
+            };
+        }
+
         #region Private Methods
 
         /// <summary>

--- a/tests/Specs/Logging.cs
+++ b/tests/Specs/Logging.cs
@@ -28,7 +28,8 @@ namespace tests.Specs
         {
             _writer = new StringWriter();
             Environment.SetEnvironmentVariable("cmf_cli_loglevel", null);
-            Program.logLevelOption.Parse(""); // reset to default log level
+
+            LoggerHelpers.LogLevelOption.Parse(""); // reset to default log level
             Log.AnsiConsole = factory.Create(new AnsiConsoleSettings
             {
                 Ansi = AnsiSupport.Yes,
@@ -72,7 +73,7 @@ namespace tests.Specs
         public void LogDebug_WhenDebug_Option()
         {
             // System.Environment.SetEnvironmentVariable("cmf:cli:loglevel", "debug");
-            Program.logLevelOption.Parse("--loglevel debug");
+            LoggerHelpers.LogLevelOption.Parse("--loglevel debug");
             // Log.Level = LogLevel.Debug;
 
             // var root = Program.Main(new string[] { "--loglevel", "debug", "ls" });
@@ -86,7 +87,7 @@ namespace tests.Specs
         public void LogDebug_WhenDebug_Environment()
         {
             System.Environment.SetEnvironmentVariable("cmf_cli_loglevel", "debug");
-            Program.logLevelOption.Parse(""); // invoke rootCommand option parser to set environment value
+            LoggerHelpers.LogLevelOption.Parse(""); // invoke rootCommand option parser to set environment value
             // --loglevel debug
             // Log.Level = LogLevel.Debug;
 


### PR DESCRIPTION
- allow ErrorCodes on CliException
- replace all `Log.Error return` and `throw new Exception` with `throw new CliException`
- add method to handle exception when comes from Reflection `exception is TargetInvocationException`