### PR TITLE
fix(build): check generic type build steps

### DIFF
--- a/cmf-cli/Handlers/PackageType/GenericPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/GenericPackageTypeHandler.cs
@@ -1,7 +1,7 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Cmf.CLI.Builders;
 using Cmf.CLI.Core.Objects;
-
 
 namespace Cmf.CLI.Handlers
 {
@@ -23,7 +23,11 @@ namespace Cmf.CLI.Handlers
                 isInstallable: false
             );
 
-            BuildSteps = cmfPackage.BuildSteps?.Select(pbs => new SingleStepCommand() { BuildStep = pbs} as IBuildCommand).ToArray();
+            IEnumerable<IBuildCommand> buildSteps = cmfPackage.BuildSteps?.Select(pbs => new SingleStepCommand() { BuildStep = pbs } as IBuildCommand);
+
+            if (buildSteps != null && buildSteps.Any()) {
+                BuildSteps = buildSteps.ToArray();
+            }
         }
     }
 }


### PR DESCRIPTION
# Description

This PR fixes the `build` command when used on a `Generic` package type without `BuildSteps`

## Steps to reproduce

Run: `cmf build`

with the following cmfpackage.json:

```json
{
  "packageId": "Cmf.Custom.SecurityPortal",
  "version": "1.0.0",
  "description": "This package deploys Cmf.Custom.SecurityPortal in Critical Manufacturing MES",
  "packageType": "Generic",
  "isInstallable": true,
  "targetLayer": "securityportal",
  "isUniqueInstall": true,
  "steps": [
    {
      "order": 1,
      "type": "TransformFile",
      "file": "config.json",
      "tagFile": true
    }
  ],
  "dependencies": [],
  "contentToPack": [
    {
      "source": "config.json",
      "target": "."
    }
  ]
}

```

```sh
  Caught exception at program.
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
     System.NullReferenceException: Object reference not set to an instance of an object.
       at void Cmf.CLI.Handlers.PackageTypeHandler.Build(bool test) in /home/runner/work/cli/cli/cmf-cli/Handlers/PackageType/
          PackageTypeHandler.cs:526
       at void Cmf.CLI.Commands.BuildCommand.Execute(IDirectoryInfo packagePath, bool test) in
          /home/runner/work/cli/cli/cmf-cli/Commands/build/BuildCommand.cs:74
  at void Cmf.CLI.Utilities.CliException.Handler(Exception exception) in /home/runner/work/cli/cli/core/Utilities/CliException.cs:61
  at void Cmf.CLI.Core.StartupModule.<>c.<Configure>b__0_1(Exception exception, InvocationContext context) in
     /home/runner/work/cli/cli/core/StartupModule.cs:78
  at void System.CommandLine.Builder.CommandLineBuilderExtensions.<>c__DisplayClass8_0.<<UseExceptionHandler>b__0>d.MoveNext()
  at void System.CommandLine.Builder.CommandLineBuilderExtensions.<>c.<<CancelOnProcessTermination>b__1_0>d.MoveNext()
  at async Task<int> System.CommandLine.Invocation.InvocationPipeline.<InvokeAsync>g__FullInvocationChainAsync|2_0(InvocationContext
     context)
  at async Task<int> System.CommandLine.Parsing.ParseResultExtensions.InvokeAsync(ParseResult parseResult, IConsole console)
  at async Task<int> System.CommandLine.Parsing.ParserExtensions.InvokeAsync(Parser parser, string[] args, IConsole console)
  at async Task<int> Cmf.CLI.Program.Main(string[] args) in /home/runner/work/cli/cli/cmf-cli/Program.cs:62
  Logging an uncaught exception to telemetry.
 ```