### PR TITLE
Development 84981 start end method validator

### DIFF
--- a/cmf-cli/Commands/build/business/BusinessCommand.cs
+++ b/cmf-cli/Commands/build/business/BusinessCommand.cs
@@ -1,8 +1,5 @@
-﻿using System.CommandLine;
-using System.CommandLine.NamingConventionBinder;
-using System.IO.Abstractions;
-using Cmf.CLI.Core.Attributes;
-using Cmf.CLI.Core.Commands;
+﻿using Cmf.CLI.Core.Attributes;
+using System.CommandLine;
 
 namespace Cmf.CLI.Commands.build.business
 {
@@ -10,14 +7,12 @@ namespace Cmf.CLI.Commands.build.business
 	/// "new" command group
 	/// </summary>
 	[CmfCommand("business", Id = "build_business", ParentId = "build")]
-	public class BusinessCommand : TemplateCommand
+	public class BusinessCommand : BaseCommand
 	{
-		private Command _cmd;
-
 		/// <summary>
 		/// constructor
 		/// </summary>
-		public BusinessCommand() : base("business")
+		public BusinessCommand()
 		{
 		}
 
@@ -26,16 +21,6 @@ namespace Cmf.CLI.Commands.build.business
 		/// </summary>
 		/// <param name="cmd"></param>
 		public override void Configure(Command cmd)
-		{
-			_cmd = cmd;
-			cmd.Handler = CommandHandler.Create(Execute);
-		}
-
-		/// <summary>
-		/// Execute command
-		/// </summary>
-		/// <param name="reset"></param>
-		public void Execute()
 		{
 		}
 	}

--- a/cmf-cli/Commands/build/business/BusinessCommand.cs
+++ b/cmf-cli/Commands/build/business/BusinessCommand.cs
@@ -1,0 +1,42 @@
+﻿using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Commands;
+
+namespace Cmf.CLI.Commands.build.business
+{
+	/// <summary>
+	/// "new" command group
+	/// </summary>
+	[CmfCommand("business", Id = "build_business", ParentId = "build")]
+	public class BusinessCommand : TemplateCommand
+	{
+		private Command _cmd;
+
+		/// <summary>
+		/// constructor
+		/// </summary>
+		public BusinessCommand() : base("business")
+		{
+		}
+
+		/// <summary>
+		/// Configure command
+		/// </summary>
+		/// <param name="cmd"></param>
+		public override void Configure(Command cmd)
+		{
+			_cmd = cmd;
+			cmd.Handler = CommandHandler.Create(Execute);
+		}
+
+		/// <summary>
+		/// Execute command
+		/// </summary>
+		/// <param name="reset"></param>
+		public void Execute()
+		{
+		}
+	}
+}

--- a/cmf-cli/Commands/build/business/ValidateStartAndEndMethodsCommand.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartAndEndMethodsCommand.cs
@@ -1,0 +1,71 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+using Cmf.CLI.Core.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.CommandLine.Parsing;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Text;
+
+namespace Cmf.CLI.Commands.build.business;
+
+/// <summary>
+/// This command validates StartMethods and EndMethods
+/// </summary>
+/// <seealso cref="PowershellCommand" />
+[CmfCommand(name: "validateStartAndEndMethods", ParentId = "build_business", Id = "build_business_validateStartAndEndMethods")]
+public class ValidateStartAndEndMethodsCommand : BaseCommand
+{
+	public ValidateStartAndEndMethodsCommand()
+	{
+	}
+
+	public ValidateStartAndEndMethodsCommand(IFileSystem fileSystem) : base(fileSystem)
+	{
+	}
+
+	/// <summary>
+	/// configure the command
+	/// </summary>
+	/// <param name="cmd"></param>
+	public override void Configure(Command cmd)
+	{
+		cmd.AddArgument(new Argument<string>(
+			name: "solutionPath",
+			description: "The solution path"
+		));
+
+		var filesArgument = new Argument<string[]>(
+			name: "files",
+			description: "The files to validate"
+		);
+		filesArgument.Arity = ArgumentArity.ZeroOrMore;
+
+		cmd.AddArgument(filesArgument);
+
+		cmd.Handler = CommandHandler.Create<string, string[]>(Execute);
+	}
+
+	/// <summary>
+	/// Executes this instance.
+	/// </summary>
+	public void Execute(string solutionPath, string[] files)
+	{
+		if (string.IsNullOrEmpty(solutionPath))
+		{
+			return;
+		}
+
+		Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+		// TODO: Can be replaced when cli implements Dependency injection
+		var services = new ServiceCollection();
+		services.AddProcessors();
+		var serviceProvider = services.BuildServiceProvider();
+
+		var solutionValidator = new SolutionValidator(serviceProvider, solutionPath, files);
+		solutionValidator.ValidateSolution().Wait();
+	}
+}

--- a/cmf-cli/Commands/build/business/ValidateStartAndEndMethodsCommand.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartAndEndMethodsCommand.cs
@@ -1,12 +1,11 @@
 ﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
 using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 using Cmf.CLI.Core.Attributes;
 using Microsoft.Extensions.DependencyInjection;
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
-using System.CommandLine.Parsing;
 using System.IO.Abstractions;
-using System.Linq;
 using System.Text;
 
 namespace Cmf.CLI.Commands.build.business;
@@ -40,8 +39,10 @@ public class ValidateStartAndEndMethodsCommand : BaseCommand
 		var filesArgument = new Argument<string[]>(
 			name: "files",
 			description: "The files to validate"
-		);
-		filesArgument.Arity = ArgumentArity.ZeroOrMore;
+		)
+		{
+			Arity = ArgumentArity.ZeroOrMore
+		};
 
 		cmd.AddArgument(filesArgument);
 
@@ -65,7 +66,7 @@ public class ValidateStartAndEndMethodsCommand : BaseCommand
 		services.AddProcessors();
 		var serviceProvider = services.BuildServiceProvider();
 
-		var solutionValidator = new SolutionValidator(serviceProvider, solutionPath, files);
+		var solutionValidator = new SolutionValidator(serviceProvider.GetService<IProcessorFactory>(), solutionPath, files);
 		solutionValidator.ValidateSolution().Wait();
 	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/IValidateLogger.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/IValidateLogger.cs
@@ -1,0 +1,7 @@
+﻿namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions
+{
+	public interface IValidateLogger
+	{
+		void Warning(string message);
+	}
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IBaseProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IBaseProcessor.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
@@ -10,7 +11,7 @@ internal interface IBaseProcessor
 
     string StartEndMethodString { get; }
 
-    void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType);
+    void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType, ClassType classType);
 
     void ValidateParameterCount(ArgumentListSyntax statementArguments);
 

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IBaseProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IBaseProcessor.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+
+internal interface IBaseProcessor
+{
+    bool IsStartMethod { get; }
+
+    string StartEndMethodString { get; }
+
+    void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType);
+
+    void ValidateParameterCount(ArgumentListSyntax statementArguments);
+
+    void Process(SyntaxNode statement);
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IBaseProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IBaseProcessor.cs
@@ -7,13 +7,13 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.P
 
 internal interface IBaseProcessor
 {
-    bool IsStartMethod { get; }
+	bool IsStartMethod { get; }
 
-    string StartEndMethodString { get; }
+	string StartEndMethodString { get; }
 
-    void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType, ClassType classType);
+	void SetValues(ClassType classType, string namespaceName, string className, string methodName, string outputType, IEnumerable<ParameterSyntax> parameters, SyntaxNode statementToProcess);
 
-    void ValidateParameterCount(ArgumentListSyntax statementArguments);
+	void ValidateParameterCount(ArgumentListSyntax statementArguments);
 
