### PR TITLE
fix(build): install and build lbos package

### DIFF
--- a/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
@@ -62,6 +62,10 @@ namespace Cmf.CLI.Handlers
                     }
             );
 
+            var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
+            var tsLBOsPath = this.fileSystem.Path.Join(projectRoot.FullName, "Libs", "LBOs", "TypeScript");
+            var tsLBOsDir = this.fileSystem.DirectoryInfo.New(tsLBOsPath);
+
             BuildSteps = new IBuildCommand[]
             {
                 new ExecuteCommand<RestoreCommand>()
@@ -80,6 +84,20 @@ namespace Cmf.CLI.Handlers
                     Args = new []{ "--force" },
                     WorkingDirectory = cmfPackage.GetFileInfo().Directory
                 },
+                new NPMCommand()
+                {
+                    DisplayName = "NPM Install LBOs",
+                    Command  = "install",
+                    Args = new []{ "--force" },
+                    WorkingDirectory = tsLBOsDir
+                },
+                new NPMCommand()
+                {
+                    DisplayName = "Build LBOs",
+                    Command  = "run",
+                    Args = new []{ "build" },
+                    WorkingDirectory = tsLBOsDir
+                },
                 new ExecuteCommand<LinkLBOsCommand>()
                 {
                     DisplayName = "Link LBOs",
@@ -87,7 +105,6 @@ namespace Cmf.CLI.Handlers
                     Execute = command => command.Execute(cmfPackage.GetFileInfo().Directory)
                 }
             };
-
             cmfPackage.DFPackageType = PackageType.Presentation;
 
             // Projects BuildSteps


### PR DESCRIPTION
# Description

This PR fixes the `build` command when used on `HTML` package on v10.1.1

After analyses, I noticed that after linking LBO's we still need to get the packages the LBOs depend on.

With this PR, it will install and build the LBO package as well before linking. 

## Steps to reproduce

Run: `cmf build` on `HTML` package with v.10.1.1

```sh
  Executing 'ng build Cmf.Custom.HTML'
  - Generating browser application bundles (phase: setup)...
  √ Browser application bundle generation complete.
  √ Browser application bundle generation complete.
  
  ../Libs/LBOs/TypeScript/esm/cmf-lbos.mjs:1:0-28 - Error: Module not found: Error: Can't resolve 'moment' in 
'C:\agentsWork\SRV-PI-BS01-11\9451\s\Libs\LBOs\TypeScript\esm'
  
  Error: ../Libs/LBOs/TypeScript/index.d.ts:1:20 - error TS2307: Cannot find module 'moment' or its corresponding type declarations.
  
  1 import moment from "moment";
                       ~~~~~~~~
  
  
  Error: Optimization error [main.6874f47118be7dc5.js]: X [ERROR] Invalid assignment target

 ```