### PR TITLE
docs: fix links to prevent default navigation and include target='_bl…

### DIFF
--- a/cmf-cli/resources/template_feed/helpSrcPkg/Help.Src.Package/assets/%dfPackageName%.techspec/index.md
+++ b/cmf-cli/resources/template_feed/helpSrcPkg/Help.Src.Package/assets/%dfPackageName%.techspec/index.md
@@ -1,11 +1,11 @@
-# MES Administration Usefull Links
+# MES Administration Useful Links
 | Section                                                          |
 |------------------------------------------------------------------|
-| [Administration Landing Page](/LandingPage/Administration)	   |
-| [Configuration](/Administration/Configuration)                   |
-| [DEE Actions](/Administration/DEEActions)		                   |
-| [Entity Types](/Administration/EntityType)		               |
-| [Localized Messages](/Administration/LocalizedMessages)          |
-| [Name Generators](/Administration/NameGenerators)	               |
-| [Security](/Administration/Security)	                           |
-| [Tables](/Administration/Tables)			                       |
+| <a href="/LandingPage/Administration" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Administration Landing Page</a> |
+| <a href="/Administration/Configuration" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Configuration</a> |
+| <a href="/Administration/DEEActions" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">DEE Actions</a> |
+| <a href="/Administration/EntityType" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Entity Types</a> |
+| <a href="/Administration/LocalizedMessages" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Localized Messages</a> |
+| <a href="/Administration/NameGenerators" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Name Generators</a> |
+| <a href="/Administration/Security" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Security</a> |
+| <a href="/Administration/Tables" onclick="event.preventDefault(); event.stopImmediatePropagation(); window.open(this.href, '_blank');">Tables</a> |


### PR DESCRIPTION
Since this page navigate from Documentation Portal to MES, it's necessary to force the links to open in a new tab; otherwise, the default navigation will try to navigate incorrectly.
![image](https://github.com/criticalmanufacturing/cli/assets/52329533/933b376a-ed87-40b6-baff-3f56cd66f811)
