### PR TITLE
refactor: read project-config as a versioned object instead of a JsonDocument

### DIFF
--- a/cmf-cli/Commands/LayerTemplateCommand.cs
+++ b/cmf-cli/Commands/LayerTemplateCommand.cs
@@ -94,16 +94,16 @@ namespace Cmf.CLI.Commands
             var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem, throwException: true);
 
             //load .project-config
-            var projectConfig = FileSystemUtilities.ReadProjectConfig(this.fileSystem);
+            var projectConfig = ExecutionContext.Instance.ProjectConfig;
             var organization = Constants.CliConstants.DefaultOrganization;
             var product = Constants.CliConstants.DefaultProduct;
-            if (projectConfig.RootElement.TryGetProperty("Organization", out JsonElement element))
+            if (!string.IsNullOrWhiteSpace(projectConfig.Organization))
             {
-                organization = element.GetString();
+                organization = projectConfig.Organization;
             }
-            if (projectConfig.RootElement.TryGetProperty("Product", out JsonElement element2))
+            if (!string.IsNullOrWhiteSpace(projectConfig.Product))
             {
-                product = element2.GetString();
+                product = projectConfig.Product;
             }
             var packageName = $"{organization}.{product}.{this.packageType}";
 
@@ -156,8 +156,7 @@ namespace Cmf.CLI.Commands
             var (packageName, featureName) = names.Value;
 
             //load .project-config
-            var projectConfig = FileSystemUtilities.ReadProjectConfig(this.fileSystem);
-            var tenant = projectConfig.RootElement.GetProperty("Tenant").GetString();
+            var tenant = ExecutionContext.Instance.ProjectConfig.Tenant;
             var args = new List<string>()
             {
                 // engine options
@@ -171,7 +170,7 @@ namespace Cmf.CLI.Commands
             };
 
             var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
-            args = this.GenerateArgs(projectRoot, workingDir, args, projectConfig);
+            args = this.GenerateArgs(projectRoot, workingDir, args);
             this.executedArgs = args.ToArray();
             base.RunCommand(args);
             if (registerInParent)
@@ -188,6 +187,6 @@ namespace Cmf.CLI.Commands
         /// <param name="args">the base arguments: output, package name, version, id segment and tenant</param>
         /// <param name="projectConfig">a JsonDocument with the .project-config.json content</param>
         /// <returns>the complete list of arguments</returns>
-        protected abstract List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig);
+        protected abstract List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args);
     }
 }

--- a/cmf-cli/Commands/UILayerTemplateCommand.cs
+++ b/cmf-cli/Commands/UILayerTemplateCommand.cs
@@ -30,7 +30,7 @@ namespace Cmf.CLI.Commands
         /// </summary>
         /// <param name="versionTag"></param>
         /// <param name="target"></param>
