### PR TITLE
fix: force order by name on getContentToPack method

### DIFF
--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -428,7 +428,7 @@ namespace Cmf.CLI.Handlers
 
                     try
                     {
-                        _filesToPack = packageDirectory.GetFiles(_source);
+                       _filesToPack = packageDirectory.GetFiles(_source).OrderBy(file => file.Name).ToArray();
                     }
                     // Because the method GetFiles throws an exception if the folder is not found
                     // we need to catch the error and don't throw an exception


### PR DESCRIPTION
It was reported that on linux, the order of contentToPack was alphanumeric.

I wasn't able to reproduce this issue, anyway I think this can solve the issue.