### PR TITLE
feat: ignore custom dlls when packing biz

### DIFF
--- a/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs
@@ -35,7 +35,7 @@ namespace Cmf.CLI.Handlers
                         },
                         new Step(StepType.DeployFiles)
                         {
-                            ContentPath = "**/*.dll"
+                            ContentPath = "**/!(Cmf.Custom.*.BusinessObjects.*.dll)"
                         },
                         new Step(StepType.Generic)
                         {


### PR DESCRIPTION
# **Description**

This PR adds logic to ignore custom dlls when packing business solution.

# **Open topics**

Should we add this logic in here? If yes, should we add any kind of guard for projects that really need to deliver custom dlls?

# Tests

Still need to test on the pipeline if is being ignore when deploying.

**Tested manually:** After running the packing command, the manifest has the following default steps:

```
  <steps>
    <step type="Generic" onExecute="$(Agent.Root)/agent/scripts/stop_host.ps1" />
    <step type="DeployFiles" contentPath="**/!(Cmf.Custom.*.BusinessObjects.*.dll)" />
    <step type="Generic" onExecute="$(Agent.Root)/agent/scripts/start_host.ps1" />
  </steps>
``` 