-        protected void CloneHTMLStarter(string versionTag, IDirectoryInfo target)
+        protected void CloneHTMLStarter(Version versionTag, IDirectoryInfo target)
         {
             if (target?.Exists != true)
             {
@@ -47,7 +47,7 @@ namespace Cmf.CLI.Commands
             // git fetch
             (new GitCommand() { Command = "fetch", WorkingDirectory = target }).Exec();
             // git pull origin $vars['HTMLStarterVersion']
-            (new GitCommand() { Command = "pull", WorkingDirectory = target, Args = new[] { "origin", versionTag } }).Exec();
+            (new GitCommand() { Command = "pull", WorkingDirectory = target, Args = new[] { "origin", versionTag.ToString() } }).Exec();
             Log.Debug("delete .git folder");
             this.DeleteFolderWithReadOnlyFiles(target.GetDirectories(".git").FirstOrDefault());
             // delete apps/.gitkeep

--- a/cmf-cli/Commands/build/GenerateBasedOnTemplatesCommand.cs
+++ b/cmf-cli/Commands/build/GenerateBasedOnTemplatesCommand.cs
@@ -38,12 +38,11 @@ namespace Cmf.CLI.Commands
         {
             var regex = new Regex("\"?id\"?:\\s+[\"'](.*)[\"']"); // match for menu item IDs
             
-            var mesVersionStr = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("MESVersion").GetString();
-            Log.Debug($"Generating markdown for a help package for base version {mesVersionStr}");
-            var mesVersion = Version.Parse(mesVersionStr!);
+            var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
+            Log.Debug($"Generating markdown for a help package for base version {mesVersion}");
 
             var helpRoot = FileSystemUtilities.GetPackageRootByType(Environment.CurrentDirectory, PackageType.Help, this.fileSystem).FullName;
-            var project = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("Tenant").GetString();
+            var project = ExecutionContext.Instance.ProjectConfig.Tenant;
             var helpPackagesRoot = (mesVersion.Major > 9) ? this.fileSystem.Path.Join(helpRoot, "projects") : this.fileSystem.Path.Join(helpRoot, "src", "packages");
             var helpPackages = this.fileSystem.Directory.GetDirectories(helpPackagesRoot);
             var pkgName = CmfPackage.Load(this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(helpRoot, CliConstants.CmfPackageFileName))).PackageId.ToLowerInvariant();

--- a/cmf-cli/Commands/build/GenerateBasedOnTemplatesCommandPWSH.cs
+++ b/cmf-cli/Commands/build/GenerateBasedOnTemplatesCommandPWSH.cs
@@ -36,12 +36,11 @@ namespace Cmf.CLI.Commands
         {
             var regex = new Regex("\"?id\"?:\\s+[\"'](.*)[\"']"); // match for menu item IDs
             
-            var mesVersionStr = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("MESVersion").GetString();
-            Log.Debug($"Generating markdown for a help package for base version {mesVersionStr}");
-            var mesVersion = Version.Parse(mesVersionStr!);
+            var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
+            Log.Debug($"Generating markdown for a help package for base version {mesVersion}");
             
             var helpRoot = FileSystemUtilities.GetPackageRootByType(Environment.CurrentDirectory, PackageType.Help, this.fileSystem).FullName;
-            var project = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("Tenant").GetString();
+            var project = ExecutionContext.Instance.ProjectConfig.Tenant;
             var helpPackagesRoot = (mesVersion.Major > 9) ? this.fileSystem.Path.Join(helpRoot, "projects") : this.fileSystem.Path.Join(helpRoot, "src", "packages");
             var helpPackages = this.fileSystem.Directory.GetDirectories(helpPackagesRoot);
             var pkgName = CmfPackage.Load(this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(helpRoot, CliConstants.CmfPackageFileName))).PackageId.ToLowerInvariant();

--- a/cmf-cli/Commands/build/GenerateMenuItemsCommand.cs
+++ b/cmf-cli/Commands/build/GenerateMenuItemsCommand.cs
@@ -10,6 +10,7 @@ using System.Text.RegularExpressions;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 
 namespace Cmf.CLI.Commands 
@@ -45,11 +46,10 @@ namespace Cmf.CLI.Commands
         public void Execute()
         {
             var helpRoot = FileSystemUtilities.GetPackageRootByType(Environment.CurrentDirectory, PackageType.Help, this.fileSystem).FullName;
-            var project = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("Tenant").GetString();
+            var project = ExecutionContext.Instance.ProjectConfig.Tenant;
             
-            var mesVersionStr = FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("MESVersion").GetString();
-            Log.Debug($"Generating menu items database for a help package for base version {mesVersionStr}");
-            var mesVersion = Version.Parse(mesVersionStr!);
+            var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
+            Log.Debug($"Generating menu items database for a help package for base version {mesVersion}");
 
             if (project == null)
             {

--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -4,32 +4,16 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.IO.Abstractions;
 using Cmf.CLI.Constants;
-using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Commands;
+using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
-using Cmf.CLI.Enums;
 using Cmf.CLI.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 
 namespace Cmf.CLI.Commands
 {
-    /// <summary>
-    /// Azure DevOps Agent Type
-    /// </summary>
-    public enum AgentType
-    {
-        /// <summary>
-        /// Cloud agents
-        /// </summary>
-        Cloud,
-        /// <summary>
-        /// Self-host agents
-        /// </summary>
-        Hosted
-    }
-
     // this is public because Execute is public by convention but never invoked externally
     // so this class mirrors the command internal structure and is never used outside
     // ReSharper disable once ClassNeverInstantiated.Global

--- a/cmf-cli/Commands/new/BusinessCommand.cs
+++ b/cmf-cli/Commands/new/BusinessCommand.cs
@@ -6,6 +6,7 @@ using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
 
 namespace Cmf.CLI.Commands.New
 {
@@ -31,20 +32,17 @@ namespace Cmf.CLI.Commands.New
         }
 
         /// <inheritdoc />
-        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig)
+        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args)
         {
-            var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
+            var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
             var includeMESNugets = true;
             
-            var version = Version.Parse(mesVersion);
-            if (version.Major > 8)
+            if (mesVersion.Major > 8)
             {
                 this.CommandName = "business9";
-                var bl = projectConfig.RootElement.GetProperty("BaseLayer").GetString();
-                var couldParse = Enum.TryParse<BaseLayer>(bl, out var baseLayerValue);
-                var baseLayer = couldParse ? baseLayerValue : CliConstants.DefaultBaseLayer;
+                var baseLayer = ExecutionContext.Instance.ProjectConfig.BaseLayer ?? CliConstants.DefaultBaseLayer;
                 includeMESNugets = baseLayer == BaseLayer.MES;
-                Log.Debug($"Project is targeting base layer {baseLayer} ({bl} {couldParse} {baseLayerValue}), so scaffolding {(includeMESNugets ? "with" : "without")} MES nugets.");
+                Log.Debug($"Project is targeting base layer {baseLayer}, so scaffolding {(includeMESNugets ? "with" : "without")} MES nugets.");
             }
 
             // calculate relative path to local environment and create a new symbol for it
@@ -63,7 +61,7 @@ namespace Cmf.CLI.Commands.New
 
             args.AddRange(new []
             {
-                "--MESVersion", mesVersion,
+                "--MESVersion", mesVersion.ToString(),
                 "--localEnvRelativePath", relativePathToLocalEnv,
                 "--deploymentMetadataRelativePath", relativePathToDeploymentMetadata,
                 "--includeMESNugets", includeMESNugets.ToString()

--- a/cmf-cli/Commands/new/BusinessCommand.cs
+++ b/cmf-cli/Commands/new/BusinessCommand.cs
@@ -1,17 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.CommandLine;
-using System.CommandLine.Invocation;
-using System.Diagnostics;
-using System.IO;
 using System.IO.Abstractions;
 using System.Text.Json;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
-using Cmf.CLI.Enums;
-using Cmf.CLI.Utilities;
 
 namespace Cmf.CLI.Commands.New
 {

--- a/cmf-cli/Commands/new/DataCommand.cs
+++ b/cmf-cli/Commands/new/DataCommand.cs
@@ -9,6 +9,7 @@ using Cmf.CLI.Builders;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 
 namespace Cmf.CLI.Commands.New
@@ -43,7 +44,7 @@ namespace Cmf.CLI.Commands.New
         }
 
         /// <inheritdoc />
-        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig)
+        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args)
         {
             var relativePathToRoot =
                 this.fileSystem.Path.Join("..", //always one level deeper
@@ -58,9 +59,8 @@ namespace Cmf.CLI.Commands.New
             });
             
             #region version-specific bits
-            var config = FileSystemUtilities.ReadProjectConfig(this.fileSystem);
-            var x = config.RootElement.EnumerateObject();
-            var version = Version.Parse(x.FirstOrDefault(y => y.NameEquals("MESVersion")).Value.ToString());
+
+            var version = ExecutionContext.Instance.ProjectConfig.MESVersion;
             args.AddRange(new []{ "--targetFramework", version.Major > 8 ? "net6.0" : "netstandard2.0" });
             #endregion
 

--- a/cmf-cli/Commands/new/DatabaseCommand.cs
+++ b/cmf-cli/Commands/new/DatabaseCommand.cs
@@ -29,7 +29,7 @@ namespace Cmf.CLI.Commands.New
         }
 
         /// <inheritdoc />
-        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig)
+        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args)
         {
             var relativePathToRoot =
                 this.fileSystem.Path.Join("..", "..", //always two levels deeper

--- a/cmf-cli/Commands/new/FeatureCommand.cs
+++ b/cmf-cli/Commands/new/FeatureCommand.cs
@@ -4,6 +4,7 @@ using System.CommandLine.NamingConventionBinder;
 using System.IO.Abstractions;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Commands;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 
 
@@ -78,7 +79,7 @@ namespace Cmf.CLI.Commands.New
                 // template symbols
                 "--name", packageName,
                 "--packageVersion", version,
-                "--MESVersion", FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("MESVersion").ToString()
+                "--MESVersion", ExecutionContext.Instance.ProjectConfig.MESVersion.ToString()
             };
             
             base.RunCommand(args);

--- a/cmf-cli/Commands/new/HTMLCommand.cs
+++ b/cmf-cli/Commands/new/HTMLCommand.cs
@@ -11,9 +11,7 @@ using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
-using Cmf.CLI.Enums;
 using Cmf.CLI.Utilities;
-using Namotion.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 

--- a/cmf-cli/Commands/new/IoTCommand.cs
+++ b/cmf-cli/Commands/new/IoTCommand.cs
@@ -5,6 +5,7 @@ using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
 
 namespace Cmf.CLI.Commands.New
 {
@@ -31,11 +32,11 @@ namespace Cmf.CLI.Commands.New
 
 
         /// <inheritdoc />
-        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig)
+        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args)
         {
-            var npmRegistry = projectConfig.RootElement.GetProperty("NPMRegistry").GetString();
-            var devTasksVersion = projectConfig.RootElement.GetProperty("DevTasksVersion").GetString();
-            var repoType = projectConfig.RootElement.GetProperty("RepositoryType").GetString() ?? CliConstants.DefaultRepositoryType.ToString();
+            var npmRegistry = ExecutionContext.Instance.ProjectConfig.NPMRegistry;
+            var devTasksVersion = ExecutionContext.Instance.ProjectConfig.DevTasksVersion;
+            var repoType = ExecutionContext.Instance.ProjectConfig.RepositoryType ?? CliConstants.DefaultRepositoryType;
             Log.Debug($"Creating IoT Package at {workingDir} for repo type {repoType} using registry {npmRegistry}");
 
             // calculate relative path to local environment and create a new symbol for it
@@ -49,9 +50,9 @@ namespace Cmf.CLI.Commands.New
             args.AddRange(new[]
             {
                 "--rootInnerRelativePath", relativePathToRoot,
-                "--DevTasksVersion", devTasksVersion,
-                "--npmRegistry", npmRegistry,
-                "--repositoryType", repoType
+                "--DevTasksVersion", devTasksVersion.ToString(),
+                "--npmRegistry", npmRegistry.OriginalString,
+                "--repositoryType", repoType.ToString()
             });
 
             return args;

--- a/cmf-cli/Commands/new/SecurityPortalCommand.cs
+++ b/cmf-cli/Commands/new/SecurityPortalCommand.cs
@@ -29,7 +29,7 @@ namespace Cmf.Common.Cli.Commands.New
         }
 
         /// <inheritdoc />
-        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig)
+        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args)
         {
             return args;
         }

