### PR TITLE
fix(build): logic for adding href token to help index.html

### DIFF
--- a/cmf-cli/Handlers/PackageType/HelpNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HelpNgCliPackageTypeHandler.cs
@@ -103,12 +103,12 @@ namespace Cmf.CLI.Handlers
                     {
                         DisplayName = $"ng build {package.Key}",
                         Command = "build",
-                        Args = String.Equals(package.Key, this.CmfPackage.PackageId, StringComparison.InvariantCultureIgnoreCase) ? new []{ "--", "--base-href", "$(APPLICATION_BASE_HREF)" } : Array.Empty<string>(),
+                        Args = String.Equals(package.Value.Name, this.CmfPackage.PackageId, StringComparison.InvariantCultureIgnoreCase) ? new []{ "--base-href", "$(APPLICATION_BASE_HREF)" } : Array.Empty<string>(),
                         WorkingDirectory = package.Value
                     }
                 }).ToArray();
             }
-            
+
             BuildSteps = BuildSteps.Append(new NgBuildFileTokenReplacerCommand(this.fileSystem, apps, cmfPackage)).ToArray();
         }
 
@@ -146,7 +146,7 @@ namespace Cmf.CLI.Handlers
 
                     // if package-lock also refer the package in the packages list
                     Dictionary<string, dynamic> packages = project.PackageLock.Content.packages.ToObject<Dictionary<string, dynamic>>();
-                    if(packages.ContainsKey("") && packages[""].name == project.Name)
+                    if (packages.ContainsKey("") && packages[""].name == project.Name)
                     {
                         packages[""].version = project.PackageJson.Content.version;
                         project.PackageLock.Content.packages = JObject.FromObject(packages);


### PR DESCRIPTION
Currently, the index.html deployed in the help package does not include the `$(APPLICATION_BASE_HREF)` token, which is replaced during the package installation process.
This pull request rectifies the logic that inserts the `$(APPLICATION_BASE_HREF)` token into the `index.html` file during the execution of the `cmf build`.