-    void Process(SyntaxNode statement);
+	void Process();
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IOrchestrationEndMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IOrchestrationEndMethodProcessor.cs
@@ -1,0 +1,5 @@
+﻿namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+
+internal interface IOrchestrationEndMethodProcessor : IBaseProcessor
+{
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IOrchestrationStartMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IOrchestrationStartMethodProcessor.cs
@@ -1,0 +1,5 @@
+﻿namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+
+internal interface IOrchestrationStartMethodProcessor : IBaseProcessor
+{
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IProcessorFactory.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Abstractions/Processors/IProcessorFactory.cs
@@ -1,0 +1,13 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors
+{
+	internal interface IProcessorFactory
+	{
+		public T Create<T>() where T : IBaseProcessor;
+
+		public IBaseProcessor Create(ClassType classType, string namespaceName, string className, string methodName, string outputType, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxNode statement);
+	}
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Enums/ClassType.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Enums/ClassType.cs
@@ -1,0 +1,10 @@
+﻿namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+
+public enum ClassType
+{
+    Controller,
+    Orchestration,
+    EntityType,
+    EntityTypeCollection,
+    Other
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Enums/ClassType.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Enums/ClassType.cs
@@ -2,9 +2,8 @@
 
 public enum ClassType
 {
-    Controller,
-    Orchestration,
-    EntityType,
-    EntityTypeCollection,
-    Other
+	ControllerOrOrchestration,
+	EntityType,
+	EntityTypeCollection,
+	Other
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/ErrorMessages.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/ErrorMessages.cs
@@ -2,44 +2,45 @@
 
 public static class ErrorMessages
 {
-    /// <summary>
-    /// {0} -> StartMethod or EndMethod
-    /// {1} -> namespace name
-    /// {2} -> class name
-    /// {3} -> method name
-    /// {4} -> current number of parameters
-    /// {5} -> expected number of parameters
-    /// </summary>
-    public static string MethodHasIncorrectNumberOfParameters => "{0}, File: {2}, Method: {3}, Issue: Incorrect number of parameters parameters. Current: {4} :: Expected {5}.";
+	/// <summary>
+	/// {0} -> StartMethod or EndMethod
+	/// {1} -> class name
+	/// {2} -> method name
+	/// {3} -> current number of parameters
+	/// {4} -> expected number of parameters
+	/// </summary>
+	public static string MethodHasIncorrectNumberOfParameters => "{0}, File: {1}, Method: {2}, Issue: Incorrect number of parameters parameters. Current: {3} :: Expected {4}.";
 
-    /// <summary>
-    /// {0} -> StartMethod or EndMethod
-    /// {1} -> namespace name
-    /// {2} -> class name
-    /// {3} -> method name
-    /// </summary>
-    public static string MethodHasNoParameters => "{0}, File: {2}, Method: {3}, Issue: No parameters.";
+	/// <summary>
+	/// {0} -> StartMethod or EndMethod
+	/// {2} -> class name
+	/// {3} -> method name
+	/// </summary>
+	public static string MethodHasNoParameters => "{0}, File: {1}, Method: {2}, Issue: No parameters.";
 
-    /// <summary>
-    /// {0} -> StartMethod or EndMethod
-    /// {1} -> namespace name
-    /// {2} -> class name
-    /// {3} -> method name
-    /// {4} -> method name
-    /// </summary>
-    public static string MethodParameterMissingOrIncorrectlyNamed => "{0}, File: {2}, Method: {3}, Issue: Missing parameter {4}.";
+	/// <summary>
+	/// {0} -> StartMethod or EndMethod
+	/// {1} -> class name
+	/// {2} -> method name
+	/// {3} -> method name
+	/// </summary>
+	public static string MethodParameterMissingOrIncorrectlyNamed => "{0}, File: {1}, Method: {2}, Issue: Missing parameter {3}.";
 
-    /// <summary>
-    /// {0} -> namespace name
-    /// {1} -> class name
-    /// {2} -> method name
-    /// </summary>
-    public static string StartMethodDoesNotContainMethodName => "StartMethod, File: {1}, Method: {2}, Issue: Does not contain a method name.";
+	/// <summary>
+	/// {0} -> class name
+	/// {1} -> method name
+	/// </summary>
+	public static string StartMethodDoesNotContainMethodName => "StartMethod, File: {0}, Method: {1}, Issue: Does not contain a method name.";
 
-    /// <summary>
-    /// {0} -> namespace name
-    /// {1} -> class name
-    /// {2} -> method name
-    /// </summary>
-    public static string StartMethodMethodNameIsIncorrect => "StartMethod, File: {1}, Method: {2}, Issue: Incorrect method name.";
+	/// <summary>
+	/// {0} -> class name
+	/// {1} -> method name
+	/// </summary>
+	public static string StartMethodMethodNameIsIncorrect => "StartMethod, File: {0}, Method: {1}, Issue: Incorrect method name.";
+
+	/// <summary>
+	/// {0} -> class name
+	/// {1} -> method name
+	/// </summary>
+	public static string InputOutputMethodDoNotCoincide => "File: {0}, Method: {1}, Issue: InputObject, OutputObject are different.";
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/ErrorMessages.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/ErrorMessages.cs
@@ -1,0 +1,45 @@
+﻿namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+
+public static class ErrorMessages
+{
+    /// <summary>
+    /// {0} -> StartMethod or EndMethod
+    /// {1} -> namespace name
+    /// {2} -> class name
+    /// {3} -> method name
+    /// {4} -> current number of parameters
+    /// {5} -> expected number of parameters
+    /// </summary>
+    public static string MethodHasIncorrectNumberOfParameters => "{0}, File: {2}, Method: {3}, Issue: Incorrect number of parameters parameters. Current: {4} :: Expected {5}.";
+
+    /// <summary>
+    /// {0} -> StartMethod or EndMethod
+    /// {1} -> namespace name
+    /// {2} -> class name
+    /// {3} -> method name
+    /// </summary>
+    public static string MethodHasNoParameters => "{0}, File: {2}, Method: {3}, Issue: No parameters.";
+
+    /// <summary>
+    /// {0} -> StartMethod or EndMethod
+    /// {1} -> namespace name
+    /// {2} -> class name
+    /// {3} -> method name
+    /// {4} -> method name
+    /// </summary>
+    public static string MethodParameterMissingOrIncorrectlyNamed => "{0}, File: {2}, Method: {3}, Issue: Missing parameter {4}.";
+
+    /// <summary>
+    /// {0} -> namespace name
+    /// {1} -> class name
+    /// {2} -> method name
+    /// </summary>
+    public static string StartMethodDoesNotContainMethodName => "StartMethod, File: {1}, Method: {2}, Issue: Does not contain a method name.";
+
+    /// <summary>
+    /// {0} -> namespace name
+    /// {1} -> class name
+    /// {2} -> method name
+    /// </summary>
+    public static string StartMethodMethodNameIsIncorrect => "StartMethod, File: {1}, Method: {2}, Issue: Incorrect method name.";
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ChildSyntaxListExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ChildSyntaxListExtensions.cs
@@ -8,25 +8,25 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class ChildSyntaxListExtensions
 {
-    internal static KeyValuePair<string, string> GetParameterNameValuePair(this ParameterSyntax parameterSyntax, bool isEntityType)
-    {
-        string key;
-        string value;
+	internal static KeyValuePair<string, string> GetParameterNameValuePair(this ParameterSyntax parameterSyntax, bool isEntityType)
+	{
+		string key;
+		string value;
 
-        if (isEntityType)
-        {
+		if (isEntityType)
+		{
 			value = parameterSyntax.ChildTokens().Where(y => y.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault().Text;
 			key = value.ToUpper(1);
 		}
 		else
-        {
+		{
 			key = parameterSyntax.ChildNodes()?.Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault()?.ChildTokens().FirstOrDefault().Text;
 			value = parameterSyntax.ChildTokens().Where(y => y.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault().Text;
 
-            // In this case the type of the parameter is a int, long, etc.
+			// In this case the type of the parameter is a int, long, etc.
 			key ??= value.ToUpper(1);
-		}		
+		}
 
-        return new KeyValuePair<string, string>(key, value);
-    }
+		return new KeyValuePair<string, string>(key, value);
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ChildSyntaxListExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ChildSyntaxListExtensions.cs
@@ -8,12 +8,24 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class ChildSyntaxListExtensions
 {
-    internal static KeyValuePair<string, string> GetParameterNameValuePair(this ParameterSyntax parameterSyntax)
+    internal static KeyValuePair<string, string> GetParameterNameValuePair(this ParameterSyntax parameterSyntax, bool isEntityType)
     {
-        var key = parameterSyntax.ChildNodes()?.Where(x => x.IsKind(SyntaxKind.IdentifierName) || x.IsKind(SyntaxKind.PredefinedType)).FirstOrDefault()?.ChildTokens().FirstOrDefault().Text;
-        var value = parameterSyntax.ChildTokens().Where(y => y.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault().Text;
+        string key;
+        string value;
 
-        key ??= string.Empty;
+        if (isEntityType)
+        {
+			value = parameterSyntax.ChildTokens().Where(y => y.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault().Text;
+			key = value.ToUpper(1);
+		}
+		else
+        {
+			key = parameterSyntax.ChildNodes()?.Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault()?.ChildTokens().FirstOrDefault().Text;
+			value = parameterSyntax.ChildTokens().Where(y => y.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault().Text;
+
+            // In this case the type of the parameter is a int, long, etc.
+			key ??= value.ToUpper(1);
+		}		
 
         return new KeyValuePair<string, string>(key, value);
     }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ChildSyntaxListExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ChildSyntaxListExtensions.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+internal static class ChildSyntaxListExtensions
+{
+    internal static KeyValuePair<string, string> GetParameterNameValuePair(this ParameterSyntax parameterSyntax)
+    {
+        var key = parameterSyntax.ChildNodes()?.Where(x => x.IsKind(SyntaxKind.IdentifierName) || x.IsKind(SyntaxKind.PredefinedType)).FirstOrDefault()?.ChildTokens().FirstOrDefault().Text;
+        var value = parameterSyntax.ChildTokens().Where(y => y.IsKind(SyntaxKind.IdentifierToken)).FirstOrDefault().Text;
+
+        key ??= string.Empty;
+
+        return new KeyValuePair<string, string>(key, value);
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ClassDeclarationSyntaxExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ClassDeclarationSyntaxExtensions.cs
@@ -5,29 +5,29 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class ClassDeclarationSyntaxExtensions
 {
-    public static ClassType GetClassType(this ClassDeclarationSyntax classDeclaration)
-    {
-        var name = classDeclaration.Identifier.ToString();
+	public static ClassType GetClassType(this ClassDeclarationSyntax classDeclaration)
+	{
+		var name = classDeclaration.Identifier.ToString();
 
-        if (name.EndsWith("Controller") &&
-            classDeclaration.BaseList != null &&
-            classDeclaration.BaseList.Types.Count > 0 &&
-            classDeclaration.BaseList.Types[0].Type.ToString().Equals("ControllerBase"))
-        {
-            return ClassType.Controller;
-        }
+		if (name.EndsWith("Controller") &&
+			classDeclaration.BaseList != null &&
+			classDeclaration.BaseList.Types.Count > 0 &&
+			classDeclaration.BaseList.Types[0].Type.ToString().Equals("ControllerBase"))
+		{
+			return ClassType.ControllerOrOrchestration;
+		}
 
-        if (name.EndsWith("Orchestration"))
-        {
-            return ClassType.Orchestration;
-        }
+		if (name.EndsWith("Orchestration"))
+		{
+			return ClassType.ControllerOrOrchestration;
+		}
 
-        if (classDeclaration.BaseList != null && classDeclaration.BaseList.Types.Count > 0)
-        {
-            // TODO: EntityTypeCollection
-            // TODO: EntityType
-        }
+		if (classDeclaration.BaseList != null && classDeclaration.BaseList.Types.Count > 0)
+		{
+			// TODO: EntityTypeCollection
+			// TODO: EntityType
+		}
 
-        return ClassType.Other;
-    }
+		return ClassType.Other;
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ClassDeclarationSyntaxExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ClassDeclarationSyntaxExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+internal static class ClassDeclarationSyntaxExtensions
+{
+    public static ClassType GetClassType(this ClassDeclarationSyntax classDeclaration)
+    {
+        var name = classDeclaration.Identifier.ToString();
+
+        if (name.EndsWith("Controller") &&
+            classDeclaration.BaseList != null &&
+            classDeclaration.BaseList.Types.Count > 0 &&
+            classDeclaration.BaseList.Types[0].Type.ToString().Equals("ControllerBase"))
+        {
+            return ClassType.Controller;
+        }
+
+        if (name.EndsWith("Orchestration"))
+        {
+            return ClassType.Orchestration;
+        }
+
+        if (classDeclaration.BaseList != null && classDeclaration.BaseList.Types.Count > 0)
+        {
+            // TODO: EntityTypeCollection
+            // TODO: EntityType
+        }
+
+        return ClassType.Other;
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ListExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ListExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+internal static class ListExtensions
+{
+    internal static bool ContainsKeyValue<TKey, TValue>(this IList<KeyValuePair<TKey, TValue>> list, TKey? key, TValue? value)
+    {
+        if (key is null || value is null)
+            return false;
+
+        return list.Contains(new KeyValuePair<TKey, TValue>(key, value));
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ListExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ListExtensions.cs
@@ -8,13 +8,13 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class ListExtensions
 {
-    internal static bool ContainsKeyValue<TKey, TValue>(this IList<KeyValuePair<TKey, TValue>> list, TKey? key, TValue? value)
-    {
-        if (key is null || value is null)
-            return false;
+	internal static bool ContainsKeyValue<TKey, TValue>(this IList<KeyValuePair<TKey, TValue>> list, TKey? key, TValue? value)
+	{
+		if (key is null || value is null)
+			return false;
 
-        return list.Contains(new KeyValuePair<TKey, TValue>(key, value));
-    }
+		return list.Contains(new KeyValuePair<TKey, TValue>(key, value));
+	}
 
 	internal static bool ContainsInputObject(this SeparatedSyntaxList<ParameterSyntax> list)
 	{
@@ -25,7 +25,7 @@ internal static class ListExtensions
 			if (identifierToken != null && identifierToken.ToString().EndsWith("Input"))
 				return true;
 		}
-		
-		return false;		
+
+		return false;
 	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ListExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ListExtensions.cs
@@ -1,4 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
@@ -11,4 +15,17 @@ internal static class ListExtensions
 
         return list.Contains(new KeyValuePair<TKey, TValue>(key, value));
     }
+
+	internal static bool ContainsInputObject(this SeparatedSyntaxList<ParameterSyntax> list)
+	{
+		foreach (var parameter in list)
+		{
+			var identifierToken = parameter.ChildNodes()?.Where(x => x.IsKind(SyntaxKind.IdentifierName)).FirstOrDefault()?.ChildTokens().FirstOrDefault().Text;
+
+			if (identifierToken != null && identifierToken.ToString().EndsWith("Input"))
+				return true;
+		}
+		
+		return false;		
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ServiceCollectionExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+internal static class ServiceCollectionExtensions
+{
+    public static void AddProcessors(this ServiceCollection services)
+    {
+        // Add classes
+        services.AddScoped<IOrchestrationStartMethodProcessor, OrchestrationStartMethodProcessor>();
+        services.AddScoped<IOrchestrationEndMethodProcessor, OrchestrationEndMethodProcessor>();
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ServiceCollectionExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ServiceCollectionExtensions.cs
@@ -6,10 +6,13 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class ServiceCollectionExtensions
 {
-    public static void AddProcessors(this ServiceCollection services)
-    {
-        // Add classes
-        services.AddScoped<IOrchestrationStartMethodProcessor, OrchestrationStartMethodProcessor>();
-        services.AddScoped<IOrchestrationEndMethodProcessor, OrchestrationEndMethodProcessor>();
-    }
+	public static void AddProcessors(this ServiceCollection services)
+	{
+		// Add factories
+		services.AddScoped<IProcessorFactory, ProcessorFactory>();
+
+		// Add classes
+		services.AddScoped<IOrchestrationStartMethodProcessor, OrchestrationStartMethodProcessor>();
+		services.AddScoped<IOrchestrationEndMethodProcessor, OrchestrationEndMethodProcessor>();
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ServiceCollectionExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
 using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,10 +10,13 @@ internal static class ServiceCollectionExtensions
 	public static void AddProcessors(this ServiceCollection services)
 	{
 		// Add factories
-		services.AddScoped<IProcessorFactory, ProcessorFactory>();
+		services.AddSingleton<IProcessorFactory, ProcessorFactory>();
 
 		// Add classes
-		services.AddScoped<IOrchestrationStartMethodProcessor, OrchestrationStartMethodProcessor>();
-		services.AddScoped<IOrchestrationEndMethodProcessor, OrchestrationEndMethodProcessor>();
+		services.AddTransient<IOrchestrationStartMethodProcessor, OrchestrationStartMethodProcessor>();
+		services.AddTransient<IOrchestrationEndMethodProcessor, OrchestrationEndMethodProcessor>();
+
+		// Add logger
+		services.AddSingleton<IValidateLogger, ValidateLogger>();
 	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
@@ -17,7 +17,7 @@ internal static class StringExtensions
 	private static string ToUpperOrLower(string value, int numberOfChars, bool toLower)
 	{
 		StringBuilder sb = new();
-		int i;		
+		int i;
 
 		for (i = 0; i < numberOfChars && i < value.Length; i++)
 		{

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Text;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+internal static class StringExtensions
+{
+    public static string ToLower(this string value, int numberOfChars)
+    {
+        int i = 0;
+        StringBuilder sb = new StringBuilder();
+
+        for (i = 0; i < numberOfChars && i < value.Length; i++)
+        {
+            sb.Append(char.ToLower(value[i]));
+        }
+
+        sb.Append(value.Substring(i));
+
+        return sb.ToString();
+    }
+
+    public static bool EqualsToItselfOrNameOfItself(this string value1, string value2)
+    {
+        return value1.Equals(value2) || value1.Equals($"nameof({value2})");
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
@@ -4,20 +4,20 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class StringExtensions
 {
-    public static string ToLower(this string value, int numberOfChars)
-    {
+	public static string ToLower(this string value, int numberOfChars)
+	{
 		return ToUpperOrLower(value, numberOfChars, true);
-    }
+	}
 
 	public static string ToUpper(this string value, int numberOfChars)
 	{
 		return ToUpperOrLower(value, numberOfChars, false);
 	}
 
-    private static string ToUpperOrLower(string value, int numberOfChars, bool toLower)
-    {
-		int i = 0;
-		StringBuilder sb = new StringBuilder();
+	private static string ToUpperOrLower(string value, int numberOfChars, bool toLower)
+	{
+		StringBuilder sb = new();
+		int i;		
 
 		for (i = 0; i < numberOfChars && i < value.Length; i++)
 		{
@@ -28,7 +28,7 @@ internal static class StringExtensions
 			else
 			{
 				sb.Append(char.ToUpper(value[i]));
-			}			
+			}
 		}
 
 		sb.Append(value.Substring(i));
@@ -37,7 +37,7 @@ internal static class StringExtensions
 	}
 
 	public static bool EqualsToItselfOrNameOfItself(this string value1, string value2)
-    {
-        return value1.Equals(value2) || value1.Equals($"nameof({value2})");
-    }
+	{
+		return value1.Equals(value2) || value1.Equals($"nameof({value2})");
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/StringExtensions.cs
@@ -6,20 +6,37 @@ internal static class StringExtensions
 {
     public static string ToLower(this string value, int numberOfChars)
     {
-        int i = 0;
-        StringBuilder sb = new StringBuilder();
-
-        for (i = 0; i < numberOfChars && i < value.Length; i++)
-        {
-            sb.Append(char.ToLower(value[i]));
-        }
-
-        sb.Append(value.Substring(i));
-
-        return sb.ToString();
+		return ToUpperOrLower(value, numberOfChars, true);
     }
 
-    public static bool EqualsToItselfOrNameOfItself(this string value1, string value2)
+	public static string ToUpper(this string value, int numberOfChars)
+	{
+		return ToUpperOrLower(value, numberOfChars, false);
+	}
+
+    private static string ToUpperOrLower(string value, int numberOfChars, bool toLower)
+    {
+		int i = 0;
+		StringBuilder sb = new StringBuilder();
+
+		for (i = 0; i < numberOfChars && i < value.Length; i++)
+		{
+			if (toLower)
+			{
+				sb.Append(char.ToLower(value[i]));
+			}
+			else
+			{
+				sb.Append(char.ToUpper(value[i]));
+			}			
+		}
+
+		sb.Append(value.Substring(i));
+
+		return sb.ToString();
+	}
+
+	public static bool EqualsToItselfOrNameOfItself(this string value1, string value2)
     {
         return value1.Equals(value2) || value1.Equals($"nameof({value2})");
     }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/SyntaxNodeExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/SyntaxNodeExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Linq;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+internal static class SyntaxNodeExtensions
+{
+    internal static bool IsStartMethod(this SyntaxNode statement)
+    {
+        return statement.IsKind(SyntaxKind.ExpressionStatement) &&
+            statement.ToString().Contains("StartMethod");
+    }
+
+    internal static bool IsEndMethod(this SyntaxNode statement)
+    {
+        return statement.IsKind(SyntaxKind.ExpressionStatement) &&
+            statement.ToString().Contains("EndMethod");
+    }
+
+    internal static bool IsTryStatement(this SyntaxNode statement)
+    {
+        return statement.IsKind(SyntaxKind.TryStatement);
+    }
+
+    internal static SyntaxNode GetEndMethodExpression(this SyntaxNode statement)
+    {
+        return statement.ChildNodes()
+            .Where(x => x.IsKind(SyntaxKind.Block))
+            .SelectMany(x => x.ChildNodes())
+            .Where(x => x.IsKind(SyntaxKind.ExpressionStatement) && x.ToString().Contains("EndMethod"))
+            .FirstOrDefault();
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/SyntaxNodeExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/SyntaxNodeExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using System.Linq;
 
 namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/SyntaxNodeExtensions.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Extensions/SyntaxNodeExtensions.cs
@@ -6,29 +6,20 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 internal static class SyntaxNodeExtensions
 {
-    internal static bool IsStartMethod(this SyntaxNode statement)
-    {
-        return statement.IsKind(SyntaxKind.ExpressionStatement) &&
-            statement.ToString().Contains("StartMethod");
-    }
+	internal static bool IsStartMethod(this SyntaxNode statement)
+	{
+		return statement.IsKind(SyntaxKind.ExpressionStatement) &&
+			statement.ToString().Contains("StartMethod");
+	}
 
-    internal static bool IsEndMethod(this SyntaxNode statement)
-    {
-        return statement.IsKind(SyntaxKind.ExpressionStatement) &&
-            statement.ToString().Contains("EndMethod");
-    }
+	internal static bool IsEndMethod(this SyntaxNode statement)
+	{
+		return statement.IsKind(SyntaxKind.ExpressionStatement) &&
+			statement.ToString().Contains("EndMethod");
+	}
 
-    internal static bool IsTryStatement(this SyntaxNode statement)
-    {
-        return statement.IsKind(SyntaxKind.TryStatement);
-    }
-
-    internal static SyntaxNode GetEndMethodExpression(this SyntaxNode statement)
-    {
-        return statement.ChildNodes()
-            .Where(x => x.IsKind(SyntaxKind.Block))
-            .SelectMany(x => x.ChildNodes())
-            .Where(x => x.IsKind(SyntaxKind.ExpressionStatement) && x.ToString().Contains("EndMethod"))
-            .FirstOrDefault();
-    }
+	internal static bool IsTryStatement(this SyntaxNode statement)
+	{
+		return statement.IsKind(SyntaxKind.TryStatement);
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/BaseProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/BaseProcessor.cs
@@ -1,0 +1,98 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+using Cmf.CLI.Core;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
+
+internal abstract class BaseProcessor : IBaseProcessor
+{
+    protected string _namespaceName = string.Empty;
+    protected string _className = string.Empty;
+    protected string _methodName = string.Empty;
+    protected List<KeyValuePair<string, string>> _parameterNames = new();
+    protected string _outputType = string.Empty;
+
+    internal BaseProcessor()
+    {
+    }
+
+    public abstract bool IsStartMethod { get; }
+
+    public string StartEndMethodString => IsStartMethod ? "StartMethod" : "EndMethod";
+
+    public void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType)
+    {
+        _namespaceName = namespaceName;
+        _className = className;
+        _methodName = methodName;
+        _parameterNames = new();
+        _parameterNames.AddRange(parameters.Where(x => x.IsKind(SyntaxKind.Parameter)).Select(x => x.GetParameterNameValuePair()));
+        _outputType = outputType;
+    }
+
+    public abstract void ValidateParameterCount(ArgumentListSyntax statementArguments);
+
+    public virtual void Process(SyntaxNode statement)
+    {
+        var statementArguments = statement.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
+
+        if (statementArguments is null)
+        {
+            Log.Warning(string.Format(ErrorMessages.MethodHasNoParameters, StartEndMethodString, _namespaceName, _className, _methodName));
+            return;
+        }
+
+        ValidateParameterCount(statementArguments);
+
+        ValidateMethodParameters(statementArguments.Arguments.SelectMany(arg => arg.ChildNodes()));
+    }
+
+    private void ValidateMethodParameters(IEnumerable<SyntaxNode> arguments)
+    {
+        foreach (var parameter in _parameterNames)
+        {
+            var containsParameter = false;
+
+            foreach (var argument in arguments)
+            {
+                if (argument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() is ArgumentListSyntax ObjectArgumentList
+                    && ObjectArgumentList.Arguments.Count == 2)
+                {
+                    var dictionaryKey = ObjectArgumentList?.Arguments[0].ToString().Trim('"');
+                    var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
+
+                    if (dictionaryKey != null && dictionaryKey.EqualsToItselfOrNameOfItself(parameter.Key) && parameter.Value == dictionaryValue)
+                    {
+                        containsParameter = true;
+                        break;
+                    }
+                }
+            }
+
+            if (!containsParameter)
+            {
+                Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, parameter.Key));
+            }
+        }
+
+        foreach (var objectArgument in arguments)
+        {
+            if (objectArgument.IsKind(SyntaxKind.ObjectCreationExpression))
+            {
+                var ObjectArgumentList = objectArgument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() as ArgumentListSyntax;
+                var dictionaryKey = ObjectArgumentList?.Arguments[0].ToString().Trim('"').ToLower(1);
+                var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
+
+                if (_parameterNames.ContainsKeyValue(dictionaryKey, dictionaryValue))
+                {
+                    Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, dictionaryKey));
+                }
+            }
+        }
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/BaseProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/BaseProcessor.cs
@@ -12,89 +12,90 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
 
 internal abstract class BaseProcessor : IBaseProcessor
 {
-    protected string _namespaceName = string.Empty;
-    protected string _className = string.Empty;
-    protected string _methodName = string.Empty;
-    protected List<KeyValuePair<string, string>> _parameterNames = new();
-    protected string _outputType = string.Empty;
-    private ClassType _classType; 
+	protected string _namespaceName = string.Empty;
+	protected string _className = string.Empty;
+	protected string _methodName = string.Empty;
+	protected List<KeyValuePair<string, string>> _parameterNames = new();
+	protected string _outputType = string.Empty;
+	protected SyntaxNode _statementToProcess;
 
-    internal BaseProcessor()
-    {
-    }
+	internal BaseProcessor()
+	{
+	}
 
-    public abstract bool IsStartMethod { get; }
+	public abstract bool IsStartMethod { get; }
 
-    public string StartEndMethodString => IsStartMethod ? "StartMethod" : "EndMethod";
+	public string StartEndMethodString => IsStartMethod ? "StartMethod" : "EndMethod";
 
-    public void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType, ClassType classType)
-    {
-        _namespaceName = namespaceName;
-        _className = className;
-        _methodName = methodName;
-        _parameterNames = new();
-        _parameterNames.AddRange(parameters.Where(x => x.IsKind(SyntaxKind.Parameter)).Select(x => x.GetParameterNameValuePair(classType == ClassType.EntityType)));
-        _outputType = outputType;
-    }
+	public void SetValues(ClassType classType, string namespaceName, string className, string methodName, string outputType, IEnumerable<ParameterSyntax> parameters, SyntaxNode statementToProcess)
+	{
+		_namespaceName = namespaceName;
+		_className = className;
+		_methodName = methodName;
+		_outputType = outputType;
+		_parameterNames = new();
+		_parameterNames.AddRange(parameters.Where(x => x.IsKind(SyntaxKind.Parameter)).Select(x => x.GetParameterNameValuePair(classType == ClassType.EntityType)));
+		_statementToProcess = statementToProcess;
+	}
 
-    public abstract void ValidateParameterCount(ArgumentListSyntax statementArguments);
+	public abstract void ValidateParameterCount(ArgumentListSyntax statementArguments);
 
-    public virtual void Process(SyntaxNode statement)
-    {
-        var statementArguments = statement.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
+	public virtual void Process()
+	{
+		var statementArguments = _statementToProcess.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
 
-        if (statementArguments is null)
-        {
-            Log.Warning(string.Format(ErrorMessages.MethodHasNoParameters, StartEndMethodString, _namespaceName, _className, _methodName));
-            return;
-        }
+		if (statementArguments is null)
+		{
+			Log.Warning(string.Format(ErrorMessages.MethodHasNoParameters, StartEndMethodString, _className, _methodName));
+			return;
+		}
 
-        ValidateParameterCount(statementArguments);
+		ValidateParameterCount(statementArguments);
 
-        ValidateMethodParameters(statementArguments.Arguments.SelectMany(arg => arg.ChildNodes()));
-    }
+		ValidateMethodParameters(statementArguments.Arguments.SelectMany(arg => arg.ChildNodes()));
+	}
 
-    private void ValidateMethodParameters(IEnumerable<SyntaxNode> arguments)
-    {
-        foreach (var parameter in _parameterNames)
-        {
-            var containsParameter = false;
+	private void ValidateMethodParameters(IEnumerable<SyntaxNode> arguments)
+	{
+		foreach (var parameter in _parameterNames)
+		{
+			var containsParameter = false;
 
-            foreach (var argument in arguments)
-            {
-                if (argument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() is ArgumentListSyntax ObjectArgumentList
-                    && ObjectArgumentList.Arguments.Count == 2)
-                {
-                    var dictionaryKey = ObjectArgumentList?.Arguments[0].ToString().Trim('"');
-                    var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
+			foreach (var argument in arguments)
+			{
+				if (argument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() is ArgumentListSyntax ObjectArgumentList
+					&& ObjectArgumentList.Arguments.Count == 2)
+				{
+					var dictionaryKey = ObjectArgumentList?.Arguments[0].ToString().Trim('"');
+					var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
 
-                    if (dictionaryKey != null && dictionaryKey.EqualsToItselfOrNameOfItself(parameter.Key) && parameter.Value == dictionaryValue)
-                    {
-                        containsParameter = true;
-                        break;
-                    }
-                }
-            }
+					if (dictionaryKey != null && dictionaryKey.EqualsToItselfOrNameOfItself(parameter.Key) && parameter.Value == dictionaryValue)
+					{
+						containsParameter = true;
+						break;
+					}
+				}
+			}
 
-            if (!containsParameter)
-            {
-                Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, parameter.Key));
-            }
-        }
+			if (!containsParameter)
+			{
+				Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _className, _methodName, parameter.Key));
+			}
+		}
 
-        foreach (var objectArgument in arguments)
-        {
-            if (objectArgument.IsKind(SyntaxKind.ObjectCreationExpression))
-            {
-                var ObjectArgumentList = objectArgument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() as ArgumentListSyntax;
-                var dictionaryKey = ObjectArgumentList?.Arguments[0].ToString().Trim('"').ToLower(1);
-                var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
+		foreach (var objectArgument in arguments)
+		{
+			if (objectArgument.IsKind(SyntaxKind.ObjectCreationExpression))
+			{
+				var ObjectArgumentList = objectArgument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() as ArgumentListSyntax;
+				var dictionaryKey = ObjectArgumentList?.Arguments[0].ToString().Trim('"').ToLower(1);
+				var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
 
-                if (_parameterNames.ContainsKeyValue(dictionaryKey, dictionaryValue))
-                {
-                    Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, dictionaryKey));
-                }
-            }
-        }
-    }
+				if (_parameterNames.ContainsKeyValue(dictionaryKey, dictionaryValue))
+				{
+					Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _className, _methodName, dictionaryKey));
+				}
+			}
+		}
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/BaseProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/BaseProcessor.cs
@@ -1,4 +1,5 @@
 ﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
 using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 using Cmf.CLI.Core;
 using Microsoft.CodeAnalysis;
@@ -16,6 +17,7 @@ internal abstract class BaseProcessor : IBaseProcessor
     protected string _methodName = string.Empty;
     protected List<KeyValuePair<string, string>> _parameterNames = new();
     protected string _outputType = string.Empty;
+    private ClassType _classType; 
 
     internal BaseProcessor()
     {
@@ -25,13 +27,13 @@ internal abstract class BaseProcessor : IBaseProcessor
 
     public string StartEndMethodString => IsStartMethod ? "StartMethod" : "EndMethod";
 
-    public void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType)
+    public void SetValues(string namespaceName, string className, string methodName, IEnumerable<ParameterSyntax> parameters, string outputType, ClassType classType)
     {
         _namespaceName = namespaceName;
         _className = className;
         _methodName = methodName;
         _parameterNames = new();
-        _parameterNames.AddRange(parameters.Where(x => x.IsKind(SyntaxKind.Parameter)).Select(x => x.GetParameterNameValuePair()));
+        _parameterNames.AddRange(parameters.Where(x => x.IsKind(SyntaxKind.Parameter)).Select(x => x.GetParameterNameValuePair(classType == ClassType.EntityType)));
         _outputType = outputType;
     }
 

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationEndMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationEndMethodProcessor.cs
@@ -1,6 +1,6 @@
-﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
 using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
-using Cmf.CLI.Core;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -11,6 +11,10 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
 
 internal class OrchestrationEndMethodProcessor : BaseProcessor, IOrchestrationEndMethodProcessor
 {
+	public OrchestrationEndMethodProcessor(IValidateLogger logger) : base(logger)
+	{
+	}
+
 	public override bool IsStartMethod => false;
 
 	public override void Process()
@@ -37,7 +41,7 @@ internal class OrchestrationEndMethodProcessor : BaseProcessor, IOrchestrationEn
 	{
 		if (statementArguments.Arguments.Count != 3 + _parameterNames.Count)
 		{
-			Log.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
+			_logger.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
 		}
 	}
 
@@ -47,7 +51,7 @@ internal class OrchestrationEndMethodProcessor : BaseProcessor, IOrchestrationEn
 		var _outputTypeName = _outputType[..^6];
 
 		if (_inputTypeName != _outputTypeName || _inputTypeName != _methodName)
-			Log.Warning(string.Format(ErrorMessages.InputOutputMethodDoNotCoincide, _className, _methodName));
+			_logger.Warning(string.Format(ErrorMessages.InputOutputMethodDoNotCoincide, _className, _methodName));
 	}
 
 	private void ValidateOutputParameter(IEnumerable<SyntaxNode> arguments)
@@ -69,7 +73,7 @@ internal class OrchestrationEndMethodProcessor : BaseProcessor, IOrchestrationEn
 				}
 			}
 
-			Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _className, _methodName, _outputType));
+			_logger.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _className, _methodName, _outputType));
 		}
 	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationEndMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationEndMethodProcessor.cs
@@ -1,0 +1,61 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+using Cmf.CLI.Core;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
+
+internal class OrchestrationEndMethodProcessor : BaseProcessor, IOrchestrationEndMethodProcessor
+{
+    public override bool IsStartMethod => false;
+
+    public override void Process(SyntaxNode statement)
+    {
+        base.Process(statement);
+
+        var statementArguments = statement.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
+
+        if (statementArguments is null)
+        {
+            return;
+        }
+
+        // TODO: Validate EntityTypeId
+
+        // TODO: Validate EntityId
+
+        ValidateOutputParameter(statementArguments.Arguments.Select(x => x.ChildNodes()).Aggregate((l1, l2) => l1.Concat(l2)));
+    }
+
+    public override void ValidateParameterCount(ArgumentListSyntax statementArguments)
+    {
+        if (statementArguments.Arguments.Count != 3 + _parameterNames.Count)
+        {
+            Log.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _namespaceName, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
+        }
+    }
+
+    private void ValidateOutputParameter(IEnumerable<SyntaxNode> arguments)
+    {
+        foreach (var objectArgument in arguments)
+        {
+            if (objectArgument.IsKind(SyntaxKind.ObjectCreationExpression))
+            {
+                var ObjectArgumentList = objectArgument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() as ArgumentListSyntax;
+                var dictionaryKey = ObjectArgumentList is null ? string.Empty : ObjectArgumentList.Arguments[0].ToString().Trim('"');
+                var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
+
+                if (dictionaryKey.EqualsToItselfOrNameOfItself(_outputType))
+                {
+                    return;
+                }
+            }
+        }
+
+        Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, _outputType));
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationEndMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationEndMethodProcessor.cs
@@ -41,21 +41,24 @@ internal class OrchestrationEndMethodProcessor : BaseProcessor, IOrchestrationEn
 
     private void ValidateOutputParameter(IEnumerable<SyntaxNode> arguments)
     {
-        foreach (var objectArgument in arguments)
+        if (_outputType.EndsWith("Output"))
         {
-            if (objectArgument.IsKind(SyntaxKind.ObjectCreationExpression))
-            {
-                var ObjectArgumentList = objectArgument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() as ArgumentListSyntax;
-                var dictionaryKey = ObjectArgumentList is null ? string.Empty : ObjectArgumentList.Arguments[0].ToString().Trim('"');
-                var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
+			foreach (var objectArgument in arguments)
+			{
+				if (objectArgument.IsKind(SyntaxKind.ObjectCreationExpression))
+				{
+					var ObjectArgumentList = objectArgument.ChildNodes().Where(x => x.IsKind(SyntaxKind.ArgumentList)).FirstOrDefault() as ArgumentListSyntax;
+					var dictionaryKey = ObjectArgumentList is null ? string.Empty : ObjectArgumentList.Arguments[0].ToString().Trim('"');
+					var dictionaryValue = ObjectArgumentList?.Arguments[1].ToString();
 
-                if (dictionaryKey.EqualsToItselfOrNameOfItself(_outputType))
-                {
-                    return;
-                }
-            }
-        }
+					if (dictionaryKey.EqualsToItselfOrNameOfItself(_outputType))
+					{
+						return;
+					}
+				}
+			}
 
-        Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, _outputType));
+			Log.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, StartEndMethodString, _namespaceName, _className, _methodName, _outputType));
+		}        
     }
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationStartMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationStartMethodProcessor.cs
@@ -1,6 +1,6 @@
-﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
 using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
-using Cmf.CLI.Core;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
@@ -9,6 +9,10 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
 
 internal class OrchestrationStartMethodProcessor : BaseProcessor, IOrchestrationStartMethodProcessor
 {
+	public OrchestrationStartMethodProcessor(IValidateLogger logger) : base(logger)
+	{
+	}
+
 	public override bool IsStartMethod => true;
 
 	public override void Process()
@@ -25,17 +29,17 @@ internal class OrchestrationStartMethodProcessor : BaseProcessor, IOrchestration
 		// TODO: Validate namespaceAndClass parameter
 
 		if (statementArguments.Arguments[1] is null)
-			Log.Warning(string.Format(ErrorMessages.StartMethodDoesNotContainMethodName, _className, _methodName));
+			_logger.Warning(string.Format(ErrorMessages.StartMethodDoesNotContainMethodName, _className, _methodName));
 
 		if (!statementArguments.Arguments[1].ToString().Trim('"').EqualsToItselfOrNameOfItself(_methodName))
-			Log.Warning(string.Format(ErrorMessages.StartMethodMethodNameIsIncorrect, _className, _methodName));
+			_logger.Warning(string.Format(ErrorMessages.StartMethodMethodNameIsIncorrect, _className, _methodName));
 	}
 
 	public override void ValidateParameterCount(ArgumentListSyntax statementArguments)
 	{
 		if (statementArguments.Arguments.Count != 2 + _parameterNames.Count)
 		{
-			Log.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
+			_logger.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
 		}
 	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationStartMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationStartMethodProcessor.cs
@@ -1,41 +1,41 @@
-﻿using Microsoft.CodeAnalysis;
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+using Cmf.CLI.Core;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
-using Cmf.CLI.Core;
-using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
-using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
 
 namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
 
 internal class OrchestrationStartMethodProcessor : BaseProcessor, IOrchestrationStartMethodProcessor
 {
-    public override bool IsStartMethod => true;
+	public override bool IsStartMethod => true;
 
-    public override void Process(SyntaxNode statement)
-    {
-        base.Process(statement);
+	public override void Process()
+	{
+		base.Process();
 
-        var statementArguments = statement.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
+		var statementArguments = _statementToProcess.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
 
-        if (statementArguments is null)
-        {
-            return;
-        }
+		if (statementArguments is null)
+		{
+			return;
+		}
 
-        // TODO: Validate namespaceAndClass parameter
+		// TODO: Validate namespaceAndClass parameter
 
-        if (statementArguments.Arguments[1] is null)
-            Log.Warning(string.Format(ErrorMessages.StartMethodDoesNotContainMethodName, _namespaceName, _className, _methodName));
+		if (statementArguments.Arguments[1] is null)
+			Log.Warning(string.Format(ErrorMessages.StartMethodDoesNotContainMethodName, _className, _methodName));
 
-        if (!statementArguments.Arguments[1].ToString().Trim('"').EqualsToItselfOrNameOfItself(_methodName))
-            Log.Warning(string.Format(ErrorMessages.StartMethodMethodNameIsIncorrect, _namespaceName, _className, _methodName));
-    }
+		if (!statementArguments.Arguments[1].ToString().Trim('"').EqualsToItselfOrNameOfItself(_methodName))
+			Log.Warning(string.Format(ErrorMessages.StartMethodMethodNameIsIncorrect, _className, _methodName));
+	}
 
-    public override void ValidateParameterCount(ArgumentListSyntax statementArguments)
-    {
-        if (statementArguments.Arguments.Count != 2 + _parameterNames.Count)
-        {
-            Log.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _namespaceName, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
-        }
-    }
+	public override void ValidateParameterCount(ArgumentListSyntax statementArguments)
+	{
+		if (statementArguments.Arguments.Count != 2 + _parameterNames.Count)
+		{
+			Log.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
+		}
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationStartMethodProcessor.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/OrchestrationStartMethodProcessor.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Linq;
+using Cmf.CLI.Core;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
+
+internal class OrchestrationStartMethodProcessor : BaseProcessor, IOrchestrationStartMethodProcessor
+{
+    public override bool IsStartMethod => true;
+
+    public override void Process(SyntaxNode statement)
+    {
+        base.Process(statement);
+
+        var statementArguments = statement.DescendantNodes().OfType<ArgumentListSyntax>().FirstOrDefault();
+
+        if (statementArguments is null)
+        {
+            return;
+        }
+
+        // TODO: Validate namespaceAndClass parameter
+
+        if (statementArguments.Arguments[1] is null)
+            Log.Warning(string.Format(ErrorMessages.StartMethodDoesNotContainMethodName, _namespaceName, _className, _methodName));
+
+        if (!statementArguments.Arguments[1].ToString().Trim('"').EqualsToItselfOrNameOfItself(_methodName))
+            Log.Warning(string.Format(ErrorMessages.StartMethodMethodNameIsIncorrect, _namespaceName, _className, _methodName));
+    }
+
+    public override void ValidateParameterCount(ArgumentListSyntax statementArguments)
+    {
+        if (statementArguments.Arguments.Count != 2 + _parameterNames.Count)
+        {
+            Log.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, StartEndMethodString, _namespaceName, _className, _methodName, statementArguments.Arguments.Count, 2 + _parameterNames.Count));
+        }
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/ProcessorFactory.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/ProcessorFactory.cs
@@ -1,0 +1,81 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors
+{
+	internal class ProcessorFactory : IProcessorFactory
+	{
+		private IServiceProvider _serviceProvider;
+
+		public ProcessorFactory(IServiceProvider serviceProvider)
+			=> _serviceProvider = serviceProvider;
+
+		public T Create<T>() where T : IBaseProcessor
+		{
+			return _serviceProvider.GetService<T>();
+		}
+
+		public IBaseProcessor Create(ClassType classType, string namespaceName, string className, string methodName, string outputType, SeparatedSyntaxList<ParameterSyntax> parameters, SyntaxNode statement)
+		{
+			IBaseProcessor processor = null;
+
+			if (statement.IsStartMethod())
+			{
+				switch (classType)
+				{
+					case ClassType.ControllerOrOrchestration:
+						if (parameters.ContainsInputObject())
+						{
+							processor = Create<IOrchestrationStartMethodProcessor>();
+							processor.SetValues(classType, namespaceName, className, methodName, outputType, parameters, statement);
+						}
+
+						break;
+
+					case ClassType.EntityType:
+						// TODO: EntityType
+						break;
+
+					case ClassType.EntityTypeCollection:
+						// TODO: EntityTypeCollection
+						break;
+
+					default:
+						break;
+				}
+			}
+			else if (statement.IsEndMethod())
+			{
+				switch (classType)
+				{
+					case ClassType.ControllerOrOrchestration:
+						if (parameters.ContainsInputObject())
+						{
+							processor = Create<IOrchestrationEndMethodProcessor>();
+							processor.SetValues(classType, namespaceName, className, methodName, outputType, parameters, statement);
+						}
+						break;
+
+					case ClassType.EntityType:
+						// TODO: EntityType
+						break;
+
+					case ClassType.EntityTypeCollection:
+						// TODO: EntityTypeCollection
+						break;
+
+					default:
+						break;
+				}
+			}
+
+			return processor;
+		}
+	}
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/ProcessorFactory.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/Processors/ProcessorFactory.cs
@@ -5,7 +5,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
 
 namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors
 {

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionLoader.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionLoader.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.Build.Locator;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+
+/// <summary>
+/// Loads a visual studio solution and make it ready to use by Roslyn
+/// </summary>
+public class SolutionLoader
+{
+    private readonly string _solutionPath;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SolutionLoader"/> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="solutionPath">The solution path.</param>
+    public SolutionLoader(string solutionPath)
+    {
+        _solutionPath = solutionPath;
+    }
+
+    /// <summary>
+    /// LoadSolution from path
+    /// </summary>
+    /// <returns></returns>
+    public MSBuildWorkspace ReLoadSolution()
+    {
+        if (!MSBuildLocator.IsRegistered)
+        {
+            MSBuildLocator.RegisterDefaults();
+        }
+
+        var _ = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions);
+
+        var workspace = MSBuildWorkspace.Create();
+
+        workspace.OpenSolutionAsync(_solutionPath).Wait();
+
+        return workspace;
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionLoader.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionLoader.cs
@@ -8,35 +8,35 @@ namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
 /// </summary>
 public class SolutionLoader
 {
-    private readonly string _solutionPath;
+	private readonly string _solutionPath;
 
-    /// <summary>
-    /// Initializes a new instance of the <see cref="SolutionLoader"/> class.
-    /// </summary>
-    /// <param name="logger">The logger.</param>
-    /// <param name="solutionPath">The solution path.</param>
-    public SolutionLoader(string solutionPath)
-    {
-        _solutionPath = solutionPath;
-    }
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SolutionLoader"/> class.
+	/// </summary>
+	/// <param name="logger">The logger.</param>
+	/// <param name="solutionPath">The solution path.</param>
+	public SolutionLoader(string solutionPath)
+	{
+		_solutionPath = solutionPath;
+	}
 
-    /// <summary>
-    /// LoadSolution from path
-    /// </summary>
-    /// <returns></returns>
-    public MSBuildWorkspace ReLoadSolution()
-    {
-        if (!MSBuildLocator.IsRegistered)
-        {
-            MSBuildLocator.RegisterDefaults();
-        }
+	/// <summary>
+	/// LoadSolution from path
+	/// </summary>
+	/// <returns></returns>
+	public MSBuildWorkspace ReLoadSolution()
+	{
+		if (!MSBuildLocator.IsRegistered)
+		{
+			MSBuildLocator.RegisterDefaults();
+		}
 
-        var _ = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions);
+		var _ = typeof(Microsoft.CodeAnalysis.CSharp.Formatting.CSharpFormattingOptions);
 
-        var workspace = MSBuildWorkspace.Create();
+		var workspace = MSBuildWorkspace.Create();
 
-        workspace.OpenSolutionAsync(_solutionPath).Wait();
+		workspace.OpenSolutionAsync(_solutionPath).Wait();
 
-        return workspace;
-    }
+		return workspace;
+	}
 }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionValidator.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionValidator.cs
@@ -101,11 +101,14 @@ internal class SolutionValidator
                     switch (classType)
                     {
                         case ClassType.Controller:
-                            processor = _serviceProvider.GetRequiredService<IOrchestrationStartMethodProcessor>();
-                            break;
+                            if (methodParameterList.ContainsInputObject())
+								processor = _serviceProvider.GetRequiredService<IOrchestrationStartMethodProcessor>();
+
+							break;
 
                         case ClassType.Orchestration:
-                            processor = _serviceProvider.GetRequiredService<IOrchestrationStartMethodProcessor>();
+							if (methodParameterList.ContainsInputObject())
+								processor = _serviceProvider.GetRequiredService<IOrchestrationStartMethodProcessor>();
                             break;
 
                         case ClassType.EntityType:
@@ -125,11 +128,13 @@ internal class SolutionValidator
                     switch (classType)
                     {
                         case ClassType.Controller:
-                            processor = _serviceProvider.GetRequiredService<IOrchestrationEndMethodProcessor>();
+							if (methodParameterList.ContainsInputObject())
+								processor = _serviceProvider.GetRequiredService<IOrchestrationEndMethodProcessor>();
                             break;
 
                         case ClassType.Orchestration:
-                            processor = _serviceProvider.GetRequiredService<IOrchestrationEndMethodProcessor>();
+							if (methodParameterList.ContainsInputObject())
+								processor = _serviceProvider.GetRequiredService<IOrchestrationEndMethodProcessor>();
                             break;
 
                         case ClassType.EntityType:
@@ -147,7 +152,7 @@ internal class SolutionValidator
 
                 if (processor != null)
                 {
-                    processor.SetValues(namespaceName, className, methodName, methodParameterList, outputType);
+                    processor.SetValues(namespaceName, className, methodName, methodParameterList, outputType, classType);
                     processor.Process(statementToProcess);
                 }
             }

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionValidator.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/SolutionValidator.cs
@@ -1,0 +1,156 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions.Processors;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Extensions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+
+internal class SolutionValidator
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly string _solutionPath;
+    private readonly IList<string> _files;
+
+    public SolutionValidator(IServiceProvider serviceProvider, string solutionPath, IEnumerable<string> files)
+    {
+        _serviceProvider = serviceProvider;
+        _solutionPath = solutionPath;
+        _files = files.ToList();
+    }
+
+    public async Task ValidateSolution()
+    {
+        var solutionLoader = new SolutionLoader(_solutionPath);
+        var workspace = solutionLoader.ReLoadSolution();
+        var projects = workspace.CurrentSolution.Projects;
+
+        foreach (var project in projects)
+        {
+            foreach (var document in project.Documents)
+            {
+                if (!_files.Any() || _files.Contains(document.Name))
+                {
+                    var syntaxTree = await document.GetSyntaxTreeAsync();
+
+                    if (syntaxTree is null)
+                    {
+                        continue;
+                    }
+
+                    var namespaceNodes = syntaxTree.GetRoot().DescendantNodes().OfType<NamespaceDeclarationSyntax>();
+
+                    foreach (var namespaceNode in namespaceNodes)
+                    {
+                        var classDeclarations = namespaceNode.ChildNodes().OfType<ClassDeclarationSyntax>();
+
+                        foreach (var classDeclaration in classDeclarations)
+                        {
+                            var methodNodes = classDeclaration.ChildNodes().OfType<MethodDeclarationSyntax>();
+                            var classIdentifierToken = classDeclaration.Identifier;
+                            var classType = classDeclaration.GetClassType();
+
+                            if (classType != ClassType.Other)
+                            {
+                                foreach (MethodDeclarationSyntax methodNode in methodNodes)
+                                {
+                                    ProcessMethod(methodNode, namespaceNode, classType, classIdentifierToken);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    public void ProcessMethod(MethodDeclarationSyntax methodNode, NamespaceDeclarationSyntax namespaceNode, ClassType classType, SyntaxToken classIdentifierToken)
+    {
+        var block = methodNode.Body;
+        var methodName = methodNode.Identifier.ValueText;
+        var outputType = methodNode.ReturnType is null ? string.Empty : methodNode.ReturnType.ToString();
+        var methodParameterList = methodNode.ParameterList.Parameters;
+        var namespaceName = namespaceNode.Name.ToString();
+        var className = classIdentifierToken.ToString();
+
+        if (block is null)
+        {
+            return;
+        }
+
+        foreach (var statement in block.DescendantNodes())
+        {
+            var statementToProcess = statement;
+
+            if (statement.IsTryStatement())
+            {
+                statementToProcess = statement.GetEndMethodExpression();
+            }
+
+            if (statementToProcess != null)
+            {
+                IBaseProcessor processor = null;
+
+                if (statementToProcess.IsStartMethod())
+                {
+                    switch (classType)
+                    {
+                        case ClassType.Controller:
+                            processor = _serviceProvider.GetRequiredService<IOrchestrationStartMethodProcessor>();
+                            break;
+
+                        case ClassType.Orchestration:
+                            processor = _serviceProvider.GetRequiredService<IOrchestrationStartMethodProcessor>();
+                            break;
+
+                        case ClassType.EntityType:
+                            // TODO: EntityType
+                            break;
+
+                        case ClassType.EntityTypeCollection:
+                            // TODO: EntityTypeCollection
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
+                else if (statementToProcess.IsEndMethod())
+                {
+                    switch (classType)
+                    {
+                        case ClassType.Controller:
+                            processor = _serviceProvider.GetRequiredService<IOrchestrationEndMethodProcessor>();
+                            break;
+
+                        case ClassType.Orchestration:
+                            processor = _serviceProvider.GetRequiredService<IOrchestrationEndMethodProcessor>();
+                            break;
+
+                        case ClassType.EntityType:
+                            // TODO: EntityType
+                            break;
+
+                        case ClassType.EntityTypeCollection:
+                            // TODO: EntityTypeCollection
+                            break;
+
+                        default:
+                            break;
+                    }
+                }
+
+                if (processor != null)
+                {
+                    processor.SetValues(namespaceName, className, methodName, methodParameterList, outputType);
+                    processor.Process(statementToProcess);
+                }
+            }
+        }
+    }
+}

--- a/cmf-cli/Commands/build/business/ValidateStartEndMethods/ValidateLogger.cs
+++ b/cmf-cli/Commands/build/business/ValidateStartEndMethods/ValidateLogger.cs
@@ -1,0 +1,9 @@
+﻿using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions;
+
+namespace Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+
+public class ValidateLogger : IValidateLogger
+{
+	public void Warning(string message)
+		=> Cmf.CLI.Core.Log.Warning(message);
+}

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -1,86 +1,92 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
-    <TargetName>cmf</TargetName>
-    <RootNamespace>Cmf.CLI</RootNamespace>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>cmf</ToolCommandName>
-    <PackageOutputPath>./nupkg</PackageOutputPath>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AssemblyName>cmf</AssemblyName>
-    <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <DocumentationFile>../docs/cmf/cmf.xml</DocumentationFile>
-    <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
-    <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
-    <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
-    <Version>4.0.0-1</Version>
-  </PropertyGroup>
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net6.0</TargetFramework>
+        <TargetName>cmf</TargetName>
+        <RootNamespace>Cmf.CLI</RootNamespace>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>cmf</ToolCommandName>
+        <PackageOutputPath>./nupkg</PackageOutputPath>
+        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+        <AssemblyName>cmf</AssemblyName>
+        <GenerateDocumentationFile>false</GenerateDocumentationFile>
+        <DocumentationFile>../docs/cmf/cmf.xml</DocumentationFile>
+        <DefaultDocumentationFileNameMode>Name</DefaultDocumentationFileNameMode>
+        <DefaultDocumentationNestedTypeVisibility>Namespace</DefaultDocumentationNestedTypeVisibility>
+        <DefaultDocumentationGeneratedPages>Namespaces</DefaultDocumentationGeneratedPages>
+        <Version>4.0.0-1</Version>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="DefaultDocumentation" Version="0.8.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
-    <PackageReference Include="Spectre.Console" Version="0.46.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
-    <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Remove="nupkg\**" />
-    <EmbeddedResource Remove="nupkg\**" />
-    <None Remove="nupkg\**" />
-    <EmbeddedResource Update="CliMessages.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>CliMessages.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
-    <Compile Update="CliMessages.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>CliMessages.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="DefaultDocumentation" Version="0.8.2">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+        <PackageReference Include="Microsoft.PowerShell.SDK" Version="7.1.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Spectre.Console" Version="0.46.0" />
+        <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+        <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
+        <PackageReference Include="System.Management.Automation" Version="7.1.3" />
+    </ItemGroup>
+    <ItemGroup>
+        <Compile Remove="nupkg\**" />
+        <EmbeddedResource Remove="nupkg\**" />
+        <None Remove="nupkg\**" />
+        <EmbeddedResource Update="CliMessages.resx">
+            <Generator>ResXFileCodeGenerator</Generator>
+            <LastGenOutput>CliMessages.Designer.cs</LastGenOutput>
+        </EmbeddedResource>
+        <Compile Update="CliMessages.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>CliMessages.resx</DependentUpon>
+        </Compile>
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="CliMessages.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>CliMessages.resx</DependentUpon>
-    </EmbeddedResource>
-    <EmbeddedResource Include="resources\**" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="CliMessages.Designer.cs">
+            <DesignTime>True</DesignTime>
+            <AutoGen>True</AutoGen>
+            <DependentUpon>CliMessages.resx</DependentUpon>
+        </EmbeddedResource>
+        <EmbeddedResource Include="resources\**" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Remove="resources\template_feed\**" />
-    <Compile Remove="resources\template_feed\**" />
-    <None Include="resources\template_feed\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Remove="resources\template_feed\**" />
+        <Compile Remove="resources\template_feed\**" />
+        <None Include="resources\template_feed\**">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="installDependencies\Data\GenerateLBOs.ps1" />
-  </ItemGroup>
+    <ItemGroup>
+        <EmbeddedResource Include="installDependencies\Data\GenerateLBOs.ps1" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Update="installDependencies\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
+    <ItemGroup>
+        <None Update="installDependencies\**">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </None>
+    </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Properties\" />
-  </ItemGroup>
+    <ItemGroup>
+        <Folder Include="Properties\" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\.editorconfig" Link=".editorconfig" />
-  </ItemGroup>
+    <ItemGroup>
+        <None Include="..\.editorconfig" Link=".editorconfig" />
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\core\core.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\core\core.csproj" />
+    </ItemGroup>
 </Project>

--- a/tests/Specs/Build.cs
+++ b/tests/Specs/Build.cs
@@ -1,6 +1,7 @@
 using Cmf.CLI.Builders;
 using Cmf.CLI.Commands.restore;
 using Cmf.CLI.Constants;
+using Cmf.CLI.Core.Constants;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Core.Utilities;
 using Cmf.CLI.Factories;

--- a/tests/Specs/ValidateStartAndEndMethods.cs
+++ b/tests/Specs/ValidateStartAndEndMethods.cs
@@ -1,0 +1,241 @@
+﻿using Autofac.Extras.Moq;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Abstractions;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Enums;
+using Cmf.CLI.Commands.build.business.ValidateStartEndMethods.Processors;
+using Grpc.Net.Client.Configuration;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace tests.Specs;
+
+public class ValidateStartAndEndMethods
+{
+	private static string _baseNamespaceName = "Cmf.Foundation.BusinessOrchestration.SecurityManagement";
+	private static string _baseClassName = "SecurityOrchestration";
+	private static string _baseMethodName = "RemoveUsersFromRole";
+	private static string _baseOutputType = "RemoveUsersFromRoleOutput";
+
+	[Fact]
+	public void Process_EverythingOk_ShouldNotLogAnything()
+	{
+		// Arrange
+		using var mock = AutoMock.GetLoose();
+		var logger = mock.Mock<IValidateLogger>();
+
+		PrepareScenario(out var parameters, out var statement);
+
+		var processor = mock.Create<OrchestrationStartMethodProcessor>();
+		processor.SetValues(ClassType.ControllerOrOrchestration,
+							_baseNamespaceName,
+							_baseClassName,
+							_baseMethodName,
+							_baseOutputType,
+							parameters,
+							statement);
+
+		// Act
+		processor.Process();
+
+		// Assert
+		logger.Verify(x => x.Warning(It.IsAny<string>()), Times.Never);
+	}
+
+	[Fact]
+	public void Process_MethodNameWrong_ShouldLogMethodNameIsWrong()
+	{
+		// Arrange
+		using var mock = AutoMock.GetLoose();
+		var logger = mock.Mock<IValidateLogger>();
+		var wrongMethodName = "WrongMethodName";
+		PrepareScenario(out var parameters, out var statement);
+
+		var processor = mock.Create<OrchestrationStartMethodProcessor>();
+		processor.SetValues(ClassType.ControllerOrOrchestration,
+							_baseNamespaceName,
+							_baseClassName,
+							wrongMethodName,
+							_baseOutputType,
+							parameters,
+							statement);
+
+		// Act
+		processor.Process();
+
+		// Assert
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.StartMethodMethodNameIsIncorrect, _baseClassName, wrongMethodName)), Times.Once);
+		logger.Verify(x => x.Warning(It.IsAny<string>()), Times.Once);
+	}
+
+	[Fact]
+	public void Process_MissingArgument_ShouldLogMissingParameterAndIncorrectNumberOfParameters()
+	{
+		// Arrange
+		using var mock = AutoMock.GetLoose();
+		var logger = mock.Mock<IValidateLogger>();
+
+		var extraParameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("newParameter"))
+									.WithType(SyntaxFactory.ParseTypeName("NewParameterType"));
+
+		PrepareScenario(out var parameters, out var statement, aditionalParameters: new List<ParameterSyntax>() { extraParameter });
+
+		var processor = mock.Create<OrchestrationStartMethodProcessor>();
+		processor.SetValues(ClassType.ControllerOrOrchestration,
+							_baseNamespaceName,
+							_baseClassName,
+							_baseMethodName,
+							_baseOutputType,
+							parameters,
+							statement);
+
+		// Act
+		processor.Process();
+
+		// Assert
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, "StartMethod", _baseClassName, _baseMethodName, "NewParameterType")), Times.Once);
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.MethodHasIncorrectNumberOfParameters, "StartMethod", _baseClassName, _baseMethodName, 3, 4)), Times.Once);
+		logger.Verify(x => x.Warning(It.IsAny<string>()), Times.Exactly(2));
+	}
+
+	[Fact]
+	public void Process_MethodNameWrongAndOutputNameWrong_ShouldLogInputObjectOutputObjectMethodNameDifferentAndOutputNameWrongOrMissing()
+	{
+		// Arrange
+		using var mock = AutoMock.GetLoose();
+		var logger = mock.Mock<IValidateLogger>();
+		var wrongMethodName = "WrongMethodName";
+		PrepareScenario(out var parameters, out var statement, new List<ArgumentSyntax>() { SyntaxFactory.Argument(GetObjectCreationExpressionSyntax("RemoveUsersFromRoleInput", "input")) });
+		
+		var processor = mock.Create<OrchestrationEndMethodProcessor>();
+		processor.SetValues(ClassType.ControllerOrOrchestration,
+							_baseNamespaceName,
+							_baseClassName,
+							wrongMethodName,
+							_baseOutputType,
+							parameters,
+							statement);
+
+		// Act
+		processor.Process();
+
+		// Assert
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.InputOutputMethodDoNotCoincide, _baseClassName, wrongMethodName)), Times.Once);
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.MethodParameterMissingOrIncorrectlyNamed, "EndMethod", _baseClassName, wrongMethodName, _baseOutputType)), Times.Once);
+		logger.Verify(x => x.Warning(It.IsAny<string>()), Times.Exactly(2));
+	}
+
+	[Fact]
+	public void Process_MethodNameWrong_ShouldLogInputObjectOutputObjectMethodNameDifferent()
+	{
+		// Arrange
+		using var mock = AutoMock.GetLoose();
+		var logger = mock.Mock<IValidateLogger>();
+		var wrongMethodName = "WrongMethodName";
+		PrepareScenario(out var parameters, out var statement, new List<ArgumentSyntax>() { SyntaxFactory.Argument(GetObjectCreationExpressionSyntax(_baseOutputType, "output")) });
+
+		var processor = mock.Create<OrchestrationEndMethodProcessor>();
+		processor.SetValues(ClassType.ControllerOrOrchestration,
+							_baseNamespaceName,
+							_baseClassName,
+							wrongMethodName,
+							_baseOutputType,
+							parameters,
+							statement);
+
+		// Act
+		processor.Process();
+
+		// Assert
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.InputOutputMethodDoNotCoincide, _baseClassName, wrongMethodName)), Times.Once);
+		logger.Verify(x => x.Warning(It.IsAny<string>()), Times.Once);
+	}
+
+	[Fact]
+	public void Process_OutputTypeWrong_ShouldLogMethodNameIsWrong()
+	{
+		// Arrange
+		using var mock = AutoMock.GetLoose();
+		var logger = mock.Mock<IValidateLogger>();
+		PrepareScenario(out var parameters, out var statement);
+
+		var processor = mock.Create<OrchestrationEndMethodProcessor>();
+		processor.SetValues(ClassType.ControllerOrOrchestration,
+							_baseNamespaceName,
+							_baseClassName,
+							_baseMethodName,
+							"WrongOutput",
+							parameters,
+							statement);
+
+		// Act
+		processor.Process();
+
+		// Assert
+		logger.Verify(x => x.Warning(string.Format(ErrorMessages.InputOutputMethodDoNotCoincide, _baseClassName, _baseMethodName)), Times.Once);
+	}
+
+	private void PrepareScenario(out List<ParameterSyntax> parameters, out InvocationExpressionSyntax statement, List<ArgumentSyntax> aditionalArguments = null, List<ParameterSyntax> aditionalParameters = null)
+	{
+		var statementArguments = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(new[] {
+																								SyntaxFactory.Argument(SyntaxFactory.IdentifierName("objectTypeName")),
+																								SyntaxFactory.Argument(SyntaxFactory.IdentifierName("RemoveUsersFromRole")),
+																								SyntaxFactory.Argument(GetObjectCreationExpressionSyntax("RemoveUsersFromRoleInput", "input"))
+																							   }));
+		if(aditionalArguments != null)
+			statementArguments = statementArguments.AddArguments(aditionalArguments.ToArray());
+
+		parameters = new List<ParameterSyntax>();
+		var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("input"))
+									.WithType(SyntaxFactory.ParseTypeName("RemoveUsersFromRoleInput"));
+		parameters.Add(parameter);
+
+		if (aditionalParameters != null)
+			parameters.AddRange(aditionalParameters);
+
+		var descendentNodes = new List<SyntaxNode>();
+		var argumentListSyntax = SyntaxFactory.ArgumentList();
+		descendentNodes.Add(argumentListSyntax);
+
+		statement = SyntaxFactory.InvocationExpression(SyntaxFactory.IdentifierName("RemoveUsersFromRole"), statementArguments);
+	}
+
+	private ObjectCreationExpressionSyntax GetObjectCreationExpressionSyntax(string key, string value)
+		=> SyntaxFactory.ObjectCreationExpression(
+				SyntaxFactory.GenericName(SyntaxFactory.Identifier("KeyValuePair"))
+					.WithTypeArgumentList(
+						SyntaxFactory.TypeArgumentList(
+							SyntaxFactory.SeparatedList<TypeSyntax>(
+								new[]
+								{
+									SyntaxFactory.ParseTypeName("String"),
+									SyntaxFactory.ParseTypeName("Object")
+								}
+							)
+						)
+					)
+				)
+				.WithArgumentList(
+					SyntaxFactory.ArgumentList(
+						SyntaxFactory.SeparatedList<ArgumentSyntax>(
+							new[]
+							{
+								SyntaxFactory.Argument(
+									SyntaxFactory.LiteralExpression(
+										SyntaxKind.StringLiteralExpression,
+										SyntaxFactory.Literal(key)
+									)
+								),
+								SyntaxFactory.Argument(
+									SyntaxFactory.IdentifierName(value)
+								)
+							}
+						)
+					)
+				);
+}

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Autofac.Extras.Moq" Version="6.1.0" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Added a new command: cmf build business validateStartAndEndMethods <solutionPath> <listOfFiles>

The objective of this development was to validate start and end methods in services and orchestration but I've already added a "structure" to later implement validation for entity types also.

Note: If no list of files is provided the command validates all files in the solution.