### PR TITLE
refactor(plugins)!: bypass System.CommandLine API when invoking plugins

### DIFF
--- a/cmf-cli/Program.cs
+++ b/cmf-cli/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Cmf.CLI.Utilities;
 using System;
+using System.CommandLine;
 using System.Threading.Tasks;
 using Cmf.CLI.Commands;
 using Cmf.CLI.Core;
@@ -7,6 +8,8 @@ using Cmf.CLI.Core.Objects;
 using Microsoft.Extensions.DependencyInjection;
 using Cmf.CLI.Core.Enums;
 using System.CommandLine.Parsing;
+using System.Linq;
+using System.Reflection;
 
 namespace Cmf.CLI
 {
@@ -36,8 +39,28 @@ namespace Cmf.CLI
                 
                 if (rootCommand != null)
                 {
+                    var nonPluginCommands = rootCommand.Children.Where(symbol => symbol is Command).ToList();
                     BaseCommand.AddPluginCommands(rootCommand);
-                    result = await parser.InvokeAsync(args);
+                    var pluginCommands =
+                        rootCommand.Children.Where(cmd => cmd is Command && nonPluginCommands.All(np => np.Name != cmd.Name)).ToList();
+
+                    if (args.Length > 0 && pluginCommands.FirstOrDefault(pc => pc.Name == args[0]) is Command pluginMatch)
+                    {
+                        // we are executing a plugin. we should forward all arguments (except the first) to the plugin
+                        var pluginArgs = args[1..];
+
+                        // we should invoke this through the System.CommandLine API but right now we'd have to generate a new pipeline. We'll revisit this in a next version, as it's expected the pipeline instantiation gets more flexible.
+                        var type = pluginMatch!.Handler!.GetType();
+                        var method = type.GetField("_handlerDelegate", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)!;
+                        var del = method.GetValue(pluginMatch.Handler) as Delegate;
+                        var pluginCommand = del!.Target as PluginCommand;
+                        pluginCommand!.Execute(pluginArgs);
+                        result = 0;
+                    }
+                    else
+                    {
+                        result = await parser.InvokeAsync(args);
+                    }
                 }
                  
                 activity?.SetTag("execution.success", true);


### PR DESCRIPTION
BREAKING CHANGE: -- is no longer needed/supported: all params are sent to plugin

This could use a refactor to use System.CommandLine more, but we're waiting for the customizable invocation pipeline they are planning to ship.