--- a/cmf-cli/Commands/new/TestCommand.cs
+++ b/cmf-cli/Commands/new/TestCommand.cs
@@ -6,6 +6,7 @@ using System.IO.Abstractions;
 using System.Text.Json;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 
 namespace Cmf.CLI.Commands.New
@@ -38,7 +39,7 @@ namespace Cmf.CLI.Commands.New
         }
 
         /// <inheritdoc />
-        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args, JsonDocument projectConfig)
+        protected override List<string> GenerateArgs(IDirectoryInfo projectRoot, IDirectoryInfo workingDir, List<string> args)
         {
             return args;
         }
@@ -51,8 +52,8 @@ namespace Cmf.CLI.Commands.New
         {
             var packageName = "Cmf.Custom.Tests";
             var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
-            var projectConfig = FileSystemUtilities.ReadProjectConfig(this.fileSystem);
-            var tenant = projectConfig.RootElement.GetProperty("Tenant").GetString();
+            var projectConfig = ExecutionContext.Instance.ProjectConfig;
+            var tenant = projectConfig.Tenant;
             var args = new List<string>()
             {
                 // engine options
@@ -65,28 +66,28 @@ namespace Cmf.CLI.Commands.New
                 "--Tenant", tenant
             };
 
-            var restPort = projectConfig.RootElement.GetProperty("RESTPort").GetString();
-            var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
-            var htmlPort = projectConfig.RootElement.GetProperty("HTMLPort").GetString();
-            var vmHostname = projectConfig.RootElement.GetProperty("vmHostname").GetString();
-            var testScenariosNugetVersion = projectConfig.RootElement.GetProperty("TestScenariosNugetVersion").GetString();
-            var isSslEnabled = projectConfig.RootElement.GetProperty("IsSslEnabled").GetString();
+            var restPort = projectConfig.RESTPort;
+            var mesVersion = projectConfig.MESVersion;
+            var htmlPort = projectConfig.HTMLPort;
+            var vmHostname = projectConfig.vmHostname;
+            var testScenariosNugetVersion = projectConfig.TestScenariosNugetVersion;
+            var isSslEnabled = projectConfig.IsSslEnabled;
             args.AddRange(new[]
             {
                 "--vmHostname", vmHostname,
-                "--RESTPort", restPort,
-                "--testScenariosNugetVersion", testScenariosNugetVersion,
-                "--HTMLPort", htmlPort,
-                "--MESVersion", mesVersion
+                "--RESTPort", restPort.ToString(),
+                "--testScenariosNugetVersion", testScenariosNugetVersion.ToString(),
+                "--HTMLPort", htmlPort.ToString(),
+                "--MESVersion", mesVersion.ToString()
             });
 
-            if (string.Equals(isSslEnabled, "True"))
+            if (isSslEnabled)
             {
                 args.Add("--IsSslEnabled");
             }
             
             #region version-specific bits
-            args.AddRange(new []{ "--targetFramework", Version.Parse(mesVersion).Major > 8 ? "net6.0" : "netcoreapp3.1" });
+            args.AddRange(new []{ "--targetFramework", mesVersion.Major > 8 ? "net6.0" : "netcoreapp3.1" });
             #endregion
 
             this.executedArgs = args.ToArray();

--- a/cmf-cli/Constants/CliConstants.cs
+++ b/cmf-cli/Constants/CliConstants.cs
@@ -1,5 +1,5 @@
 using System.Text.RegularExpressions;
-using Cmf.CLI.Enums;
+using Cmf.CLI.Core.Enums;
 
 namespace Cmf.CLI.Constants
 {

--- a/cmf-cli/Factories/PackageTypeFactory.cs
+++ b/cmf-cli/Factories/PackageTypeFactory.cs
@@ -74,10 +74,8 @@ namespace Cmf.CLI.Factories
 
         private static IPackageTypeHandler HelpHandler(CmfPackage cmfPackage)
         {
-            var projectConfig = FileSystemUtilities.ReadProjectConfig(ExecutionContext.Instance.FileSystem);
-            var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
+            var targetVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
             var minimumVersion = new Version("10.0.0");
-            var targetVersion = new Version(mesVersion!);
             if (targetVersion.CompareTo(minimumVersion) < 0)
             {
                 return new HelpGulpPackageTypeHandler(cmfPackage);
@@ -88,10 +86,8 @@ namespace Cmf.CLI.Factories
 
         private static IPackageTypeHandler HtmlHandler(CmfPackage cmfPackage)
         {
-            var projectConfig = FileSystemUtilities.ReadProjectConfig(ExecutionContext.Instance.FileSystem);
-            var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
+            var targetVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
             var minimumVersion = new Version("10.0.0");
-            var targetVersion = new Version(mesVersion!);
             if (targetVersion.CompareTo(minimumVersion) < 0)
             {
                 return new HtmlGulpPackageTypeHandler(cmfPackage);

--- a/cmf-cli/Handlers/PackageType/IoTPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/IoTPackageTypeHandler.cs
@@ -30,9 +30,7 @@ namespace Cmf.CLI.Handlers
         public IoTPackageTypeHandler(CmfPackage cmfPackage) : base(cmfPackage)
         {
             var minimumVersion = new Version("8.3.5");
-            var projectConfig = FileSystemUtilities.ReadProjectConfig(this.fileSystem);
-            var mesVersion = projectConfig.RootElement.GetProperty("MESVersion").GetString();
-            var targetVersion = new Version(mesVersion!);
+            var targetVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
             if (targetVersion.CompareTo(minimumVersion) < 0)
             {
                 Log.Debug(

--- a/cmf-cli/Handlers/PackageType/SecurityPortalPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/SecurityPortalPackageTypeHandler.cs
@@ -67,7 +67,7 @@ namespace Cmf.CLI.Handlers
                 string fileContent = ResourceUtilities.GetEmbeddedResourceContent($"{CliConstants.FolderTemplates}/{CmfPackage.PackageType}/{CliConstants.CmfPackagePresentationConfig}");
 
                 fileContent = fileContent.Replace(CliConstants.TokenPackageId, packageName);
-                fileContent = fileContent.Replace(CliConstants.StrategyPath, CliConstants.DefaultStrategyPath).Replace(CliConstants.Tenant, FileSystemUtilities.ReadProjectConfig(this.fileSystem).RootElement.GetProperty("Tenant").GetString());
+                fileContent = fileContent.Replace(CliConstants.StrategyPath, CliConstants.DefaultStrategyPath).Replace(CliConstants.Tenant, ExecutionContext.Instance.ProjectConfig.Tenant);
                 fileContent = fileContent.Replace(CliConstants.Strategy, type);
                 fileContent = fileContent.Replace(CliConstants.MetadataUrl, metadataUrl);
                 fileContent = fileContent.Replace(CliConstants.RedirectUrl, redirectUrl);

--- a/cmf-cli/resources/template_feed/test/Tests.Package/Cmf.Custom.Tests.IoT/AutomaticTests.json
+++ b/cmf-cli/resources/template_feed/test/Tests.Package/Cmf.Custom.Tests.IoT/AutomaticTests.json
@@ -1,24 +1,24 @@
 {
     "id": "REPLACE_IN_COMMANDLINE",
     "cache": "%TEST_DATA_LOCATION%/Packages",
-    "monitorApplication": "C:/IoT_ASMSMT/Monitor@7.0.1-71391/src/index.js",
+    "monitorApplication": "C:/path/Monitor@7.0.1-71391/src/index.js",
     "repository": {
       "type": "Npm",
       "settings": {
-        "url": "http://vm-asm:4873"
+        "url": "http://registry:4873"
       }
     },
     "system": {
-      "tenantName": "ASM",
+      "tenantName": "",
       "address": "localhost",
       "port": "6183",
       "timeout": 60000,
       "useSSL": "false",
       "authentication": {
-        "domain": "CMF",
+        "domain": "",
         "mode": "Password",
-        "password": "qaz123WSX",
-        "username": "cmfsu"
+        "password": "",
+        "username": ""
       }
     },
     "storage": {

--- a/core/Enums/AgentType.cs
+++ b/core/Enums/AgentType.cs
@@ -1,0 +1,16 @@
+namespace Cmf.CLI.Core.Enums;
+
+/// <summary>
+/// Azure DevOps Agent Type
+/// </summary>
+public enum AgentType
+{
+    /// <summary>
+    /// Cloud agents
+    /// </summary>
+    Cloud,
+    /// <summary>
+    /// Self-host agents
+    /// </summary>
+    Hosted
+}

--- a/core/Enums/BaseLayer.cs
+++ b/core/Enums/BaseLayer.cs
@@ -1,4 +1,4 @@
-namespace Cmf.CLI.Enums;
+namespace Cmf.CLI.Core.Enums;
 
 public enum BaseLayer
 {

--- a/core/Enums/RepositoryType.cs
+++ b/core/Enums/RepositoryType.cs
@@ -1,4 +1,4 @@
-namespace Cmf.CLI.Enums;
+namespace Cmf.CLI.Core.Enums;
 
 /// <summary>
 ///  the type of repository we are initializing

--- a/core/Objects/ExecutionContext.cs
+++ b/core/Objects/ExecutionContext.cs
@@ -26,6 +26,11 @@ namespace Cmf.CLI.Core.Objects
         /// The current execution RepositoriesConfig object
         /// </summary>
         public RepositoriesConfig RepositoriesConfig { get; set; }
+        
+        /// <summary>
+        /// the current repository's project config
+        /// </summary>
+        public ProjectConfig ProjectConfig { get; private set; }
 
         /// <summary>
         /// Get the current (executing) version of the CLI
@@ -46,7 +51,7 @@ namespace Cmf.CLI.Core.Objects
         /// true if we're running a development/unstable version 
         /// </summary>
         public static bool IsDevVersion => CurrentVersion.Contains("-");
-        
+
         /// <summary>
         /// IoC container for services
         /// NOTE: As we already have this ExecutionContext object, we're not enabling Hosting, but instead we are hosting the container in the execution context
@@ -70,6 +75,14 @@ namespace Cmf.CLI.Core.Objects
             // private constructor, can only obtain instance via the Instance property
             this.fileSystem = fileSystem;
             this.RepositoriesConfig = FileSystemUtilities.ReadRepositoriesConfig(fileSystem);
+            if (ServiceProvider != null)
+            {
+                IProjectConfigService pcs = ServiceProvider.GetService<IProjectConfigService>();
+                if (pcs != null)
+                {
+                    this.ProjectConfig = pcs.Load(fileSystem);
+                }
+            }
         }
 
         /// <summary>

--- a/core/Objects/ProjectConfig/ProjectConfig.cs
+++ b/core/Objects/ProjectConfig/ProjectConfig.cs
@@ -1,0 +1,5 @@
+namespace Cmf.CLI.Core.Objects;
+
+public class ProjectConfig : ProjectConfigV1
+{
+}

--- a/core/Objects/ProjectConfig/ProjectConfigV1.cs
+++ b/core/Objects/ProjectConfig/ProjectConfigV1.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Text.Json.Serialization;
+using Cmf.CLI.Core.Enums;
+using Newtonsoft.Json;
+using NuGet.Versioning;
+
+namespace Cmf.CLI.Core.Objects;
+
+public class ProjectConfigV1
+{
+    public string ProjectName { get; set; }
+    public RepositoryType RepositoryType { get; set; }
+    public BaseLayer BaseLayer { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri NPMRegistry { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri NuGetRegistry { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri AzureDevopsCollectionURL { get; set; }
+    public string AgentPool { get; set; }
+    public AgentType AgentType { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri RepositoryURL { get; set; }
+    public string EnvironmentName { get; set; }
+    public string DefaultDomain { get; set; }
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    public int? RESTPort { get; set; }
+    public string Tenant { get; set; }
+    public Version MESVersion { get; set; }
+    public SemanticVersion DevTasksVersion { get; set; }
+    public Version HTMLStarterVersion { get; set; }
+    public Version YoGeneratorVersion { get; set; }
+    public Version NGXSchematicsVersion { get; set; }
+    public Version NugetVersion { get; set; }
+    public Version TestScenariosNugetVersion { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(BooleanJsonConverter))]
+    public bool IsSslEnabled { get; set; }
+    public string vmHostname { get; set; }
+    public string DBReplica1 { get; set; }
+    public string DBReplica2 { get; set; }
+    public string DBServerOnline { get; set; }
+    public string DBServerODS { get; set; }
+    public string DBServerDWH { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri ReportServerURI { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(BooleanJsonConverter))]
+    public bool AlwaysOn { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri InstallationPath { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri DBBackupPath { get; set; }
+    [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
+    public Uri TemporaryPath { get; set; }
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    public int? HTMLPort { get; set; }
+    [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
+    public int? GatewayPort { get; set; }
+    public string ReleaseEnvironmentConfig { get; set; }
+    public Uri ISOLocation { get; set; }
+}
+
+public class BooleanJsonConverter : Newtonsoft.Json.JsonConverter
+{
+    public override bool CanRead => true;
+    public override bool CanWrite => false;
+
+    public override bool CanConvert( Type objectType )
+    {
+        if (Nullable.GetUnderlyingType(objectType) != null)
+        {
+            return Nullable.GetUnderlyingType(objectType) == typeof(bool);
+        }
+        return objectType == typeof(bool);
+    }
+
+    public override object ReadJson( JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer )
+    {
+        // handle True and False as old project configs have these values (remnant of powershell implementation)
+        switch ( reader.Value.ToString().ToLower().Trim() )
+        {
+            case "true":
+                return true;
+            case "false":
+                return false;
+            case "":
+                return null;
+        }
+
+        // If we reach here, we're pretty much going to throw an error so let's let Json.NET throw it's pretty-fied error message.
+        return new JsonSerializer().Deserialize( reader, objectType );
+    }
+
+    public override void WriteJson( JsonWriter writer, object value, JsonSerializer serializer )
+    {
+    }
+
+}

--- a/core/Objects/ProjectConfig/ProjectConfigV1.cs
+++ b/core/Objects/ProjectConfig/ProjectConfigV1.cs
@@ -9,8 +9,8 @@ namespace Cmf.CLI.Core.Objects;
 public class ProjectConfigV1
 {
     public string ProjectName { get; set; }
-    public RepositoryType RepositoryType { get; set; }
-    public BaseLayer BaseLayer { get; set; }
+    public RepositoryType? RepositoryType { get; set; }
+    public BaseLayer? BaseLayer { get; set; }
     [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
     public Uri NPMRegistry { get; set; }
     [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
@@ -57,6 +57,9 @@ public class ProjectConfigV1
     public int? GatewayPort { get; set; }
     public string ReleaseEnvironmentConfig { get; set; }
     public Uri ISOLocation { get; set; }
+
+    public string Organization { get; set; }
+    public string Product { get; set; }
 }
 
 public class BooleanJsonConverter : Newtonsoft.Json.JsonConverter

--- a/core/Objects/ProjectConfigService.cs
+++ b/core/Objects/ProjectConfigService.cs
@@ -17,9 +17,9 @@ public class ProjectConfigService : IProjectConfigService
     public ProjectConfig ProjectConfig { get; private set; }
     public ProjectConfig Load(IFileSystem fileSystem)
     {
-        if (ProjectConfig == null)
+        if (System.Environment.GetEnvironmentVariable("cmf_cli_internal_disable_projectconfig_cache") != null || ProjectConfig == null)
         {
-            if (isInsideProject == null)
+            if (System.Environment.GetEnvironmentVariable("cmf_cli_internal_disable_projectconfig_cache") != null || isInsideProject == null)
             {
                 var projectCfg = fileSystem.Path.Join(FileSystemUtilities.GetProjectRoot(fileSystem)?.FullName,
                     CoreConstants.ProjectConfigFileName);

--- a/core/Objects/ProjectConfigService.cs
+++ b/core/Objects/ProjectConfigService.cs
@@ -1,0 +1,41 @@
+using System.IO.Abstractions;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Utilities;
+using Newtonsoft.Json;
+
+namespace Cmf.CLI.Core.Objects;
+
+public interface IProjectConfigService
+{
+    public ProjectConfig ProjectConfig { get; }
+    public ProjectConfig Load(IFileSystem fileSystem);
+}
+
+public class ProjectConfigService : IProjectConfigService
+{
+    private bool? isInsideProject = null;
+    public ProjectConfig ProjectConfig { get; private set; }
+    public ProjectConfig Load(IFileSystem fileSystem)
+    {
+        if (ProjectConfig == null)
+        {
+            if (isInsideProject == null)
+            {
+                var projectCfg = fileSystem.Path.Join(FileSystemUtilities.GetProjectRoot(fileSystem)?.FullName,
+                    CoreConstants.ProjectConfigFileName);
+                if (!fileSystem.FileInfo.New(projectCfg).Exists)
+                {
+                    Log.Debug("Running outside a project repository");
+                    isInsideProject = false;
+                    return null;
+                }
+                Log.Debug($"Loading .project-config.json");
+                var json = fileSystem.File.ReadAllText(projectCfg);
+                this.ProjectConfig = JsonConvert.DeserializeObject<ProjectConfig>(json);
+                Log.Debug($"Loaded .project-config.json");
+                isInsideProject = true;
+            }
+        }
+        return this.ProjectConfig;
+    }
+}

--- a/core/Objects/RepositoriesConfig.cs
+++ b/core/Objects/RepositoriesConfig.cs
@@ -44,7 +44,10 @@ namespace Cmf.CLI.Core.Objects
         {
             if (reader.TokenType == JsonToken.String)
             {
-                return new Uri((serializer.Deserialize(reader, typeof(string)) as string)!, UriKind.Absolute);
+                var value = (serializer.Deserialize(reader, typeof(string)) as string);
+                if (string.IsNullOrEmpty(value))
+                    return null;
+                return new Uri(value, UriKind.Absolute);
             }
 
             return hasExistingValue ? existingValue : null;

--- a/core/StartupModule.cs
+++ b/core/StartupModule.cs
@@ -43,6 +43,7 @@ namespace Cmf.CLI.Core
                 .AddSingleton(npmClient ?? new NPMClient())
                 .AddSingleton<IVersionService>(new VersionService(packageName))
                 .AddSingleton<ITelemetryService>(new TelemetryService(packageName))
+                .AddSingleton<IProjectConfigService, ProjectConfigService>()
                 .BuildServiceProvider();
 
             // initialize Telemetry

--- a/core/Utilities/FileSystemUtilities.cs
+++ b/core/Utilities/FileSystemUtilities.cs
@@ -316,8 +316,10 @@ namespace Cmf.CLI.Utilities
         /// <returns></returns>
         public static JsonDocument ReadProjectConfig(IFileSystem fileSystem)
         {
+            Log.Debug("Loading .project-config.json (legacy mode)");
             var projectCfg = fileSystem.Path.Join(GetProjectRoot(fileSystem)?.FullName, CoreConstants.ProjectConfigFileName);
             var json = fileSystem.File.ReadAllText(projectCfg);
+            Log.Debug("Loaded .project-config.json (legacy mode)");
             return JsonDocument.Parse(json);
         }
 

--- a/core/Utilities/FileSystemUtilities.cs
+++ b/core/Utilities/FileSystemUtilities.cs
@@ -314,6 +314,7 @@ namespace Cmf.CLI.Utilities
         /// Reads the project configuration.
         /// </summary>
         /// <returns></returns>
+        [Obsolete("Use ExecutionContext.Instance.ProjectConfig")]
         public static JsonDocument ReadProjectConfig(IFileSystem fileSystem)
         {
             Log.Debug("Loading .project-config.json (legacy mode)");

--- a/tests/Specs/Bump.cs
+++ b/tests/Specs/Bump.cs
@@ -7,6 +7,7 @@ using Cmf.CLI.Factories;
 using Cmf.CLI.Handlers;
 using Cmf.CLI.Interfaces;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Xunit;
 
@@ -80,6 +81,9 @@ public class Bump
             }
         });
 
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IProjectConfigService>(new ProjectConfigService())
+            .BuildServiceProvider();
         ExecutionContext.Initialize(fileSystem);
 
         IFileInfo cmfpackageFile = fileSystem.FileInfo.New(cmfPackageJson);

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -5,6 +5,7 @@ using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Abstractions;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
 using System.Text.Json;
@@ -19,6 +20,7 @@ using Cmf.Common.Cli.TestUtilities;
 using Moq;
 using Newtonsoft.Json;
 using Cmf.CLI.Core.Commands;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace tests.Specs
 {
@@ -26,6 +28,12 @@ namespace tests.Specs
     {
         public New()
         {
+            System.Environment.SetEnvironmentVariable("cmf_cli_internal_disable_projectconfig_cache", "1");
+                
+            ExecutionContext.ServiceProvider = (new ServiceCollection())
+                .AddSingleton<IProjectConfigService>(new ProjectConfigService())
+                .BuildServiceProvider();
+
             var newCommand = new NewCommand();
             var cmd = new Command("x");
             newCommand.Configure(cmd);
@@ -968,6 +976,15 @@ namespace tests.Specs
             string packageFolder = "IoTData";
 
             TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+            var projCfg = Path.Join(dir, ".project-config.json");
+            if (File.Exists(projCfg))
+            {
+                File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                    .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                    .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                    .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                );
+            }
             RunNew(new IoTCommand(), packageId, dir);
 
             // Validate IoT Data
@@ -990,6 +1007,15 @@ namespace tests.Specs
             string packageFolder = "IoTPackages";
 
             TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+            var projCfg = Path.Join(dir, ".project-config.json");
+            if (File.Exists(projCfg))
+            {
+                File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                    .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                    .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                    .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                );
+            }
             RunNew(new IoTCommand(), packageId, dir);
 
             // Validate IoT Package
@@ -1058,6 +1084,16 @@ namespace tests.Specs
 
                 // place new fixture: an init'd repository
                 TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+                
+                var projCfg = Path.Join(dir, ".project-config.json");
+                if (File.Exists(projCfg))
+                {
+                    File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                        .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                        .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                        .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                    );
+                }
 
                 var newCommand = new TestCommand();
                 var cmd = new Command("x");
@@ -1112,6 +1148,15 @@ namespace tests.Specs
             {
                 Directory.SetCurrentDirectory(dir);
                 TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+                var projCfg = Path.Join(dir, ".project-config.json");
+                if (File.Exists(projCfg))
+                {
+                    File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                        .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                        .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                        .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                    );
+                }
 
                 RunNew(new BusinessCommand(), "Cmf.Custom.Business", scaffoldingDir: dir);
                 RunNew(new DataCommand(), "Cmf.Custom.Data", scaffoldingDir: dir);
@@ -1179,6 +1224,16 @@ namespace tests.Specs
             {
                 Directory.SetCurrentDirectory(dir);
                 TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+                
+                var projCfg = Path.Join(dir, ".project-config.json");
+                if (File.Exists(projCfg))
+                {
+                    File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                        .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                        .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                        .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                    );
+                }
 
                 RunFeature_WithoutPrefix(scaffoldingDir: dir);
                 var console = RunNew(new BusinessCommand(), "Cmf.Custom.Business", scaffoldingDir: dir, defaultAsserts: false);
@@ -1210,6 +1265,16 @@ namespace tests.Specs
                 Directory.SetCurrentDirectory(dir);
                 TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
                 TestUtilities.CopyFixture("featureBase", new DirectoryInfo(dir));
+                
+                var projCfg = Path.Join(dir, ".project-config.json");
+                if (File.Exists(projCfg))
+                {
+                    File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                        .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                        .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                        .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                    );
+                }
 
                 var pkgDir = Path.Join(dir, "Features", "TestFeature");
                 const string packageId = "Cmf.Custom.TestFeature.Business";
@@ -1246,6 +1311,16 @@ namespace tests.Specs
                 Directory.SetCurrentDirectory(dir);
                 TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
                 TestUtilities.CopyFixture("featureBase", new DirectoryInfo(dir));
+                
+                var projCfg = Path.Join(dir, ".project-config.json");
+                if (File.Exists(projCfg))
+                {
+                    File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                        .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                        .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                        .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                    );
+                }
 
                 var pkgDir = Path.Join(dir, "Features", "TestFeature");
                 const string packageId = "Cmf.Custom.TestFeature.Help";
@@ -1291,6 +1366,15 @@ namespace tests.Specs
                 Directory.SetCurrentDirectory(dir);
                 TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
                 TestUtilities.CopyFixture("featureBase", new DirectoryInfo(dir));
+                var projCfg = Path.Join(dir, ".project-config.json");
+                if (File.Exists(projCfg))
+                {
+                    File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                        .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                        .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                        .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                    );
+                }
 
                 var pkgDir = Path.Join(dir, "Features", "TestFeature");
                 const string packageId = "Cmf.Custom.TestFeature.HTML";
@@ -1322,6 +1406,15 @@ namespace tests.Specs
         {
             string dir = TestUtilities.GetTmpDirectory();
             TestUtilities.CopyFixture("new", new DirectoryInfo(dir));
+            var projCfg = Path.Join(dir, ".project-config.json");
+            if (File.Exists(projCfg))
+            {
+                File.WriteAllText(projCfg, File.ReadAllText(projCfg)
+                    .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                    .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                    .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
+                );
+            }
 
             Random rnd = new Random();
             string pkgVersion = $"{rnd.Next(10)}.{rnd.Next(10)}.{rnd.Next(10)}";
@@ -1363,9 +1456,14 @@ namespace tests.Specs
                             .Replace(@"""MESVersion"": ""8.2.0""", $@"""MESVersion"": ""{mesVersion}""")
                             .Replace(@"""BaseLayer"": ""MES""", $@"""BaseLayer"": ""{baseLayer}""")
                             .Replace(@"""RepositoryType"": ""Customization""", $@"""RepositoryType"": ""{repositoryType}""")
+                            .Replace("install_path", MockUnixSupport.Path(@"x:\install_path").Replace(@"\", @"\\"))
+                            .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
+                            .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
                         );
                     }
                 }
+
+                ExecutionContext.Initialize(new FileSystem());
 
                 var cmd = new Command("x");
                 newCommand.Configure(cmd);

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -12,7 +12,6 @@ using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Commands;
 using Cmf.CLI.Commands.New;
 using Cmf.CLI.Core.Objects;
-using Cmf.CLI.Enums;
 using FluentAssertions;
 using Xunit;
 using Assert = tests.AssertWithMessage;

--- a/tests/Specs/PackageTypeHandler.cs
+++ b/tests/Specs/PackageTypeHandler.cs
@@ -6,6 +6,7 @@ using Cmf.CLI.Handlers;
 using System;
 using System.IO;
 using System.IO.Abstractions.TestingHelpers;
+using Microsoft.Extensions.DependencyInjection;
 using tests.Objects;
 using Xunit;
 
@@ -13,6 +14,13 @@ namespace tests.Specs
 {
     public class PackageTypeHandler
     {
+        public PackageTypeHandler()
+        {
+            ExecutionContext.ServiceProvider = (new ServiceCollection())
+                .AddSingleton<IProjectConfigService>(new ProjectConfigService())
+                .BuildServiceProvider();
+        }
+        
         [Fact]
         public void GetContentToPack_WithNonExistentIgnoreFiles()
         {

--- a/tests/Specs/ProjectConfig.cs
+++ b/tests/Specs/ProjectConfig.cs
@@ -1,0 +1,66 @@
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using Cmf.CLI.Core.Objects;
+using FluentAssertions;
+using Xunit;
+
+namespace tests.Specs;
+
+public class ProjectConfig
+{
+    const string projCfgTpl = @"{
+          ""ProjectName"": ""ExampleProject"",
+          ""NPMRegistry"": ""http://npmrepo/"",
+          ""NuGetRegistry"": ""https://nuget-repo/"",
+          ""AzureDevopsCollectionURL"": ""https://azuredevops.server/ExampleCollection"",
+          ""AgentPool"": ""ExamplePool"",
+
+          ""RepositoryURL"": ""https://azuredevops.server/ExampleCollection/ExampleProject/_git/ExampleRepo"",
+          ""EnvironmentName"": ""ExampleIntegration"",
+          ""DefaultDomain"": ""AD"",
+          ""RESTPort"": ""443"",
+          ""Tenant"": ""ExampleClient"",
+          ""MESVersion"": ""9.0.5"",
+          ""DevTasksVersion"": ""{DEV_TASKS_VERSION}"",
+          ""HTMLStarterVersion"": ""8.0.0"",
+          ""YoGeneratorVersion"": ""8.1.1"",
+          ""NugetVersion"": ""9.0.5"",
+          ""TestScenariosNugetVersion"": ""9.0.5"",
+          ""IsSslEnabled"": ""True"",
+          ""vmHostname"": ""exampleintegration.int.local"",
+          ""DBReplica1"": ""SERV\\INSTANCE"",
+          ""DBReplica2"": ""SERV\\INSTANCE"",
+          ""DBServerOnline"": ""SERV\\INSTANCE"",
+          ""DBServerODS"": ""SERV\\INSTANCE"",
+          ""DBServerDWH"": ""SERV\\INSTANCE"",
+          ""ReportServerURI"": ""http://serv/Reports"",
+          ""AlwaysOn"": ""False"",
+          ""InstallationPath"": """",
+          ""DBBackupPath"": """",
+          ""TemporaryPath"": """",
+          ""HTMLPort"": ""443"",
+          ""GatewayPort"": ""443"",
+          ""ReleaseEnvironmentConfig"": ""ExampleIntegration_Development_parameters.json""
+        }";
+    
+    [Theory]
+    [InlineData("9.0.0")]
+    [InlineData("9.0.0-5")]
+    [InlineData("9.0.0-pre.5")]
+    public void ClassicProjectConfig(string devTasksVersion)
+    {
+        var projConfig = projCfgTpl.Replace("{DEV_TASKS_VERSION}", devTasksVersion);
+        
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { "/.project-config.json", new MockFileData(projConfig)}
+        });
+
+        var pc = (new ProjectConfigService()).Load(fileSystem);
+
+        pc.Should().NotBeNull("project config was not loaded");
+        pc.HTMLPort.Should().Be(443, "could not load HTML port");
+        pc.AlwaysOn.Should().BeFalse("AlwaysOn should be false");
+        pc.IsSslEnabled.Should().BeTrue("IsSslEnabled should be true");
+    }
+}


### PR DESCRIPTION
Deprecate the use of the ReadProjectConfig utility.