### PR TITLE
Support building HTML without custom LBOs. Fix token support in Help packages.

### DIFF
--- a/cmf-cli/Commands/build/html/LinkLBOsCommand.cs
+++ b/cmf-cli/Commands/build/html/LinkLBOsCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.Diagnostics;
 using System.IO.Abstractions;
+using Cmf.CLI.Builders;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
@@ -56,6 +57,22 @@ public class LinkLBOsCommand : BaseCommand
         Log.Debug($"Checking if {tsLBOsPath} exists...");
         if (fileSystem.Directory.Exists(tsLBOsPath))
         {
+            var tsLBOsDir = fileSystem.DirectoryInfo.New(tsLBOsPath);
+            new NPMCommand()
+            {
+                DisplayName = "NPM Install LBOs",
+                Command = "install",
+                Args = new[] { "--force" },
+                WorkingDirectory = tsLBOsDir
+            }.Exec()?.Wait();
+            new NPMCommand()
+            {
+                DisplayName = "Build LBOs",
+                Command = "run",
+                Args = new[] { "build" },
+                WorkingDirectory = tsLBOsDir
+            }.Exec()?.Wait();
+            
             var packageRoot = cmfPackage.GetFileInfo().DirectoryName;
             var linkTargetPath = this.fileSystem.Path.Join(packageRoot, "node_modules", "cmf-lbos");
             var linkTarget = this.fileSystem.DirectoryInfo.New(linkTargetPath);
@@ -71,7 +88,7 @@ public class LinkLBOsCommand : BaseCommand
         else
         {
             // if there are no LBOs we don't need to do anything
-            Log.Verbose($"Path '{tsLBOsPath}' does not exist, not linking anything.");
+            Log.Verbose($"Path '{tsLBOsPath}' does not exist, not doing anything.");
         }
     }
 }

--- a/cmf-cli/Handlers/PackageType/HelpNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HelpNgCliPackageTypeHandler.cs
@@ -103,7 +103,7 @@ namespace Cmf.CLI.Handlers
                     {
                         DisplayName = $"ng build {package.Key}",
                         Command = "build",
-                        Args = String.Equals(package.Key, this.CmfPackage.PackageId, StringComparison.InvariantCultureIgnoreCase) ? new []{ "--", "--base-href", "$(APPLICATION_BASE_HREF)" } : Array.Empty<string>(),
+                        Args = apps.Contains(package.Key.ToKebabCase()) ? new []{ "--base-href", "$(APPLICATION_BASE_HREF)" } : Array.Empty<string>(),
                         WorkingDirectory = package.Value
                     }
                 }).ToArray();
@@ -146,7 +146,7 @@ namespace Cmf.CLI.Handlers
 
                     // if package-lock also refer the package in the packages list
                     Dictionary<string, dynamic> packages = project.PackageLock.Content.packages.ToObject<Dictionary<string, dynamic>>();
-                    if(packages.ContainsKey("") && packages[""].name == project.Name)
+                    if (packages.ContainsKey("") && packages[""].name == project.Name)
                     {
                         packages[""].version = project.PackageJson.Content.version;
                         project.PackageLock.Content.packages = JObject.FromObject(packages);

--- a/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
@@ -84,20 +84,6 @@ namespace Cmf.CLI.Handlers
                     Args = new []{ "--force" },
                     WorkingDirectory = cmfPackage.GetFileInfo().Directory
                 },
-                new NPMCommand()
-                {
-                    DisplayName = "NPM Install LBOs",
-                    Command  = "install",
-                    Args = new []{ "--force" },
-                    WorkingDirectory = tsLBOsDir
-                },
-                new NPMCommand()
-                {
-                    DisplayName = "Build LBOs",
-                    Command  = "run",
-                    Args = new []{ "build" },
-                    WorkingDirectory = tsLBOsDir
-                },
                 new ExecuteCommand<LinkLBOsCommand>()
                 {
                     DisplayName = "Link LBOs",

--- a/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
@@ -104,7 +104,7 @@ namespace Cmf.CLI.Handlers
                     {
                         DisplayName = $"ng build {package.Key}",
                         Command = "build",
-                        Args = apps.Contains(package.Key) ? new []{ "--base-href", "$(APPLICATION_BASE_HREF)" } : Array.Empty<string>(),
+                        Args = apps.Contains(package.Key.ToKebabCase()) ? new []{ "--base-href", "$(APPLICATION_BASE_HREF)" } : Array.Empty<string>(),
                         WorkingDirectory = package.Value
                     }
                 }).ToArray();

--- a/core/Utilities/ExtensionMethods.cs
+++ b/core/Utilities/ExtensionMethods.cs
@@ -7,6 +7,7 @@ using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Xml.Linq;
 using Cmf.CLI.Core.Constants;
 using Cmf.CLI.Core.Enums;
@@ -95,6 +96,36 @@ namespace Cmf.CLI.Utilities
         public static bool IgnoreCaseEquals(this string str, string value)
         {
             return str != null && value != null && str.Equals(value, System.StringComparison.InvariantCultureIgnoreCase);
+        }
+
+        /// <summary>
+        /// Converts a string to kebab-case
+        /// </summary>
+        /// <param name="str">the input string</param>
+        /// <returns>the kebab-case equivalent</returns>
+        public static string ToKebabCase(this string str)
+        {
+            // converts a pascal case string to kebab case
+            var kebabCase = new StringBuilder();
+
+            for (var i = 0; i < str.Length; i++)
+            {
+                var currentChar = str[i];
+                if (char.IsUpper(currentChar))
+                {
+                    if (i > 0 && !char.IsUpper(str[i - 1]) &&  ((str[i - 1]>='A' && str[i - 1]<='Z') || (str[i - 1]>='a' && str[i - 1]<='z')))
+                    {
+                        kebabCase.Append('-');
+                    }
+                    kebabCase.Append(Char.ToLower(currentChar));
+                }
+                else
+                {
+                    kebabCase.Append(currentChar);
+                }
+            }
+
+            return kebabCase.ToString();
         }
 
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build:prod:singlefile:osx": "dotnet publish ./cmf-cli/cmf.csproj -c Release -r osx-x64 -o dist/osx-x64 --self-contained /p:PublishSingleFile=true",
     "publish": "cd npm && npm publish --tag next && cd ..",
     "publish:live": "cd npm && npm publish --tag latest && cd ..",
-    "publish:dev": "DEV_VERSION=0.0.0-$(git branch --show-current)-$(date '+%Y%m%d%H%M') npm run bump:npm:dev && npm run build:bundle && cd npm && npm publish --tag $(git branch --show-current) --registry http://vm-it.cmf.criticalmanufacturing.com:4873 && cd ..",
+    "publish:dev": "DEV_VERSION=0.0.0-$(git branch --show-current)-$(date '+%Y%m%d%H%M') npm run bump:npm:dev && npm run build:bundle && cd npm && npm publish --tag $(git branch --show-current) --registry https://dev.criticalmanufacturing.io/repository/npm-releases/ && cd ..",
     "bump:npm:pre": "cd npm && npm version prerelease --no-git-tag-version && cd ..",
     "bump:npm:pre:breaking": "cd npm && npm version premajor --no-git-tag-version && cd ..",
     "bump:npm:pre:feature": "cd npm && npm version preminor --no-git-tag-version && cd ..",


### PR DESCRIPTION
- fix(build html): move install and build LBOs to link LBOs command
- fix(build html/help): fixed token injection for HTML and Help packages
- chore(publish): use another repository for dev releases
