### PR TITLE
Feat: cmf menu

### DIFF
--- a/cmf-cli/Builders/ProcessCommand.cs
+++ b/cmf-cli/Builders/ProcessCommand.cs
@@ -5,25 +5,25 @@ using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.IO.Abstractions;
 using System.Linq;
+using System.Media;
 using System.Threading.Tasks;
 
 namespace Cmf.CLI.Builders
 {
     /// <summary>
-    ///
     /// </summary>
     public abstract class ProcessCommand : IProcessCommand
     {
         /// <summary>
-        /// the underlying file system
+        ///     the underlying file system
         /// </summary>
         protected IFileSystem fileSystem = new FileSystem();
 
         /// <summary>
-        /// Gets or sets the working directory.
+        ///     Gets or sets the working directory.
         /// </summary>
         /// <value>
-        /// The working directory.
+        ///     The working directory.
         /// </value>
         public IDirectoryInfo WorkingDirectory { get; set; }
 
@@ -33,9 +33,10 @@ namespace Cmf.CLI.Builders
         }
 
         /// <summary>
-        /// Executes this instance.
+        ///     Executes this instance.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// </returns>
         public Task Exec()
         {
             foreach (var step in this.GetSteps())
@@ -88,6 +89,11 @@ namespace Cmf.CLI.Builders
                     ps.WaitForExit();
                     if (ps.ExitCode != 0)
                     {
+                        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                        {
+                            // SoundPlayer is only supported on windows
+                            new SoundPlayer(@"C:\Windows\Media\chord.wav").PlaySync();
+                        }
                         throw new CliException($"Command '{command} {String.Join(' ', step.Args)}' did not finish successfully: Exit code {ps.ExitCode}. Please check the log for more details");
                     }
                     ps.Dispose();
@@ -102,9 +108,10 @@ namespace Cmf.CLI.Builders
         }
 
         /// <summary>
-        /// Gets the steps.
+        ///     Gets the steps.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// </returns>
         public abstract ProcessBuildStep[] GetSteps();
     }
 }

--- a/cmf-cli/Commands/bump/BumpCommand.cs
+++ b/cmf-cli/Commands/bump/BumpCommand.cs
@@ -14,16 +14,16 @@ using System.IO.Abstractions;
 namespace Cmf.CLI.Commands
 {
     /// <summary>
-    ///
     /// </summary>
-    /// <seealso cref="BaseCommand" />
+    /// <seealso cref="BaseCommand"/>
     [CmfCommand("bump", Id = "bump")]
     public class BumpCommand : BaseCommand
     {
         /// <summary>
-        /// Configure command
+        ///     Configure command
         /// </summary>
-        /// <param name="cmd"></param>
+        /// <param name="cmd">
+        /// </param>
         public override void Configure(Command cmd)
         {
             cmd.AddArgument(new Argument<DirectoryInfo>(
@@ -43,20 +43,44 @@ namespace Cmf.CLI.Commands
                 aliases: new string[] { "-r", "--root" },
                 description: "Will bump only versions under a specific root folder (i.e. 1.0.0)"));
 
+            cmd.AddOption(new Option<bool>(
+                aliases: new string[] { "-p", "--parentDep" },
+                getDefaultValue: () => false,
+                description: "Will bump the dependency version on parent packages"));
+
+            cmd.AddOption(new Option<bool>(
+                aliases: new string[] { "-f", "--renameVersionFolders" },
+                getDefaultValue: () => false,
+                description: "Will rename Version folders from old to new version"));
+
             // Add the handler
-            cmd.Handler = CommandHandler.Create<DirectoryInfo, string, string, string>(Execute);
+            cmd.Handler = CommandHandler.Create<DirectoryInfo, string, string, string, bool, bool>(Execute);
         }
 
         /// <summary>
-        /// Executes the specified package path.
+        ///     Executes the specified package path.
         /// </summary>
-        /// <param name="packagePath">The package path.</param>
-        /// <param name="version">The version.</param>
-        /// <param name="buildNr">The version for build Nr.</param>
-        /// <param name="root">The root.</param>
-        /// <exception cref="CliException"></exception>
-        /// <exception cref="CliException"></exception>
-        public void Execute(DirectoryInfo packagePath, string version, string buildNr, string root)
+        /// <param name="packagePath">
+        ///     The package path.
+        /// </param>
+        /// <param name="version">
+        ///     The version.
+        /// </param>
+        /// <param name="buildNr">
+        ///     The version for build Nr.
+        /// </param>
+        /// <param name="root">
+        ///     The root.
+        /// </param>
+        /// <param name="parentDep">
+        ///     Flag indicating if the dependency version in all parent packages will be updated.
+        /// </param>
+        /// <param name="renameVersionFolders">
+        ///     Flag indicating if version folders will be renamed.
+        /// </param>
+        /// <exception cref="CliException">
+        /// </exception>
+        public void Execute(DirectoryInfo packagePath, string version, string buildNr, string root, bool parentDep, bool renameVersionFolders)
         {
             using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.New($"{packagePath}/{CliConstants.CmfPackageFileName}");
@@ -69,20 +93,44 @@ namespace Cmf.CLI.Commands
             // Reading cmfPackage
             CmfPackage cmfPackage = CmfPackage.Load(cmfpackageFile);
 
-            Execute(cmfPackage, version, buildNr, root);
+            Execute(
+                cmfPackage,
+                version,
+                buildNr,
+                root,
+                packagesToUpdateDep: parentDep ? FileSystemUtilities.GetAllPackages(fileSystem) : null,
+                renameVersionFolders: renameVersionFolders
+            );
         }
 
         /// <summary>
-        /// Executes the specified CMF package.
+        ///     Executes the specified CMF package.
         /// </summary>
-        /// <param name="cmfPackage">The CMF package.</param>
-        /// <param name="version">The version.</param>
-        /// <param name="buildNr">The version for build Nr.</param>
-        /// <param name="root">The root.</param>
-        /// <exception cref="CliException"></exception>
-        public void Execute(CmfPackage cmfPackage, string version, string buildNr, string root)
+        /// <param name="cmfPackage">
+        ///     The CMF package.
+        /// </param>
+        /// <param name="version">
+        ///     The version.
+        /// </param>
+        /// <param name="buildNr">
+        ///     The version for build Nr.
+        /// </param>
+        /// <param name="root">
+        ///     The root.
+        /// </param>
+        /// <param name="packagesToUpdateDep">
+        ///     <para>CmfPackages to check and update dependency version.</para>
+        ///     <para>Default = null (means that dependency version wont be updated in any package)</para>
+        /// </param>
+        /// <param name="renameVersionFolders">
+        ///     Flag indicating if version folders will be renamed.
+        /// </param>
+        /// <exception cref="CliException">
+        /// </exception>
+        public void Execute(CmfPackage cmfPackage, string version, string buildNr, string root, CmfPackageCollection packagesToUpdateDep = null, bool renameVersionFolders = false)
         {
-            IDirectoryInfo packageDirectory = cmfPackage.GetFileInfo().Directory;
+            string oldVersion = cmfPackage.Version;
+
             IPackageTypeHandler packageTypeHandler = PackageTypeFactory.GetPackageTypeHandler(cmfPackage);
 
             // Will execute specific bump code per Package Type
@@ -95,6 +143,20 @@ namespace Cmf.CLI.Commands
 
             // will save with new version
             cmfPackage.SaveCmfPackage();
+
+            // Update Version in package dependencies
+            if (packagesToUpdateDep.HasAny())
+            {
+                foreach (CmfPackage packageToUpdate in packagesToUpdateDep)
+                {
+                    packageToUpdate.UpdateDependency(cmfPackage);
+                }
+            }
+
+            if (renameVersionFolders)
+            {
+                cmfPackage.RenameVersionFolders(oldVersion);
+            }
         }
     }
 }

--- a/cmf-cli/Commands/bump/BumpInteractiveCommand.cs
+++ b/cmf-cli/Commands/bump/BumpInteractiveCommand.cs
@@ -1,0 +1,84 @@
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Bump
+{
+    /// <summary>
+    ///     BumpInteractiveCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("interactive", Id = "bump_interactive", ParentId = "bump")]
+    public class BumpInteractiveCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            CmfPackageCollection allPackages = FileSystemUtilities.GetAllPackages(fileSystem);
+
+            foreach (CmfPackage package in allPackages)
+            {
+                Log.Verbose("");
+                Log.Verbose($"{package.PackageId}");
+                Log.Verbose($"Current version: {package.Version}");
+                string option = GenericUtilities.ReadStringValueFromConsole(prompt: "Bump? (Y/n):", allowEmptyValueInput: true, allowedValues: new string[] { "y", "n" });
+
+                if (string.IsNullOrEmpty(option) || option.IgnoreCaseEquals("y"))
+                {
+                    Version version = new Version(package.Version);
+                    string newVersion = string.Empty;
+                    switch (GenericUtilities.ReadStringValueFromConsole(prompt: "Version to bump (a - Major) (i - Minor) (p - Patch):", allowedValues: new string[] { "a", "i", "p" }))
+                    {
+                        case "a":
+                            {
+                                newVersion = $"{version.Major + 1}.0.0";
+                                break;
+                            }
+                        case "i":
+                            {
+                                newVersion = $"{version.Major}.{version.Minor + 1}.0";
+                                break;
+                            }
+                        case "p":
+                            {
+                                newVersion = $"{version.Major}.{version.Minor}.{version.Build + 1}";
+                                break;
+                            }
+                    }
+
+                    string updateDepInParOption = GenericUtilities.ReadStringValueFromConsole(prompt: "Update in Parent Packages? (Y/n):", allowEmptyValueInput: true, allowedValues: new string[] { "y", "n" });
+                    string renameVersionFoldersOption = GenericUtilities.ReadStringValueFromConsole(prompt: "Rename Version folders? (Y/n):", allowEmptyValueInput: true, allowedValues: new string[] { "y", "n" });
+
+                    // Change Current Directory because BumpCommand uses it
+                    Environment.CurrentDirectory = package.GetFileInfo().Directory.FullName;
+
+                    new BumpCommand().Execute(
+                        cmfPackage: package,
+                        version: newVersion,
+                        buildNr: null,
+                        root: null,
+                        packagesToUpdateDep: (string.IsNullOrEmpty(updateDepInParOption) || updateDepInParOption.IgnoreCaseEquals("y")) ? allPackages : null,
+                        renameVersionFolders: string.IsNullOrEmpty(renameVersionFoldersOption) || renameVersionFoldersOption.IgnoreCaseEquals("y")
+                    );
+                }
+            }
+        }
+    }
+}

--- a/cmf-cli/Commands/dbManager/BackupDatabaseCommand.cs
+++ b/cmf-cli/Commands/dbManager/BackupDatabaseCommand.cs
@@ -1,0 +1,66 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.DbManager
+{
+    /// <summary>
+    ///     BackupDatabaseCommand
+    /// </summary>
+    [CmfCommand("backup", Id = "dbmanager_backup", ParentId = "dbmanager")]
+    public class BackupDatabaseCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "--backupName" },
+                    getDefaultValue: () => null,
+                    description: "Backup Name."
+                )
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute(string backupName = null)
+        {
+            string defaultDbName = ExecutionContext.Instance.ProjectConfig.EnvironmentName;
+            string currentDb = GenericUtilities.GetCurrentDb(fileSystem);
+
+            if (backupName.IsNullOrEmpty())
+            {
+                backupName = GenericUtilities.ReadStringValueFromConsole(prompt: $"Backup name (Press ENTER to use the current '{currentDb}'):", allowEmptyValueInput: true);
+                if (backupName.IsNullOrEmpty())
+                {
+                    backupName = currentDb;
+                }
+            }
+
+            string backupFileName = $"Custom-{backupName}.bak";
+
+            Log.Status("Backing up database", (_) =>
+            {
+                GenericUtilities.ExecuteSqlCommand(
+                    connectionString: $"Data Source=127.0.0.1,1433;Initial Catalog=master;User ID={CoreConstants.LocalDbUser};Password={CoreConstants.LocalDbPassword}",
+                    sqlCommand: $"USE[{defaultDbName}]; BACKUP DATABASE [{defaultDbName}] TO DISK = N'/DBDumps/{backupFileName}' WITH NOFORMAT, INIT, NAME = N'{defaultDbName}-Full Database Backup', SKIP, NOREWIND, NOUNLOAD, STATS = 10"
+                );
+
+                Log.Information($"DB backup '{backupFileName}' created.");
+            });
+        }
+    }
+}

--- a/cmf-cli/Commands/dbManager/DbManagerCommand.cs
+++ b/cmf-cli/Commands/dbManager/DbManagerCommand.cs
@@ -1,0 +1,31 @@
+﻿using Cmf.CLI.Core.Attributes;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands
+{
+    /// <summary>
+    ///     DbManagerCommand
+    /// </summary>
+    [CmfCommand("dbmanager", Id = "dbmanager")]
+    public class DbManagerCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+        }
+    }
+}

--- a/cmf-cli/Commands/dbManager/DeleteDatabaseBackupCommand.cs
+++ b/cmf-cli/Commands/dbManager/DeleteDatabaseBackupCommand.cs
@@ -1,0 +1,75 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO;
+
+namespace Cmf.CLI.Commands.DbManager
+{
+    /// <summary>
+    ///     DeleteDatabaseBackupCommand
+    /// </summary>
+    [CmfCommand("delete", Id = "dbmanager_delete", ParentId = "dbmanager")]
+    public class DeleteDatabaseBackupCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "-f", "--backupFileName" },
+                    getDefaultValue: () => null,
+                    description: "Backup file name (e.g.: Custom-Babkup.bak)."
+                )
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute(string backupFileName = null)
+        {
+            Log.Verbose("");
+
+            // Set initial backupFilePath
+            string backupFilePath = fileSystem.Path.Combine(FileSystemUtilities.GetProjectRoot(fileSystem).FullName, "LocalEnvironment", "DBDumps", backupFileName.IsNullOrEmpty() ? "" : backupFileName);
+
+            string[] dbBackups = GenericUtilities.GetBdBackups(fileSystem);
+
+            if (backupFileName.IsNullOrEmpty())
+            {
+                Log.Verbose("Select DB backup file to delete:");
+                for (int i = 0; i < dbBackups.Length; i++)
+                {
+                    Log.Verbose($"{i + 1} - {Path.GetFileName(dbBackups[i])}");
+                }
+                int option = GenericUtilities.ReadIntValueFromConsole(
+                    prompt: "Option:",
+                    minValue: 1,
+                    maxValue: dbBackups.Length
+                );
+                backupFilePath = dbBackups[option - 1];
+                backupFileName = Path.GetFileName(backupFilePath);
+            }
+            else if (!File.Exists(backupFilePath))
+            {
+                throw new FileNotFoundException($"DB Backup '{backupFileName}' doesn't exist.");
+            }
+
+            Log.Status("Deleting backup file", (_) =>
+            {
+                File.Delete(backupFilePath);
+
+                Log.Information($"Deleted '{backupFileName}'.");
+            });
+        }
+    }
+}

--- a/cmf-cli/Commands/dbManager/RestoreDatabaseCommand.cs
+++ b/cmf-cli/Commands/dbManager/RestoreDatabaseCommand.cs
@@ -1,0 +1,80 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO;
+
+namespace Cmf.CLI.Commands.DbManager
+{
+    /// <summary>
+    ///     RestoreDatabaseCommand
+    /// </summary>
+    [CmfCommand("restore", Id = "dbmanager_restore", ParentId = "dbmanager")]
+    public class RestoreDatabaseCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "-f", "--backupFileName" },
+                    getDefaultValue: () => null,
+                    description: "Backup Name (e.g.: Custom-Babkup.bak)."
+                )
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute(string backupFileName = null)
+        {
+            string defaultDbName = ExecutionContext.Instance.ProjectConfig.EnvironmentName;
+
+            Log.Verbose("");
+            Log.Verbose($"Current database: {GenericUtilities.GetCurrentDb(fileSystem)}");
+            Log.Warning("Close all programs using the DB (e.g.: HostService)");
+
+            string[] dbBackups = GenericUtilities.GetBdBackups(fileSystem);
+
+            if (backupFileName.IsNullOrEmpty())
+            {
+                Log.Verbose("Select DB backup to restore:");
+                for (int i = 0; i < dbBackups.Length; i++)
+                {
+                    Log.Verbose($"{i + 1} - {Path.GetFileName(dbBackups[i])}");
+                }
+                int option = GenericUtilities.ReadIntValueFromConsole(
+                    prompt: "Option:",
+                    minValue: 1,
+                    maxValue: dbBackups.Length
+                );
+                backupFileName = Path.GetFileName(dbBackups[option - 1]);
+            }
+            else if (!File.Exists(fileSystem.Path.Combine(FileSystemUtilities.GetProjectRoot(fileSystem).FullName, "LocalEnvironment", "DBDumps", backupFileName)))
+            {
+                throw new FileNotFoundException($"DB Backup '{backupFileName}' doesn't exist.");
+            }
+
+            Log.Status("Restoring database", (_) =>
+            {
+                GenericUtilities.ExecuteSqlCommand(
+                    connectionString: $"Data Source=127.0.0.1,1433;Initial Catalog=master;User ID={CoreConstants.LocalDbUser};Password={CoreConstants.LocalDbPassword}",
+                    sqlCommand: $"USE[master] RESTORE DATABASE[{defaultDbName}] FROM DISK = N'/DBDumps/{backupFileName}' WITH FILE = 1, MOVE N'{defaultDbName}_Primary' TO N'/var/opt/mssql/data/{defaultDbName}.mdf', MOVE N'{defaultDbName}_FG_MainTableDat_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_MainTableDat_1.ndf', MOVE N'{defaultDbName}_FG_MainTableIdx_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_MainTableIdx_1.ndf', MOVE N'{defaultDbName}_FG_HstTableDat_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_HstTableDat_1.ndf', MOVE N'{defaultDbName}_FG_HstTableIdx_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_HstTableIdx_1.ndf', MOVE N'{defaultDbName}_FG_MappingTableIdx_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_MappingTableIdx_1.ndf', MOVE N'{defaultDbName}_FG_MappingTableDat_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_MappingTableDat_1.ndf', MOVE N'{defaultDbName}_FG_MappingHstIdx_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_MappingHstIdx_1.ndf', MOVE N'{defaultDbName}_FG_MappingHstDat_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_MappingHstDat_1.ndf', MOVE N'{defaultDbName}_FG_IntegrationTableIdx_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_IntegrationTableIdx_1.ndf', MOVE N'{defaultDbName}_FG_IntegrationTableDat_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_IntegrationTableDat_1.ndf', MOVE N'{defaultDbName}_FG_IntegrationHstIdx_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_IntegrationHstIdx_1.ndf', MOVE N'{defaultDbName}_FG_IntegrationHstDat_1' TO N'/var/opt/mssql/data/{defaultDbName}_FG_IntegrationHstDat_1.ndf', MOVE N'{defaultDbName}_log' TO N'/var/opt/mssql/data/{defaultDbName}.ldf', NOUNLOAD, STATS = 5"
+                );
+
+                Log.Information($"Restored '{backupFileName}'.");
+            });
+        }
+    }
+}

--- a/cmf-cli/Commands/generate/GenerateCommand.cs
+++ b/cmf-cli/Commands/generate/GenerateCommand.cs
@@ -1,0 +1,32 @@
+using Cmf.CLI.Core.Attributes;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands
+{
+    /// <summary>
+    ///     GenerateCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("generate", Id = "generate")]
+    public class GenerateCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+        }
+    }
+}

--- a/cmf-cli/Commands/generate/GenerateDocumentationCommand.cs
+++ b/cmf-cli/Commands/generate/GenerateDocumentationCommand.cs
@@ -1,0 +1,52 @@
+﻿using Cmf.CLI.Builders;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Commands.Generate
+{
+    /// <summary>
+    ///     GenerateDocumentationCommand
+    /// </summary>
+    [CmfCommand("documentation", Id = "generate_documentation", ParentId = "generate")]
+    public class GenerateDocumentationCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            IDirectoryInfo helpDirectory = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.Help).GetFileInfo().Directory;
+
+            Environment.CurrentDirectory = helpDirectory.FullName;
+
+            new GenerateBasedOnTemplatesCommand().Execute();
+            new GenerateMenuItemsCommand().Execute();
+
+            new GulpCommand()
+            {
+                GulpFile = "gulpfile.js",
+                Task = "build",
+                DisplayName = "Build Help",
+                GulpJS = "node_modules/gulp/bin/gulp.js",
+                Args = new[] { "--production" },
+                WorkingDirectory = helpDirectory
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/Commands/generate/GenerateLBOsCommand.cs
+++ b/cmf-cli/Commands/generate/GenerateLBOsCommand.cs
@@ -1,0 +1,50 @@
+﻿using Cmf.CLI.Builders;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Generate
+{
+    /// <summary>
+    ///     GenerateLBOsCommand
+    /// </summary>
+    [CmfCommand("lbos", Id = "generate_lbos", ParentId = "generate")]
+    public class GenerateLBOsCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            string powershellExe = GenericUtilities.GetPowerShellExecutable();
+            string generateLBOsScriptPath = fileSystem.Path.Join("Libs", "LBOs", "generateLBOs.ps1");
+
+            CmfGenericUtilities.StartProjectDbContainer(fileSystem);
+            CmfGenericUtilities.BuildAllPackagesOfType(PackageType.Business, fileSystem);
+
+            Log.Information("GenerateLBOs PowerShell Script");
+            new CmdCommand()
+            {
+                DisplayName = $"{powershellExe} .\\{generateLBOsScriptPath}",
+                Command = $"{powershellExe} .\\{generateLBOsScriptPath}",
+                Args = Array.Empty<string>(),
+                WorkingDirectory = FileSystemUtilities.GetProjectRoot(fileSystem)
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/Commands/generate/GenerateReleaseNotesCommand.cs
+++ b/cmf-cli/Commands/generate/GenerateReleaseNotesCommand.cs
@@ -1,0 +1,247 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using Newtonsoft.Json;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO;
+using System.IO.Abstractions;
+using System.Net.Http;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Web;
+
+namespace Cmf.CLI.Commands.Generate
+{
+    /// <summary>
+    ///     GenerateReleaseNotesCommand
+    /// </summary>
+    [CmfCommand("releasenotes", Id = "generate_releasenotes", ParentId = "generate")]
+    public class GenerateReleaseNotesCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "--date" },
+                    getDefaultValue: () => DateTime.Now.ToString("yyyy/MM/dd"),
+                    description: "Release Notes date."
+                )
+            );
+
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "--includes" },
+                    getDefaultValue: () => "-",
+                    description: "List of previous package versions included in current package (separated by \",\" comma)."
+                )
+            );
+
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "--customDependsOnVersion" },
+                    getDefaultValue: () => "-",
+                    description: "Package version in which current Package depends on."
+                )
+            );
+
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "--tfsProject" },
+                    getDefaultValue: () => ExecutionContext.Instance.ProjectConfig.ProjectName,
+                    description: "Tfs Project Name."
+                )
+            );
+
+            cmd.AddOption(
+                new Option<string>(
+                    aliases: new[] { "--tfsProjectTeam" },
+                    description: "Tfs Project Team Name."
+                )
+                { IsRequired = true }
+            );
+
+            cmd.AddOption(
+                new Option<bool>(
+                    aliases: new[] { "--removeHtmlTags" },
+                    getDefaultValue: () => true,
+                    description: "Remove Html Tags."
+                )
+            );
+
+            cmd.AddOption(
+                new Option<bool>(
+                    aliases: new[] { "--onlyResolvedOrClosed" },
+                    getDefaultValue: () => false,
+                    description: "Get only Work Items with State \"Resolved\" or \"Closed\"."
+                )
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute(string date = null, string includes = "-", string customDependsOnVersion = "-", string tfsProject = null, string tfsProjectTeam = null, bool removeHtmlTags = true, bool onlyResolvedOrClosed = false)
+        {
+            #region Input Date
+
+            // If no Date was inputed in parameter (when executing trough `cmf menu`)
+            if (string.IsNullOrEmpty(date))
+            {
+                int yearInput = GenericUtilities.ReadIntValueFromConsole(prompt: "Year (empty to use current):", allowEmptyValueInput: true);
+                int year = yearInput == 0 ? DateTime.Now.Year : yearInput;
+
+                int monthInput = GenericUtilities.ReadIntValueFromConsole(prompt: "Month (empty to use current):", minValue: 1, maxValue: 12, allowEmptyValueInput: true);
+                int month = monthInput == 0 ? DateTime.Now.Month : monthInput;
+
+                int dayInput = GenericUtilities.ReadIntValueFromConsole(prompt: "Day (empty to use current):", minValue: 1, maxValue: DateTime.DaysInMonth(year, month), allowEmptyValueInput: true);
+                int day = dayInput == 0 ? DateTime.Now.Day : dayInput;
+                date = new DateTime(year, month, day).ToString("yyyy/MM/dd");
+            }
+
+            if (!DateTime.TryParse(date, out DateTime __))
+            {
+                Log.Error("Invalid input date. Try again.");
+                return;
+            }
+
+            #endregion Input Date
+
+            #region Validate/Set Input data
+
+            tfsProject = string.IsNullOrEmpty(tfsProject) ? ExecutionContext.Instance.ProjectConfig.ProjectName : tfsProject;
+
+            if (string.IsNullOrEmpty(tfsProjectTeam))
+            {
+                tfsProjectTeam = GenericUtilities.ReadValueFromConsole<string>(prompt: "Tfs Project Team:");
+            }
+
+            #endregion Validate/Set Input data
+
+            #region Get WI and Generate Release Notes file
+
+            CmfPackage helpPackage = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.Help);
+            IFileInfo helpPackageFileInfo = helpPackage.GetFileInfo();
+
+            string srcPackage = Directory.GetDirectories($@"{helpPackageFileInfo.Directory}\src\packages")[0];
+            string releaseNotesFolderPath = Array.Find(Directory.GetDirectories($@"{srcPackage}\assets"), dir => dir.Contains("releasenotes"));
+            if (string.IsNullOrEmpty(releaseNotesFolderPath))
+            {
+                Log.Error("Release Notes folder not found.");
+            }
+            string releaseNotesTemplateFile = $@"{releaseNotesFolderPath}\packagetemplate";
+
+            string query = $"SELECT [System.Id], [System.Title], [System.WorkItemType], [System.State], [Project.ReleaseNotes] FROM workitems WHERE [System.TeamProject] = \"{tfsProject}\" AND [System.WorkItemType] IN (\"User Story\", \"Bug\") AND NOT [System.Tags] CONTAINS \"Internal\" AND NOT [System.Tags] CONTAINS \"Product\" AND NOT [System.Tags] CONTAINS \"T&M\" AND [Project.DocumentationImpact] CONTAINS \"{helpPackage.Version}\" {(onlyResolvedOrClosed ? "AND ([System.State] = \"Resolved\" OR [System.State] = \"Closed\")" : "")} ORDER BY [System.WorkItemType] DESC";
+            StringContent body = new StringContent(JsonConvert.SerializeObject(new { query }), Encoding.UTF8, "application/json");
+
+            using HttpClient client = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true });
+            client.DefaultRequestHeaders.Add("ContentType", "application/json");
+            client.DefaultRequestHeaders.Add("Accept", "application/json;api-version=4.1;excludeUrls=true");
+            client.DefaultRequestHeaders.Add("Accept-Encoding", "gzip, deflate, br");
+
+            string uri = $"{CoreConstants.TfsServerUrl}/{HttpUtility.UrlPathEncode(tfsProject)}/{HttpUtility.UrlPathEncode(tfsProjectTeam)}/_apis/wit/wiql?timePrecision=true&$top=50";
+
+            // TODO: FIX returning bad response (might be related with server?)
+            /*
+             * when using a random Tfs Project Team, it gets an error response body with a readable message
+             * when using a correct Tfs Project Team, it gets an unreadable response with strange characters (responseContent = "\u001f�\b\0\0\0\0\0\u0004\0��\a`\u001cI�%&/m�{\u007fJ�J��t�\b�`\u0013$ؐ...)
+             */
+            HttpResponseMessage response = client.PostAsync(uri, body).Result;
+            string responseContent = response.Content.ReadAsStringAsync().Result;
+            dynamic responseObject = JsonConvert.DeserializeObject(responseContent);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new CliException(responseObject["message"].Value);
+            }
+
+            string columns = string.Empty;
+            string workItemIds = string.Empty;
+
+            foreach (dynamic column in responseObject.columns)
+            {
+                if (!string.IsNullOrEmpty(columns))
+                    columns += ",";
+                columns += column.referenceName;
+            }
+
+            foreach (dynamic column in responseObject.workItems)
+            {
+                if (!string.IsNullOrEmpty(workItemIds))
+                    workItemIds += ",";
+                workItemIds += column.id;
+            }
+
+            string releaseNotesContent = string.Empty;
+            if (!string.IsNullOrEmpty(workItemIds))
+            {
+                string workItemsUri = $"{CoreConstants.TfsServerUrl}/_apis/wit/workItems?ids={workItemIds}&fields={columns}";
+                string workItemsResponseContent = client.GetAsync(workItemsUri).GetAwaiter().GetResult().Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                dynamic workItems = JsonConvert.DeserializeObject(workItemsResponseContent);
+
+                releaseNotesContent += "## User Stories/Bugs\n\n";
+                releaseNotesContent += "| Title        | Notes            |\n";
+                releaseNotesContent += "| :----------- | :--------------- |\n";
+
+                foreach (dynamic column in responseObject.workItems)
+                {
+                    string workItemId = column.id.ToString();
+                    dynamic item = null;
+                    foreach (dynamic wi in workItems.value)
+                    {
+                        if (wi.id.ToString() == workItemId)
+                        {
+                            item = wi.fields;
+                            break;
+                        }
+                    }
+                    if (item == null)
+                        throw new CliException("Item not found");
+
+                    string releasenotes = item.Project.ReleaseNotes ?? "-";
+                    if (removeHtmlTags)
+                    {
+                        releasenotes = Regex.Replace(releasenotes, "<[^>]*?>", "");
+                    }
+
+                    string idSection = $"**{item.id}**";
+                    bool isBug = item.System.WorkItemType != "User Story";
+                    if (isBug)
+                    {
+                        idSection = "<span style='color:red'>" + idSection + "</span>";
+                    }
+                    releaseNotesContent += $"| {idSection} {item.System.Title} | {releasenotes} |\n";
+                }
+            }
+
+            string packageTemplateContent = File.ReadAllText(releaseNotesTemplateFile, Encoding.UTF8)
+                .Replace("@PackageId@", helpPackage.PackageName)
+                .Replace("@SprintNumber@", Regex.Replace(helpPackage.Version, "Sprint", ""))
+                .Replace("@PackageVersion@", helpPackage.Version)
+                .Replace("@ExpectedReleaseDate@", date)
+                .Replace("@PackageDeliverablesIncluded@", includes)
+                .Replace("@MESVersion@", ExecutionContext.Instance.ProjectConfig.MESVersion.ToString())
+                .Replace("@CustomDependsOn@", customDependsOnVersion)
+                .Replace("@UserStories@", releaseNotesContent);
+
+            string outputFileName = releaseNotesTemplateFile.Replace("packagetemplate", $"{date.Replace("/", "")}-{helpPackage.Version.Replace(".", "_")}.md");
+            File.WriteAllText(outputFileName, packageTemplateContent, Encoding.UTF8);
+
+            #endregion Get WI and Generate Release Notes file
+
+            new GenerateDocumentationCommand().Execute();
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallBusinessCommand.cs
+++ b/cmf-cli/Commands/install/InstallBusinessCommand.cs
@@ -1,0 +1,48 @@
+﻿using Cmf.CLI.Core.Attributes;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Install
+{
+    /// <summary>
+    ///     InstallBusinessCommand
+    /// </summary>
+    [CmfCommand("business", Id = "install_business", ParentId = "install")]
+    public class InstallBusinessCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<long>(
+                    aliases: new[] { "--licenseId" },
+                    description: "Project License Id"
+                )
+                { IsRequired = true }
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the commands:
+        ///     <list type="number">
+        ///         <item><see cref="InstallBusinessDatabaseCommand"/></item>
+        ///         <item><see cref="InstallBusinessLocalEnvCommand"/></item>
+        ///     </list>
+        /// </summary>
+        /// <param name="licenseId">
+        ///     Project License Id
+        /// </param>
+        public void Execute(long licenseId)
+        {
+            new InstallBusinessDatabaseCommand().Execute(licenseId);
+            new InstallBusinessLocalEnvCommand().Execute();
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallBusinessDatabaseCommand.cs
+++ b/cmf-cli/Commands/install/InstallBusinessDatabaseCommand.cs
@@ -1,0 +1,65 @@
+﻿using Cmf.CLI.Builders;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Commands.Install
+{
+    /// <summary>
+    ///     InstallBusinessDatabaseCommand
+    /// </summary>
+    [CmfCommand("database", Id = "install_business_database", ParentId = "install_business")]
+    public class InstallBusinessDatabaseCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<long>(
+                    aliases: new[] { "--licenseId" },
+                    description: "Project License Id"
+                )
+                { IsRequired = true }
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        ///     <code>
+        ///cmf-dev local db --license {licenseId};
+        ///     </code>
+        /// </summary>
+        /// <param name="licenseId">
+        ///     Project License Id
+        /// </param>
+        public void Execute(long licenseId)
+        {
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+            // Set default DB as current DB
+            Log.Information($"Setting default DB as {ExecutionContext.Instance.ProjectConfig.EnvironmentName}");
+            GenericUtilities.SetCurrentDb(fileSystem, $"{ExecutionContext.Instance.ProjectConfig.EnvironmentName}");
+
+            // cmf-dev local db --license {licenseId};
+            Log.Information("Install Business Database");
+            new CmdCommand()
+            {
+                DisplayName = $"cmf-dev local db --license {licenseId}",
+                Command = "cmf-dev local db",
+                Args = new string[] { $"--license {licenseId}" },
+                WorkingDirectory = projectRoot
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallBusinessLocalEnvCommand.cs
+++ b/cmf-cli/Commands/install/InstallBusinessLocalEnvCommand.cs
@@ -1,0 +1,50 @@
+﻿using Cmf.CLI.Builders;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Commands.Install
+{
+    /// <summary>
+    ///     InstallBusinessLocalEnvCommand
+    /// </summary>
+    [CmfCommand("localenv", Id = "install_business_localenv", ParentId = "install_business")]
+    public class InstallBusinessLocalEnvCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        ///     <code>
+        ///cmf-dev local env;
+        ///     </code>
+        /// </summary>
+        public void Execute()
+        {
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+            // cmf-dev local env;
+            Log.Information("Install Business Local Env");
+            new CmdCommand()
+            {
+                DisplayName = "cmf-dev local env",
+                Command = "cmf-dev local env",
+                Args = Array.Empty<string>(),
+                WorkingDirectory = projectRoot
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallCommand.cs
+++ b/cmf-cli/Commands/install/InstallCommand.cs
@@ -1,0 +1,53 @@
+using Cmf.CLI.Commands.Install;
+using Cmf.CLI.Core.Attributes;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands
+{
+    /// <summary>
+    ///     InstallCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("install", Id = "install")]
+    public class InstallCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<long>(
+                    aliases: new[] { "--licenseId" },
+                    description: "Project License Id"
+                )
+                { IsRequired = true }
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     <para>Installs everything needed for the local environment to work</para>
+        ///     <para>Executes the commands:</para>
+        ///     <list type="number">
+        ///         <item><see cref="InstallBusinessCommand"/></item>
+        ///         <item><see cref="InstallHtmlCommand"/></item>
+        ///         <item><see cref="InstallHelpCommand"/></item>
+        ///     </list>
+        /// </summary>
+        /// <param name="licenseId">
+        ///     Project License Id
+        /// </param>
+        public void Execute(long licenseId)
+        {
+            new InstallBusinessCommand().Execute(licenseId);
+            new InstallHtmlCommand().Execute();
+            new InstallHelpCommand().Execute();
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallHelpCommand.cs
+++ b/cmf-cli/Commands/install/InstallHelpCommand.cs
@@ -1,0 +1,46 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Commands.Install
+{
+    /// <summary>
+    ///     InstallHelpCommand
+    /// </summary>
+    [CmfCommand("help", Id = "install_help", ParentId = "install")]
+    public class InstallHelpCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            CmfPackage helpPackage = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.Help);
+
+            Log.Information($"Install Help: {helpPackage.PackageId}");
+            IDirectoryInfo helpPackageDirectory = helpPackage.GetFileInfo().Directory;
+
+            // Set the "Environment.CurrentDirectory" to the Help Package directory because "GenerateBasedOnTemplatesCommand" is using the "Environment.CurrentDirectory"
+            Environment.CurrentDirectory = helpPackageDirectory.FullName;
+
+            new BuildCommand(fileSystem).Execute(helpPackageDirectory);
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallHtmlCommand.cs
+++ b/cmf-cli/Commands/install/InstallHtmlCommand.cs
@@ -1,0 +1,39 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Install
+{
+    /// <summary>
+    ///     InstallHtmlCommand
+    /// </summary>
+    [CmfCommand("html", Id = "install_html", ParentId = "install")]
+    public class InstallHtmlCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            CmfPackage htmlPackage = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.HTML);
+
+            Log.Information($"Install HTML: {htmlPackage.PackageId}");
+            new BuildCommand(fileSystem).Execute(htmlPackage.GetFileInfo().Directory);
+        }
+    }
+}

--- a/cmf-cli/Commands/install/InstallIotCommand.cs
+++ b/cmf-cli/Commands/install/InstallIotCommand.cs
@@ -1,0 +1,39 @@
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Install
+{
+    /// <summary>
+    ///     InstallIotCommand
+    /// </summary>
+    [CmfCommand("iot", Id = "install_iot", ParentId = "install")]
+    public class InstallIotCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            CmfPackage iotPackage = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.IoT);
+
+            Log.Information($"Install IoT: {iotPackage.PackageId}");
+            new BuildCommand(fileSystem).Execute(iotPackage.GetFileInfo().Directory);
+        }
+    }
+}

--- a/cmf-cli/Commands/menu/MenuCommand.cs
+++ b/cmf-cli/Commands/menu/MenuCommand.cs
@@ -1,0 +1,488 @@
+﻿using Cmf.CLI.Commands.Bump;
+using Cmf.CLI.Commands.DbManager;
+using Cmf.CLI.Commands.Generate;
+using Cmf.CLI.Commands.Install;
+using Cmf.CLI.Commands.Run;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands
+{
+    /// <summary>
+    ///     MenuCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("menu", Id = "menu")]
+    public class MenuCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.AddOption(
+                new Option<long>(
+                    aliases: new[] { "--licenseId" },
+                    description: "Project License Id"
+                )
+                { IsRequired = true }
+            );
+
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        /// <param name="licenseId">
+        ///     Project License Id
+        /// </param>
+        public void Execute(long licenseId)
+        {
+            GenericUtilities.EnsureIsRunningAsAdmin();
+
+            Menu menu = new Menu(
+                prompt: "Select what to run:",
+                items: new List<MenuItem>
+                {
+                    new MenuItem(
+                        identifier: 1,
+                        title: "Install All",
+                        action: () => new InstallCommand().Execute(licenseId),
+                        children: new List<MenuItem>
+                        {
+                            new MenuItem(
+                                identifier: 11,
+                                title: "Install Business",
+                                action: () => new InstallBusinessCommand().Execute(licenseId)
+                            ),
+                            new MenuItem(
+                                identifier: 12,
+                                title: "Install HTML",
+                                action: () => new InstallHtmlCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 13,
+                                title: "Install Help",
+                                action: () => new InstallHelpCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 14,
+                                title: "Install IoT",
+                                action: () => new InstallIotCommand().Execute()
+                            )
+                        }
+                    ),
+                    new MenuItem(
+                        identifier: 2,
+                        title: "Run All (MessageBus | Host | HTML)",
+                        action: () => new RunCommand().Execute(),
+                        children: new List<MenuItem>
+                        {
+                            new MenuItem(
+                                identifier: 21,
+                                title: "Run MessageBus",
+                                action: () => new RunMessageBusCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 22,
+                                title: "Run Host",
+                                action: () => new RunHostCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 23,
+                                title: "Run HTML",
+                                action: () => new RunHTMLCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 24,
+                                title: "Run Help",
+                                action: () => new RunHelpCommand().Execute()
+                            )
+                        }
+                    ),
+                    new MenuItem(
+                        identifier: 3,
+                        title: "Local DB Manager",
+                        children: new List<MenuItem>
+                        {
+                            new MenuItem(
+                                identifier: 31,
+                                title: "Backup Local DB",
+                                action: () => new BackupDatabaseCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 32,
+                                title: "Restore Local DB",
+                                action: () => new RestoreDatabaseCommand().Execute()
+                            ),
+                            new MenuItem(
+                                identifier: 33,
+                                title: "Delete Local DB Backup File",
+                                action: () => new DeleteDatabaseBackupCommand().Execute()
+                            )
+                        },
+                        disabled: true
+                    ),
+                    new MenuItem(
+                        identifier: 4,
+                        title: "Generate LBOs",
+                        action: () => new GenerateLBOsCommand().Execute()
+                    ),
+                    new MenuItem(
+                        identifier: 5,
+                        title: "Generate Documentation",
+                        action: () => new GenerateDocumentationCommand().Execute()
+                    ),
+                    new MenuItem(
+                        identifier: 6,
+                        title: "Generate Release Notes (BROKEN)",
+                        action: () => new GenerateReleaseNotesCommand().Execute()
+                    ),
+                    new MenuItem(
+                        identifier: 7,
+                        title: "Bump Version (Interactive)",
+                        action: () => new BumpInteractiveCommand().Execute()
+                    ),
+                }
+            );
+
+            Log.Information($"---------- {ExecutionContext.Instance.ProjectConfig.Tenant} ----------");
+            Log.Verbose($"Current License: {licenseId}");
+            Log.Verbose($"Current Database: {GenericUtilities.GetCurrentDb(fileSystem)}");
+            Log.Verbose("");
+            menu.Run();
+        }
+    }
+
+    /// <summary>
+    ///     Represents a Menu with a Prompt and a List of <see cref="MenuCommand"/>.
+    /// </summary>
+    public class Menu
+    {
+        /// <summary>
+        ///     Gets or sets the prompt.
+        /// </summary>
+        /// <value>
+        ///     Text written in console before printing the Menu Items
+        /// </value>
+        public string Prompt { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the items.
+        /// </summary>
+        /// <value>
+        ///     List of Menu Items
+        /// </value>
+        public List<MenuItem> Items { get; set; } = new List<MenuItem>();
+
+        #region Constructors
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Menu"/> class with an empty List of <see cref="MenuItem"/>.
+        /// </summary>
+        /// <param name="prompt">
+        ///     See <see cref="Prompt"/>
+        /// </param>
+        public Menu(string prompt)
+        {
+            Prompt = prompt;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="Menu"/> class with given List of <see cref="MenuItem"/>.
+        /// </summary>
+        /// <param name="prompt">
+        ///     See <see cref="Prompt"/>
+        /// </param>
+        /// <param name="items">
+        ///     See <see cref="Items"/>
+        /// </param>
+        public Menu(string prompt, List<MenuItem> items) : this(prompt)
+        {
+            Items = items;
+        }
+
+        #endregion Constructors
+
+        #region Private Methods/Functions
+
+        /// <summary>
+        ///     Searches for a <see cref="MenuItem"/> with a specific identifier, including nested levels (Children of Children).
+        /// </summary>
+        /// <param name="identifier">
+        ///     Identifier of the <see cref="MenuItem"/> to find.
+        /// </param>
+        /// <returns>
+        ///     <para>Returns a <see cref="MenuItem"/> that matches the provided identifier and is not disabled.</para>
+        ///     <para>
+        ///         If a matching item is found in the first level of children, it is returned immediately. If not, the method searches in the Items Children
+        ///         and Children of Children (2nd and subsequent levels) until a matching item is found, and that item is returned. If no matching item is
+        ///         found, a null value is returned.
+        ///     </para>
+        /// </returns>
+        private MenuItem FindItem(int identifier)
+        {
+            // Find in Menu.Items (1st level)
+            MenuItem item = Items.Find(item => item.Identifier == identifier && !item.Disabled);
+            if (!item.IsNullOrEmpty()) return item;
+
+            foreach (MenuItem menuItem in Items)
+            {
+                // Find in Menu.Items.Children recursively (2nd and subsequent levels)
+                item = menuItem.FindChildren(identifier);
+                if (!item.IsNullOrEmpty()) break;
+            }
+
+            return item;
+        }
+
+        /// <summary>
+        ///     Reads an option from the console until a valid <see cref="MenuItem"/> is found.
+        /// </summary>
+        /// <returns>
+        ///     <see cref="MenuItem"/>
+        /// </returns>
+        private MenuItem ReadOption()
+        {
+            MenuItem item = null;
+
+            while (item.IsNullOrEmpty())
+            {
+                int option = GenericUtilities.ReadIntValueFromConsole(prompt: "Option:");
+                item = FindItem(option);
+                if (item.IsNullOrEmpty())
+                {
+                    Log.Error("Invalid option. Try again.");
+                }
+            }
+
+            return item;
+        }
+
+        #endregion Private Methods/Functions
+
+        #region Public Methods/Functions
+
+        /// <summary>
+        ///     Runs the Menu
+        /// </summary>
+        public void Run()
+        {
+            // Print the Menu
+            Log.Verbose(Prompt);
+            foreach (MenuItem item in Items)
+            {
+                item.Print();
+            }
+
+            // Read and execute the MenuItem.Action
+            ReadOption().Action();
+        }
+
+        #endregion Public Methods/Functions
+    }
+
+    /// <summary>
+    ///     Represents a MenuItem that can execute <see cref="Action"/> and have Children <see cref="MenuItem"/>.
+    /// </summary>
+    public class MenuItem
+    {
+        /// <summary>
+        ///     Gets or sets the identifier.
+        /// </summary>
+        /// <value>
+        ///     Number that the user will input to execute this <see cref="MenuItem"/>
+        /// </value>
+        public int Identifier { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the title.
+        /// </summary>
+        /// <value>
+        ///     Text that will be written next to the <see cref="Identifier"/>.
+        /// </value>
+        public string Title { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether disabled.
+        /// </summary>
+        /// <value>
+        ///     Indicates if the <see cref="MenuItem"/> is disabled or not. Disabled means that no <see cref="Identifier"/> will be displayed.
+        /// </value>
+        public bool Disabled { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the action.
+        /// </summary>
+        /// <value>
+        ///     Action that will be executed when the user chooses an option from the menu
+        /// </value>
+        public Action Action { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the children.
+        /// </summary>
+        /// <value>
+        ///     List of <see cref="MenuItem"/> that are children
+        /// </value>
+        public List<MenuItem> Children { get; set; } = new List<MenuItem>();
+
+        #region Constructors
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MenuItem"/> class.
+        /// </summary>
+        /// <param name="identifier">
+        ///     The identifier.
+        /// </param>
+        /// <param name="title">
+        ///     The title.
+        /// </param>
+        public MenuItem(int identifier, string title)
+        {
+            Identifier = identifier;
+            Title = title;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MenuItem"/> class.
+        /// </summary>
+        /// <param name="identifier">
+        ///     The identifier.
+        /// </param>
+        /// <param name="title">
+        ///     The title.
+        /// </param>
+        /// <param name="children">
+        ///     The children.
+        /// </param>
+        /// <param name="disabled">
+        ///     If true, disabled.
+        /// </param>
+        public MenuItem(int identifier, string title, List<MenuItem> children, bool disabled = false) : this(identifier, title)
+        {
+            Children = children;
+            Disabled = disabled;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MenuItem"/> class.
+        /// </summary>
+        /// <param name="identifier">
+        ///     The identifier.
+        /// </param>
+        /// <param name="title">
+        ///     The title.
+        /// </param>
+        /// <param name="action">
+        ///     The action.
+        /// </param>
+        public MenuItem(int identifier, string title, Action action) : this(identifier, title)
+        {
+            Action = action;
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="MenuItem"/> class.
+        /// </summary>
+        /// <param name="identifier">
+        ///     The identifier.
+        /// </param>
+        /// <param name="title">
+        ///     The title.
+        /// </param>
+        /// <param name="action">
+        ///     The action.
+        /// </param>
+        /// <param name="children">
+        ///     The children.
+        /// </param>
+        public MenuItem(int identifier, string title, Action action, List<MenuItem> children) : this(identifier, title, children)
+        {
+            Action = action;
+        }
+
+        #endregion Constructors
+
+        #region Private Methods/Functions
+
+        /// <summary>
+        ///     Prints the Menu Item
+        /// </summary>
+        /// <param name="currentRecursionLevel">
+        ///     Current recursion level. This will add spaces when printing.
+        /// </param>
+        private void PrintToConsole(int currentRecursionLevel = 0)
+        {
+            // Calculate the indentation based on the current recursion level.
+            string indentation = string.Empty;
+            for (int i = 0; i < currentRecursionLevel; i++)
+            {
+                indentation += "  ";
+            }
+
+            Log.Verbose($"{indentation}{(Disabled ? "X" : Identifier)} - {Title}");
+        }
+
+        #endregion Private Methods/Functions
+
+        #region Public Methods/Functions
+
+        /// <summary>
+        ///     Recursively Prints the Menu Item and its Children
+        /// </summary>
+        /// <param name="level">
+        ///     Current Recursion level. Always starts counting from 0.
+        /// </param>
+        public void Print(int level = 0)
+        {
+            PrintToConsole(level);
+            foreach (MenuItem child in Children)
+            {
+                child.Print(level + 1);
+            }
+        }
+
+        /// <summary>
+        ///     Recursively searches for a <see cref="MenuItem"/> with a specific identifier within the Children collection.
+        /// </summary>
+        /// <param name="identifier">
+        ///     Identifier of the <see cref="MenuItem"/> to find.
+        /// </param>
+        /// <returns>
+        ///     <para>Returns a <see cref="MenuItem"/> that matches the provided identifier and is not disabled.</para>
+        ///     <para>
+        ///         If a matching item is found in the first level of children, it is returned immediately. If not, the method recursively searches through the
+        ///         Children of Children (2nd and subsequent levels) until a matching item is found, and that item is returned. If no matching item is found, a
+        ///         null value is returned.
+        ///     </para>
+        /// </returns>
+        public MenuItem FindChildren(int identifier)
+        {
+            // Find in MenuItem.Children (1st level)
+            MenuItem item = Children.Find(item => item.Identifier == identifier && !item.Disabled);
+            if (!item.IsNullOrEmpty()) return item;
+
+            foreach (MenuItem child in Children)
+            {
+                // Find in MenuItem.Children.Children recursively (2nd and subsequent levels)
+                item = child.FindChildren(identifier);
+                if (!item.IsNullOrEmpty()) break;
+            }
+
+            return item;
+        }
+
+        #endregion Public Methods/Functions
+    }
+}

--- a/cmf-cli/Commands/run/RunCommand.cs
+++ b/cmf-cli/Commands/run/RunCommand.cs
@@ -1,0 +1,82 @@
+using Cmf.CLI.Commands.Run;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Commands
+{
+    /// <summary>
+    ///     RunCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("run", Id = "run")]
+    public class RunCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     <para>Runs everything needed to use the Local Environment</para>
+        ///     <para>Executes the commands:</para>
+        ///     <list type="number">
+        ///         <item><see cref="RunMessageBusCommand"/></item>
+        ///         <item><see cref="RunHostCommand"/></item>
+        ///         <item><see cref="RunHTMLCommand"/></item>
+        ///     </list>
+        /// </summary>
+        public void Execute()
+        {
+            GenericUtilities.EnsureWindowsTerminalIsInstalled();
+
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+            /*
+             * Use Windows Terminal to run all
+             * This will create 3 new WindowsTerminal tabs, each of them executing a specific command in the CLI.
+             */
+
+            // Create Windows Terminal tab for MessageBus
+            GenericUtilities.ExecutePowerShellCommand("wt.exe",
+                "-w 0",
+                "nt",
+                "--title MessageBus",
+                "--suppressApplicationTitle",
+                $"-d {projectRoot}",
+                GenericUtilities.GetPowerShellExecutable(),
+                @"-c cmf run messagebus"
+            );
+
+            // Create Windows Terminal tab for Host
+            GenericUtilities.ExecutePowerShellCommand("wt.exe",
+                "-w 0",
+                "nt",
+                "--title Host",
+                "--suppressApplicationTitle",
+                $"-d {projectRoot}",
+                GenericUtilities.GetPowerShellExecutable(),
+                @"-c cmf run host"
+            );
+
+            // Create Windows Terminal tab for HTML
+            GenericUtilities.ExecutePowerShellCommand("wt.exe",
+                "-w 0",
+                "nt",
+                "--title HTML",
+                "--suppressApplicationTitle",
+                $"-d {projectRoot}",
+                GenericUtilities.GetPowerShellExecutable(),
+                @"-c cmf run html"
+            );
+        }
+    }
+}

--- a/cmf-cli/Commands/run/RunHTMLCommand.cs
+++ b/cmf-cli/Commands/run/RunHTMLCommand.cs
@@ -1,0 +1,57 @@
+using Cmf.CLI.Builders;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Run
+{
+    /// <summary>
+    ///     RunHTMLCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("html", Id = "run_html", ParentId = "run")]
+    public class RunHTMLCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     <para>Runs the HTML</para>
+        /// </summary>
+        public void Execute()
+        {
+            CmfPackage htmlPackage = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.HTML);
+
+            // Build HTML
+            new GulpCommand()
+            {
+                GulpFile = "gulpfile.js",
+                Task = "build",
+                DisplayName = "Gulp Build",
+                GulpJS = "node_modules/gulp/bin/gulp.js",
+                WorkingDirectory = htmlPackage.GetFileInfo().Directory
+            }.Exec();
+
+            // Start and Watch HTML (allows Rebuild on changes)
+            new GulpCommand()
+            {
+                GulpFile = "gulpfile.js",
+                Task = "start watch",
+                DisplayName = "Gulp Start Watch",
+                GulpJS = "node_modules/gulp/bin/gulp.js",
+                WorkingDirectory = htmlPackage.GetFileInfo().Directory
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/Commands/run/RunHelpCommand.cs
+++ b/cmf-cli/Commands/run/RunHelpCommand.cs
@@ -1,0 +1,58 @@
+using Cmf.CLI.Builders;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+
+namespace Cmf.CLI.Commands.Run
+{
+    /// <summary>
+    ///     RunHelpCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("help", Id = "run_help", ParentId = "run")]
+    public class RunHelpCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     Executes the command
+        /// </summary>
+        public void Execute()
+        {
+            CmfPackage helpPackage = GenericUtilities.SelectPackage(fileSystem, packageType: PackageType.Help);
+
+            // Build Help
+            new GulpCommand()
+            {
+                GulpFile = "gulpfile.js",
+                Task = "build",
+                DisplayName = "Gulp Build",
+                GulpJS = "node_modules/gulp/bin/gulp.js",
+                Args = new[] { "--production" },
+                WorkingDirectory = helpPackage.GetFileInfo().Directory
+            }.Exec();
+
+            // Start and Watch Help (allows Rebuild on changes)
+            new GulpCommand()
+            {
+                GulpFile = "gulpfile.js",
+                Task = "start watch",
+                DisplayName = "Gulp Start Watch",
+                GulpJS = "node_modules/gulp/bin/gulp.js",
+                WorkingDirectory = helpPackage.GetFileInfo().Directory
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/Commands/run/RunHostCommand.cs
+++ b/cmf-cli/Commands/run/RunHostCommand.cs
@@ -1,0 +1,82 @@
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Cmf.CLI.Commands.Run
+{
+    /// <summary>
+    ///     RunHostCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("host", Id = "run_host", ParentId = "run")]
+    public class RunHostCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     <para>Runs the Host service</para>
+        ///     <para>Press 'R' to restart the Host execution</para>
+        /// </summary>
+        public void Execute()
+        {
+            string businessTierFolderPath = fileSystem.Path.Combine(FileSystemUtilities.GetProjectRoot(fileSystem).FullName, "LocalEnvironment", "BusinessTier");
+            string hostExePath = fileSystem.Path.Combine(businessTierFolderPath, "Cmf.Foundation.Services.HostService.exe");
+
+            Environment.CurrentDirectory = businessTierFolderPath;
+
+            while (true)
+            {
+                CmfGenericUtilities.StartProjectDbContainer(fileSystem);
+
+                CmfGenericUtilities.BuildAllPackagesOfType(PackageType.Business, fileSystem);
+
+                Environment.CurrentDirectory = businessTierFolderPath;
+
+                // Create HostService process
+                using Process process = new Process();
+                process.StartInfo.FileName = hostExePath;
+                process.Start();
+                Log.Information("Host Service process started. Press 'R' to rebuild and restart.");
+
+                while (!process.HasExited)
+                {
+                    if (Console.KeyAvailable)
+                    {
+                        ConsoleKeyInfo key = Console.ReadKey(true);
+                        if (key.Key == ConsoleKey.R)
+                        {
+                            process.Kill();
+                            GenericUtilities.FullConsoleClear();
+                            process.WaitForExit();
+
+                            CmfGenericUtilities.BuildAllPackagesOfType(PackageType.Business, fileSystem);
+
+                            process.Start();
+                            Log.Information("Host Service process rebuild and restarted.");
+                        }
+                    }
+                    Thread.Sleep(1000);
+                }
+
+                Log.Information("Process Terminated! Restarting in 30 sec.");
+                Thread.Sleep(30000);
+                GenericUtilities.FullConsoleClear();
+            }
+        }
+    }
+}

--- a/cmf-cli/Commands/run/RunMessageBusCommand.cs
+++ b/cmf-cli/Commands/run/RunMessageBusCommand.cs
@@ -1,0 +1,72 @@
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Utilities;
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics;
+using System.IO.Abstractions;
+using System.Threading;
+
+namespace Cmf.CLI.Commands.Run
+{
+    /// <summary>
+    ///     RunMessageBusCommand
+    /// </summary>
+    /// <seealso cref="BaseCommand"/>
+    [CmfCommand("messagebus", Id = "run_messagebus", ParentId = "run")]
+    public class RunMessageBusCommand : BaseCommand
+    {
+        /// <summary>
+        ///     Configure command
+        /// </summary>
+        /// <param name="cmd">
+        ///     Command
+        /// </param>
+        public override void Configure(Command cmd)
+        {
+            cmd.Handler = CommandHandler.Create(Execute);
+        }
+
+        /// <summary>
+        ///     <para>Runs the Message Bus</para>
+        ///     <para>Press 'R' to restart the MessageBus execution</para>
+        /// </summary>
+        public void Execute()
+        {
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+            string messageBusFolderPath = fileSystem.Path.Combine(projectRoot.FullName, "LocalEnvironment", "MessageBusGateway");
+            string messageBusExePath = fileSystem.Path.Combine(messageBusFolderPath, "Cmf.MessageBus.Gateway.exe");
+
+            Environment.CurrentDirectory = messageBusFolderPath;
+
+            while (true)
+            {
+                using Process process = new Process();
+                process.StartInfo.FileName = messageBusExePath;
+
+                process.Start();
+                Log.Information("Process started. Press 'R' to restart.");
+
+                while (!process.HasExited)
+                {
+                    if (Console.KeyAvailable)
+                    {
+                        ConsoleKeyInfo key = Console.ReadKey(true);
+                        if (key.Key == ConsoleKey.R)
+                        {
+                            GenericUtilities.FullConsoleClear();
+                            process.Kill();
+                            process.WaitForExit();
+
+                            process.Start();
+                            Log.Information("Process restarted.");
+                        }
+                    }
+                    Thread.Sleep(1000);
+                }
+            }
+        }
+    }
+}

--- a/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs
@@ -10,15 +10,16 @@ using System.Text.RegularExpressions;
 namespace Cmf.CLI.Handlers
 {
     /// <summary>
-    ///
     /// </summary>
-    /// <seealso cref="PackageTypeHandler" />
+    /// <seealso cref="PackageTypeHandler"/>
     public class BusinessPackageTypeHandler : PackageTypeHandler
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="BusinessPackageTypeHandler" /> class.
+        ///     Initializes a new instance of the <see cref="BusinessPackageTypeHandler"/> class.
         /// </summary>
-        /// <param name="cmfPackage">The CMF package.</param>
+        /// <param name="cmfPackage">
+        ///     The CMF package.
+        /// </param>
         public BusinessPackageTypeHandler(CmfPackage cmfPackage) : base(cmfPackage)
         {
             cmfPackage.SetDefaultValues(
@@ -67,7 +68,6 @@ namespace Cmf.CLI.Handlers
                     Command = "build",
                     DisplayName = "Build Business Solution",
                     Solution = this.fileSystem.FileInfo.New(Path.Join(cmfPackage.GetFileInfo().Directory.FullName, "Business.sln")),
-                    Configuration = "Release",
                     WorkingDirectory = cmfPackage.GetFileInfo().Directory,
                     Args = new [] { "--no-restore "}
                 },
@@ -83,11 +83,17 @@ namespace Cmf.CLI.Handlers
         }
 
         /// <summary>
-        /// Bumps the specified CMF package.
+        ///     Bumps the specified CMF package.
         /// </summary>
-        /// <param name="version">The version.</param>
-        /// <param name="buildNr">The version for build Nr.</param>
-        /// <param name="bumpInformation">The bump information.</param>
+        /// <param name="version">
+        ///     The version.
+        /// </param>
+        /// <param name="buildNr">
+        ///     The version for build Nr.
+        /// </param>
+        /// <param name="bumpInformation">
+        ///     The bump information.
+        /// </param>
         public override void Bump(string version, string buildNr, Dictionary<string, object> bumpInformation = null)
         {
             base.Bump(version, buildNr, bumpInformation);

--- a/cmf-cli/Utilities/CmfGenericUtilities.cs
+++ b/cmf-cli/Utilities/CmfGenericUtilities.cs
@@ -1,0 +1,74 @@
+﻿using Cmf.CLI.Builders;
+using Cmf.CLI.Commands;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using System;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Utilities
+{
+    /// <summary>
+    ///     Utilities Class for CMF
+    /// </summary>
+    public static class CmfGenericUtilities
+    {
+        /// <summary>
+        ///     Builds all packages of a given type.
+        /// </summary>
+        /// <param name="packageType">
+        ///     Type of package to be built.
+        /// </param>
+        /// <param name="fileSystem">
+        ///     FileSystem
+        /// </param>
+        public static void BuildAllPackagesOfType(PackageType packageType, IFileSystem fileSystem)
+        {
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+            // Get packages of given type
+            CmfPackageCollection packages = projectRoot.LoadCmfPackagesFromSubDirectories(packageType: packageType);
+
+            BuildCommand buildCommand = new BuildCommand(fileSystem);
+
+            // Build All packages
+            foreach (CmfPackage package in packages)
+            {
+                Log.Information($"Build {Enum.GetName(typeof(PackageType), packageType)}: {package.PackageId}");
+                buildCommand.Execute(package.GetFileInfo().Directory);
+            }
+        }
+
+        /// <summary>
+        ///     Stop any running project DB containers and start current project DB container.
+        /// </summary>
+        /// <param name="fileSystem">
+        ///     FileSystem`
+        /// </param>
+        public static void StartProjectDbContainer(IFileSystem fileSystem)
+        {
+            string powershellExe = GenericUtilities.GetPowerShellExecutable();
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+            Log.Information("Stopping other project containers if any is running");
+            new CmdCommand()
+            {
+                DisplayName = $"{powershellExe} -C \"if (wsl docker ps -q --filter name=\"-\") {{ wsl docker stop $(wsl docker ps -q --filter name=\"-\") }}\"",
+                Command = $"{powershellExe} -C \"if (wsl docker ps -q --filter name=\"-\") {{ wsl docker stop $(wsl docker ps -q --filter name=\"-\") }}\"",
+                Args = Array.Empty<string>(),
+                WorkingDirectory = projectRoot
+            }.Exec();
+
+            string dockerDbContainerName = $"{ExecutionContext.Instance.ProjectConfig.EnvironmentName}-DB";
+
+            Log.Information("Starting project container");
+            new CmdCommand()
+            {
+                DisplayName = $"wsl docker start {dockerDbContainerName}",
+                Command = $"wsl docker start {dockerDbContainerName}",
+                Args = Array.Empty<string>(),
+                WorkingDirectory = projectRoot
+            }.Exec();
+        }
+    }
+}

--- a/cmf-cli/cmf.csproj
+++ b/cmf-cli/cmf.csproj
@@ -33,6 +33,7 @@
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+        <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
         <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
         <PackageReference Include="System.Management.Automation" Version="7.1.3" />
     </ItemGroup>

--- a/core/Constants/CoreConstants.cs
+++ b/core/Constants/CoreConstants.cs
@@ -1,74 +1,88 @@
 ﻿namespace Cmf.CLI.Core.Constants
 {
     /// <summary>
-    ///
     /// </summary>
     public static class CoreConstants
     {
         #region Folders
 
         /// <summary>
-        /// The folder install dependencies
+        ///     The folder install dependencies
         /// </summary>
         public const string FolderInstallDependencies = "installDependencies";
 
-        #endregion
+        #endregion Folders
 
         #region Files
 
         /// <summary>
-        /// The deployment framework manifest template
+        ///     The deployment framework manifest template
         /// </summary>
         public const string DeploymentFrameworkManifestFileName = "manifest.xml";
 
         /// <summary>
-        /// The CMF package file name
+        ///     The CMF package file name
         /// </summary>
         public const string CmfPackageFileName = "cmfpackage.json";
 
         /// <summary>
-        /// The package json
+        ///     The package json
         /// </summary>
         public const string PackageJson = "package.json";
 
         /// <summary>
-        /// The project config file name, located in the project root
+        ///     The project config file name, located in the project root
         /// </summary>
         public const string ProjectConfigFileName = ".project-config.json";
 
         /// <summary>
-        /// The repositories config file name, usually located in the project root
+        ///     The repositories config file name, usually located in the project root
         /// </summary>
         public const string RepositoriesConfigFileName = "repositories.json";
 
-        #endregion
+        #endregion Files
 
         #region Generic
 
         /// <summary>
-        /// The root package default keyword
+        ///     The root package default keyword
         /// </summary>
         public const string RootPackageDefaultKeyword = "cmf-root-package";
 
         /// <summary>
-        /// npm.js repository url
+        ///     npm.js repository url
         /// </summary>
         public const string NpmJsUrl = "https://registry.npmjs.com";
 
-        #endregion
+        /// <summary>
+        ///     Tfs server url
+        /// </summary>
+        public const string TfsServerUrl = "https://tfs.criticalmanufacturing.com/ImplementationProjects";
+
+        /// <summary>
+        ///     Local DB user name
+        /// </summary>
+        public const string LocalDbUser = "MESUser";
+
+        /// <summary>
+        ///     Local DB password
+        /// </summary>
+        public const string LocalDbPassword = "localEnvPassword";
+
+        #endregion Generic
 
         #region Tokens
 
         /// <summary>
-        /// The token start element
+        ///     The token start element
         /// </summary>
         public const string TokenStartElement = "$(";
 
         /// <summary>
-        /// The token end element
+        ///     The token end element
         /// </summary>
         public const string TokenEndElement = ")";
-        
-        #endregion
+
+        #endregion Tokens
     }
 }

--- a/core/Objects/CmfPackage.cs
+++ b/core/Objects/CmfPackage.cs
@@ -11,28 +11,26 @@ using System.IO;
 using System.IO.Abstractions;
 using System.IO.Compression;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using System.Xml.Linq;
 
 namespace Cmf.CLI.Core.Objects
 {
     /// <summary>
-    ///
     /// </summary>
-    /// <seealso cref="CmfPackage" />
+    /// <seealso cref="CmfPackage"/>
     [JsonObject]
     public class CmfPackage : IEquatable<CmfPackage>
     {
         #region Private Properties
 
         /// <summary>
-        /// The file information
+        ///     The file information
         /// </summary>
         private IFileInfo FileInfo;
 
         /// <summary>
-        /// Should we set the defaults values as described in the package handler?
+        ///     Should we set the defaults values as described in the package handler?
         /// </summary>
         internal bool IsToSetDefaultValues;
 
@@ -46,19 +44,19 @@ namespace Cmf.CLI.Core.Objects
         public IFileSystem FileSystem => fileSystem;
 
         /// <summary>
-        /// Gets the file name of the package.
+        ///     Gets the file name of the package.
         /// </summary>
         /// <value>
-        /// The file name of the package.
+        ///     The file name of the package.
         /// </value>
         [JsonIgnore]
         public string PackageName => $"{PackageId}.{Version}";
 
         /// <summary>
-        /// Gets the name of the zip package.
+        ///     Gets the name of the zip package.
         /// </summary>
         /// <value>
-        /// The name of the zip package.
+        ///     The name of the zip package.
         /// </value>
         [JsonIgnore]
         public string ZipPackageName => $"{PackageName}.zip";
@@ -68,212 +66,212 @@ namespace Cmf.CLI.Core.Objects
         #region Public Properties
 
         /// <summary>
-        /// Gets the name.
+        ///     Gets the name.
         /// </summary>
         /// <value>
-        /// The name.
+        ///     The name.
         /// </value>
         [JsonProperty(Order = 0)]
         public string Name { get; private set; }
 
         /// <summary>
-        /// Gets or sets the package identifier.
+        ///     Gets or sets the package identifier.
         /// </summary>
         /// <value>
-        /// The package identifier.
+        ///     The package identifier.
         /// </value>
         [JsonProperty(Order = 1)]
         public string PackageId { get; private set; }
 
         /// <summary>
-        /// Gets or sets the version.
+        ///     Gets or sets the version.
         /// </summary>
         /// <value>
-        /// The version.
+        ///     The version.
         /// </value>
         [JsonProperty(Order = 2)]
         public string Version { get; private set; }
 
         /// <summary>
-        /// Gets or sets the description.
+        ///     Gets or sets the description.
         /// </summary>
         /// <value>
-        /// The description.
+        ///     The description.
         /// </value>
         [JsonProperty(Order = 3)]
         public string Description { get; private set; }
 
         /// <summary>
-        /// Gets or sets the type of the package.
+        ///     Gets or sets the type of the package.
         /// </summary>
         /// <value>
-        /// The type of the package.
+        ///     The type of the package.
         /// </value>
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(Order = 4)]
         public PackageType PackageType { get; private set; }
 
         /// <summary>
-        /// Gets or sets the target directory where the package contents should be installed.
-        /// This is used when the package is installed using Deployment Framework and ignored when it is installed using Environment Manager.
+        ///     Gets or sets the target directory where the package contents should be installed. This is used when the package is installed using Deployment
+        ///     Framework and ignored when it is installed using Environment Manager.
         /// </summary>
         /// <value>
-        /// The target directory.
+        ///     The target directory.
         /// </value>
         [JsonProperty(Order = 5)]
         public string TargetDirectory { get; private set; }
 
         /// <summary>
-        /// Gets or sets the target layer, which means the container in which the packages contents should be installed.
-        /// This is used when the package is installed using Environment Manager and ignored when it is installed using Deployment Framework.
+        ///     Gets or sets the target layer, which means the container in which the packages contents should be installed. This is used when the package is
+        ///     installed using Environment Manager and ignored when it is installed using Deployment Framework.
         /// </summary>
         /// <value>
-        /// The target layer.
+        ///     The target layer.
         /// </value>
         [JsonProperty(Order = 6)]
         public string TargetLayer { get; private set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether this instance is installable.
+        ///     Gets or sets a value indicating whether this instance is installable.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if this instance is installable; otherwise, <c>false</c>.
+        ///     <c>true</c> if this instance is installable; otherwise, <c>false</c>.
         /// </value>
         [JsonProperty(Order = 7)]
         public bool? IsInstallable { get; private set; }
 
         /// <summary>
-        /// Gets or sets the is unique install.
+        ///     Gets or sets the is unique install.
         /// </summary>
         /// <value>
-        /// The is unique install.
+        ///     The is unique install.
         /// </value>
         [JsonProperty(Order = 8)]
         public bool? IsUniqueInstall { get; private set; }
 
         /// <summary>
-        /// Gets or sets the is root package.
+        ///     Gets or sets the is root package.
         /// </summary>
         /// <value>
-        /// The is root package.
+        ///     The is root package.
         /// </value>
         [JsonProperty(Order = 9)]
         [JsonIgnore]
         public string Keywords { get; private set; }
 
         /// <summary>
-        /// Should we set the default steps as described in the handler?
+        ///     Should we set the default steps as described in the handler?
         /// </summary>
         /// <value>
-        /// true to set the default steps; otherwise, false.
+        ///     true to set the default steps; otherwise, false.
         /// </value>
         [JsonProperty(Order = 10)]
         [JsonIgnore]
         public bool? IsToSetDefaultSteps { get; private set; }
 
         /// <summary>
-        /// Gets or sets the dependencies.
+        ///     Gets or sets the dependencies.
         /// </summary>
         /// <value>
-        /// The dependencies.
+        ///     The dependencies.
         /// </value>
         [JsonProperty(Order = 11)]
         public DependencyCollection Dependencies { get; private set; }
 
         /// <summary>
-        /// Gets or sets the steps.
+        ///     Gets or sets the steps.
         /// </summary>
         /// <value>
-        /// The steps.
+        ///     The steps.
         /// </value>
         [JsonProperty(Order = 12)]
         public List<Step> Steps { get; set; }
 
         /// <summary>
-        /// Gets or sets the content to pack.
+        ///     Gets or sets the content to pack.
         /// </summary>
         /// <value>
-        /// The content to pack.
+        ///     The content to pack.
         /// </value>
         [JsonProperty(Order = 13)]
         public List<ContentToPack> ContentToPack { get; private set; }
 
         /// <summary>
-        /// Gets or sets the deployment framework UI file.
+        ///     Gets or sets the deployment framework UI file.
         /// </summary>
         /// <value>
-        /// The deployment framework UI file.
+        ///     The deployment framework UI file.
         /// </value>
         [JsonProperty(Order = 14)]
         public List<string> XmlInjection { get; private set; }
 
         /// <summary>
-        /// Gets or sets the Test Package Id.
+        ///     Gets or sets the Test Package Id.
         /// </summary>
         /// <value>
-        /// The Test Package Id.
+        ///     The Test Package Id.
         /// </value>
         [JsonProperty(Order = 15)]
         public DependencyCollection TestPackages { get; set; }
 
         /// <summary>
-        /// The location of the package
+        ///     The location of the package
         /// </summary>
         [JsonProperty(Order = 16)]
         [JsonIgnore]
         public PackageLocation Location { get; private set; }
 
         /// <summary>
-        /// Handler Version
+        ///     Handler Version
         /// </summary>
         [JsonProperty(Order = 17)]
         public int HandlerVersion { get; private set; }
 
         /// <summary>
-        /// Should the Deployment Framework wait for the Integration Entries created by the package
-        /// This fails the package installation if any Integration Entry fails
+        ///     Should the Deployment Framework wait for the Integration Entries created by the package This fails the package installation if any Integration
+        ///     Entry fails
         /// </summary>
         [JsonProperty(Order = 18)]
         public bool? WaitForIntegrationEntries { get; private set; }
 
         /// <summary>
-        /// The Uri of the package
+        ///     The Uri of the package
         /// </summary>
         [JsonProperty(Order = 19)]
         [JsonIgnore]
         public Uri Uri { get; private set; }
 
         /// <summary>
-        /// The df package type
+        ///     The df package type
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty(Order = 20)]
         public PackageType? DFPackageType { get; set; }
 
         /// <summary>
-        /// Gets or sets the build steps.
+        ///     Gets or sets the build steps.
         /// </summary>
         /// <value>
-        /// The build steps.
+        ///     The build steps.
         /// </value>
         [JsonProperty(Order = 21)]
         public List<ProcessBuildStep> BuildSteps { get; set; }
 
         /// <summary>
-        /// Gets or sets the Related packages, and sets what are the expected behavior.
+        ///     Gets or sets the Related packages, and sets what are the expected behavior.
         /// </summary>
         /// <value>
-        /// Packages that should be built/packed before/after the context package
+        ///     Packages that should be built/packed before/after the context package
         /// </value>
         [JsonProperty(Order = 22)]
         public RelatedPackageCollection RelatedPackages { get; set; }
 
         /// <summary>
-        /// Gets or sets the target directory where the dependencies contents should be extracted.
-        /// This is used when the package dependencies are restored in the restore and build commands.
+        ///     Gets or sets the target directory where the dependencies contents should be extracted. This is used when the package dependencies are restored
+        ///     in the restore and build commands.
         /// </summary>
         /// <value>
-        /// The dependencies target directory.
+        ///     The dependencies target directory.
         /// </value>
         [JsonProperty(Order = 23)]
         public string DependenciesDirectory { get; set; }
@@ -283,25 +281,59 @@ namespace Cmf.CLI.Core.Objects
         #region Constructors
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="CmfPackage"/> class.
+        ///     Initializes a new instance of the <see cref="CmfPackage"/> class.
         /// </summary>
-        /// <param name="name">The name.</param>
-        /// <param name="packageId">The package identifier.</param>
-        /// <param name="version">The version.</param>
-        /// <param name="description">The description.</param>
-        /// <param name="packageType">Type of the package.</param>
-        /// <param name="targetDirectory">The target directory.</param>
-        /// <param name="targetLayer">The target layer.</param>
-        /// <param name="isInstallable">The is installable.</param>
-        /// <param name="isUniqueInstall">The is unique install.</param>
-        /// <param name="keywords">The keywords.</param>
-        /// <param name="isToSetDefaultSteps">The is to set default steps.</param>
-        /// <param name="dependencies">The dependencies.</param>
-        /// <param name="steps">The steps.</param>
-        /// <param name="contentToPack">The content to pack.</param>
-        /// <param name="xmlInjection">The XML injection.</param>
-        /// <param name="waitForIntegrationEntries">should wait for integration entries to complete</param>
-        /// <param name="testPackages">The test Packages.</param>
+        /// <param name="name">
+        ///     The name.
+        /// </param>
+        /// <param name="packageId">
+        ///     The package identifier.
+        /// </param>
+        /// <param name="version">
+        ///     The version.
+        /// </param>
+        /// <param name="description">
+        ///     The description.
+        /// </param>
+        /// <param name="packageType">
+        ///     Type of the package.
+        /// </param>
+        /// <param name="targetDirectory">
+        ///     The target directory.
+        /// </param>
+        /// <param name="targetLayer">
+        ///     The target layer.
+        /// </param>
+        /// <param name="isInstallable">
+        ///     The is installable.
+        /// </param>
+        /// <param name="isUniqueInstall">
+        ///     The is unique install.
+        /// </param>
+        /// <param name="keywords">
+        ///     The keywords.
+        /// </param>
+        /// <param name="isToSetDefaultSteps">
+        ///     The is to set default steps.
+        /// </param>
+        /// <param name="dependencies">
+        ///     The dependencies.
+        /// </param>
+        /// <param name="steps">
+        ///     The steps.
+        /// </param>
+        /// <param name="contentToPack">
+        ///     The content to pack.
+        /// </param>
+        /// <param name="xmlInjection">
+        ///     The XML injection.
+        /// </param>
+        /// <param name="waitForIntegrationEntries">
+        ///     should wait for integration entries to complete
+        /// </param>
+        /// <param name="testPackages">
+        ///     The test Packages.
+        /// </param>
         [JsonConstructor]
         public CmfPackage(string name, string packageId, string version, string description, PackageType packageType,
                           string targetDirectory, string targetLayer, bool? isInstallable, bool? isUniqueInstall, string keywords,
@@ -328,16 +360,17 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// initialize an empty CmfPackage
+        ///     initialize an empty CmfPackage
         /// </summary>
         public CmfPackage() : this(fileSystem: new FileSystem())
         {
         }
 
         /// <summary>
-        /// Initialize an empty CmfPackage with a specific file system
+        ///     Initialize an empty CmfPackage with a specific file system
         /// </summary>
-        /// <param name="fileSystem"></param>
+        /// <param name="fileSystem">
+        /// </param>
         public CmfPackage(IFileSystem fileSystem)
         {
             this.fileSystem = fileSystem;
@@ -349,7 +382,7 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Initialize CmfPackage with PackageId, Version and Uri
+        ///     Initialize CmfPackage with PackageId, Version and Uri
         /// </summary>
         public CmfPackage(string packageId, string version, Uri uri)
         {
@@ -363,7 +396,7 @@ namespace Cmf.CLI.Core.Objects
         #region Public Methods
 
         /// <summary>
-        /// Validates the package.
+        ///     Validates the package.
         /// </summary>
         public void ValidatePackage()
         {
@@ -400,11 +433,13 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Indicates whether the current object is equal to another object of the same type.
+        ///     Indicates whether the current object is equal to another object of the same type.
         /// </summary>
-        /// <param name="other">An object to compare with this object.</param>
+        /// <param name="other">
+        ///     An object to compare with this object.
+        /// </param>
         /// <returns>
-        ///   <see langword="true" /> if the current object is equal to the <paramref name="other" /> parameter; otherwise, <see langword="false" />.
+        ///     <see langword="true"/> if the current object is equal to the <paramref name="other"/> parameter; otherwise, <see langword="false"/>.
         /// </returns>
         public bool Equals(CmfPackage other)
         {
@@ -426,10 +461,10 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Gets or sets the file information.
+        ///     Gets or sets the file information.
         /// </summary>
         /// <returns>
-        /// The file information.
+        ///     The file information.
         /// </returns>
         public IFileInfo GetFileInfo()
         {
@@ -437,26 +472,45 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Gets or sets the file information.
+        ///     Gets or sets the file information.
         /// </summary>
-        /// <param name="value">The file information.</param>
+        /// <param name="value">
+        ///     The file information.
+        /// </param>
         public void SetFileInfo(IFileInfo value)
         {
             FileInfo = value;
         }
 
         /// <summary>
-        /// Sets the defaults.
+        ///     Sets the defaults.
         /// </summary>
-        /// <param name="name">The name.</param>
-        /// <param name="targetDirectory">The target directory.</param>
-        /// <param name="targetLayer">The target layer container.</param>
-        /// <param name="isInstallable">The is installable.</param>
-        /// <param name="isUniqueInstall">The is unique install.</param>
-        /// <param name="keywords">The keywords.</param>
-        /// <param name="waitForIntegrationEntries">should we wait for integration entries to complete</param>
-        /// <param name="steps">The steps.</param>
-        /// <exception cref="CliException"></exception>
+        /// <param name="name">
+        ///     The name.
+        /// </param>
+        /// <param name="targetDirectory">
+        ///     The target directory.
+        /// </param>
+        /// <param name="targetLayer">
+        ///     The target layer container.
+        /// </param>
+        /// <param name="isInstallable">
+        ///     The is installable.
+        /// </param>
+        /// <param name="isUniqueInstall">
+        ///     The is unique install.
+        /// </param>
+        /// <param name="keywords">
+        ///     The keywords.
+        /// </param>
+        /// <param name="waitForIntegrationEntries">
+        ///     should we wait for integration entries to complete
+        /// </param>
+        /// <param name="steps">
+        ///     The steps.
+        /// </param>
+        /// <exception cref="CliException">
+        /// </exception>
         public void SetDefaultValues(
             string name = null,
             string targetDirectory = null,
@@ -506,23 +560,31 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Sets the version.
+        ///     Sets the version.
         /// </summary>
-        /// <param name="version">The version.</param>
-        /// <exception cref="NotImplementedException"></exception>
+        /// <param name="version">
+        ///     The version.
+        /// </param>
+        /// <exception cref="NotImplementedException">
+        /// </exception>
         public void SetVersion(string version)
         {
             Version = version;
         }
 
         /// <summary>
-        /// Builds a dependency tree by attaching the CmfPackage objects to the parent's dependencies
-        /// Can run recursively and fetch packages from a DF repository.
-        /// Supports cycles
+        ///     Builds a dependency tree by attaching the CmfPackage objects to the parent's dependencies Can run recursively and fetch packages from a DF
+        ///     repository. Supports cycles
         /// </summary>
-        /// <param name="repoUris">the address of the package repositories (currently only folders are supported)</param>
-        /// <param name="recurse">should we run recursively</param>
-        /// <returns>this CmfPackage for chaining, but the method itself is mutable</returns>
+        /// <param name="repoUris">
+        ///     the address of the package repositories (currently only folders are supported)
+        /// </param>
+        /// <param name="recurse">
+        ///     should we run recursively
+        /// </param>
+        /// <returns>
+        ///     this CmfPackage for chaining, but the method itself is mutable
+        /// </returns>
         public void LoadDependencies(IEnumerable<Uri> repoUris, StatusContext ctx, bool recurse = false)
         {
             using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity("CmfPackage LoadDependencies");
@@ -586,36 +648,44 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Should Serialize Handler Version
+        ///     Should Serialize Handler Version
         /// </summary>
-        /// <returns>returns false if handler version is 0 otherwise true</returns>
+        /// <returns>
+        ///     returns false if handler version is 0 otherwise true
+        /// </returns>
         public bool ShouldSerializeHandlerVersion()
         {
             return HandlerVersion != 0;
         }
 
         /// <summary>
-        /// Shoulds the serialize DF package type.
+        ///     Shoulds the serialize DF package type.
         /// </summary>
-        /// <returns>returns false if DF Package Type is null and Package Type is different then Generic, otherwise true</returns>
+        /// <returns>
+        ///     returns false if DF Package Type is null and Package Type is different then Generic, otherwise true
+        /// </returns>
         public bool ShouldSerializeDFPackageType()
         {
             return DFPackageType != null && PackageType == PackageType.Generic;
         }
 
         /// <summary>
-        /// Shoulds the serialize Related Packages
+        ///     Shoulds the serialize Related Packages
         /// </summary>
-        /// <returns>returns false if Related Packages is null or empty</returns>
+        /// <returns>
+        ///     returns false if Related Packages is null or empty
+        /// </returns>
         public bool ShouldSerializeRelatedPackages()
         {
             return RelatedPackages.HasAny();
         }
 
         /// <summary>
-        /// Should the Dependencies Directory be serialized
+        ///     Should the Dependencies Directory be serialized
         /// </summary>
-        /// <returns>returns false if Dependencies Directory is null or empty</returns>
+        /// <returns>
+        ///     returns false if Dependencies Directory is null or empty
+        /// </returns>
         public bool ShouldSerializeDependenciesDirectory()
         {
             return !string.IsNullOrWhiteSpace(DependenciesDirectory);
@@ -624,15 +694,22 @@ namespace Cmf.CLI.Core.Objects
         #region Static Methods
 
         /// <summary>
-        /// Loads the specified file.
+        ///     Loads the specified file.
         /// </summary>
-        /// <param name="file">The file.</param>
-        /// <param name="setDefaultValues"></param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns></returns>
+        /// <param name="file">
+        ///     The file.
+        /// </param>
+        /// <param name="setDefaultValues">
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        /// </returns>
         /// <exception cref="Cmf.CLI.Utilities.CliException">
         /// </exception>
-        /// <exception cref="CliException"></exception>
+        /// <exception cref="CliException">
+        /// </exception>
         public static CmfPackage Load(IFileInfo file, bool setDefaultValues = false, IFileSystem fileSystem = null)
         {
             fileSystem ??= ExecutionContext.Instance.FileSystem;
@@ -654,10 +731,12 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Load Method for an instantiated CmfPackage object
+        ///     Load Method for an instantiated CmfPackage object
         /// </summary>
-        /// <param name="setDefaultValues"></param>
-        /// <exception cref="CliException"></exception>
+        /// <param name="setDefaultValues">
+        /// </param>
+        /// <exception cref="CliException">
+        /// </exception>
         public void Load(bool setDefaultValues = false)
         {
             if (!FileInfo.Exists)
@@ -671,14 +750,13 @@ namespace Cmf.CLI.Core.Objects
             Location = PackageLocation.Local;
 
             RelatedPackages?.Load(this);
-
         }
 
         /// <summary>
-        /// Similar to Load, but without deserialization.
-        /// Only sets PackageId and Version
+        ///     Similar to Load, but without deserialization. Only sets PackageId and Version
         /// </summary>
-        /// <exception cref="CliException"></exception>
+        /// <exception cref="CliException">
+        /// </exception>
         public void Peek()
         {
             if (!FileInfo.Exists)
@@ -697,12 +775,17 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Gets the URI from repos.
+        ///     Gets the URI from repos.
         /// </summary>
-        /// <param name="repoDirectories">The repo directories.</param>
-        /// <param name="packageId"></param>
-        /// <param name="version"></param>
-        /// <returns></returns>
+        /// <param name="repoDirectories">
+        ///     The repo directories.
+        /// </param>
+        /// <param name="packageId">
+        /// </param>
+        /// <param name="version">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static CmfPackage LoadFromRepo(IDirectoryInfo[] repoDirectories, string packageId, string version)
         {
             if (version is null)
@@ -744,12 +827,20 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Create a CmfPackage object from a DF package manifest
+        ///     Create a CmfPackage object from a DF package manifest
         /// </summary>
-        /// <param name="manifest">the manifest content</param>
-        /// <param name="setDefaultValues">should set default values</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns>a CmfPackage</returns>
+        /// <param name="manifest">
+        ///     the manifest content
+        /// </param>
+        /// <param name="setDefaultValues">
+        ///     should set default values
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        ///     a CmfPackage
+        /// </returns>
         public static CmfPackage FromManifest(string manifest, bool setDefaultValues = false, IFileSystem fileSystem = null)
         {
             fileSystem ??= new FileSystem();
@@ -827,10 +918,10 @@ namespace Cmf.CLI.Core.Objects
         #region Utilities
 
         /// <summary>
-        /// Determines whether [is root package].
+        ///     Determines whether [is root package].
         /// </summary>
         /// <returns>
-        ///   <c>true</c> if [is root package] [the specified CMF package]; otherwise, <c>false</c>.
+        ///     <c>true</c> if [is root package] [the specified CMF package]; otherwise, <c>false</c>.
         /// </returns>
         public bool IsRootPackage()
         {
@@ -838,7 +929,7 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Saves the CMF package.
+        ///     Saves the CMF package.
         /// </summary>
         public void SaveCmfPackage()
         {
@@ -861,20 +952,70 @@ namespace Cmf.CLI.Core.Objects
         }
 
         /// <summary>
-        /// Equalses the specified object.
+        ///     Updates the version of a dependency in a given package.
         /// </summary>
-        /// <param name="obj">The object.</param>
-        /// <returns></returns>
+        /// <param name="updatedPackage">
+        ///     The package to find and update the Version in the parent package Dependencies.
+        /// </param>
+        public void UpdateDependency(CmfPackage updatedPackage)
+        {
+            Dependency dependency = null;
+
+            if (dependency.IsNullOrEmpty() && Dependencies.HasAny())
+            {
+                dependency = Dependencies.FirstOrDefault(dep => dep.Id.IgnoreCaseEquals(updatedPackage.PackageId));
+            }
+
+            if (dependency.IsNullOrEmpty() && TestPackages.HasAny())
+            {
+                dependency = TestPackages.FirstOrDefault(dep => dep.Id.IgnoreCaseEquals(updatedPackage.PackageId));
+            }
+
+            if (!dependency.IsNullOrEmpty())
+            {
+                dependency.Version = updatedPackage.Version;
+                SaveCmfPackage();
+            }
+        }
+
+        /// <summary>
+        ///     Renames all folders with a specific version in their name with the new version.
+        /// </summary>
+        /// <param name="oldVersion">
+        ///     Version number of the folders that need to be renamed.
+        /// </param>
+        public void RenameVersionFolders(string oldVersion)
+        {
+            // Gets all Version folders inside current package
+            foreach (IDirectoryInfo folder in GetFileInfo().Directory.GetDirectories(oldVersion, SearchOption.AllDirectories).Where(dir => dir.FullName.Split(PackageId).Length - 1 == 1))
+            {
+                string oldPath = folder.FullName;
+                string newPath = folder.FullName.Replace(oldVersion, Version);
+                folder.MoveTo(newPath);
+                Log.Information($"Will rename '{oldPath}' to '{newPath}'");
+            }
+        }
+
+        /// <summary>
+        ///     Equalses the specified object.
+        /// </summary>
+        /// <param name="obj">
+        ///     The object.
+        /// </param>
+        /// <returns>
+        /// </returns>
         public override bool Equals(object obj)
         {
             return Equals(obj as CmfPackage);
         }
 
         /// <summary>
-        /// Gets the hash code.
+        ///     Gets the hash code.
         /// </summary>
-        /// <returns></returns>
-        /// <exception cref="NotImplementedException"></exception>
+        /// <returns>
+        /// </returns>
+        /// <exception cref="NotImplementedException">
+        /// </exception>
         public override int GetHashCode()
         {
             throw new NotImplementedException();

--- a/core/Utilities/FileSystemUtilities.cs
+++ b/core/Utilities/FileSystemUtilities.cs
@@ -1,4 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿using Cmf.CLI.Core;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,33 +12,47 @@ using System.Linq;
 using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
-using Cmf.CLI.Core;
-using Cmf.CLI.Core.Constants;
-using Cmf.CLI.Core.Enums;
-using Cmf.CLI.Core.Objects;
 
 namespace Cmf.CLI.Utilities
 {
     /// <summary>
-    ///
     /// </summary>
     public static class FileSystemUtilities
     {
         #region Public Methods
 
         /// <summary>
-        /// Gets the files to pack.
+        ///     Gets the files to pack.
         /// </summary>
-        /// <param name="contentToPack">The content to pack.</param>
-        /// <param name="sourceDirName">Name of the source dir.</param>
-        /// <param name="destDirName">Name of the dest dir.</param>
-        /// <param name="contentToIgnore">The content to ignore.</param>
-        /// <param name="copySubDirs">if set to <c>true</c> [copy sub dirs].</param>
-        /// <param name="isCopyDependencies">if set to <c>true</c> [is copy dependencies].</param>
-        /// <param name="filesToPack">The files to pack.</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns></returns>
-        /// <exception cref="DirectoryNotFoundException">$"Source directory does not exist or could not be found: {sourceDirName}</exception>
+        /// <param name="contentToPack">
+        ///     The content to pack.
+        /// </param>
+        /// <param name="sourceDirName">
+        ///     Name of the source dir.
+        /// </param>
+        /// <param name="destDirName">
+        ///     Name of the dest dir.
+        /// </param>
+        /// <param name="contentToIgnore">
+        ///     The content to ignore.
+        /// </param>
+        /// <param name="copySubDirs">
+        ///     if set to <c>true</c> [copy sub dirs].
+        /// </param>
+        /// <param name="isCopyDependencies">
+        ///     if set to <c>true</c> [is copy dependencies].
+        /// </param>
+        /// <param name="filesToPack">
+        ///     The files to pack.
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        /// </returns>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     $"Source directory does not exist or could not be found: {sourceDirName}
+        /// </exception>
         public static List<FileToPack> GetFilesToPack(ContentToPack contentToPack, string sourceDirName, string destDirName, IFileSystem fileSystem, List<string> contentToIgnore = null, bool copySubDirs = true, bool isCopyDependencies = false, List<FileToPack> filesToPack = null)
         {
             if (filesToPack == null)
@@ -103,16 +121,30 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Directories copy.
+        ///     Directories copy.
         /// </summary>
-        /// <param name="sourceDirName">Name of the source dir.</param>
-        /// <param name="destDirName">Name of the dest dir.</param>
-        /// <param name="contentToIgnore">The exclusions.</param>
-        /// <param name="copySubDirs">if set to <c>true</c> [copy sub dirs].</param>
-        /// <param name="isCopyDependencies">if set to <c>true</c> [is copy dependencies].</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <exception cref="DirectoryNotFoundException">Source directory does not exist or could not be found: "
-        /// + sourceDirName</exception>
+        /// <param name="sourceDirName">
+        ///     Name of the source dir.
+        /// </param>
+        /// <param name="destDirName">
+        ///     Name of the dest dir.
+        /// </param>
+        /// <param name="contentToIgnore">
+        ///     The exclusions.
+        /// </param>
+        /// <param name="copySubDirs">
+        ///     if set to <c>true</c> [copy sub dirs].
+        /// </param>
+        /// <param name="isCopyDependencies">
+        ///     if set to <c>true</c> [is copy dependencies].
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <exception cref="DirectoryNotFoundException">
+        ///     Source directory does not exist or could not be found: "
+        ///     + sourceDirName
+        /// </exception>
         public static void CopyDirectory(string sourceDirName, string destDirName, IFileSystem fileSystem, List<string> contentToIgnore = null, bool copySubDirs = true, bool isCopyDependencies = false)
         {
             // Get the subdirectories for the specified directory.
@@ -164,10 +196,13 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Reads to string.
+        ///     Reads to string.
         /// </summary>
-        /// <param name="fi">The fi.</param>
-        /// <returns></returns>
+        /// <param name="fi">
+        ///     The fi.
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static string ReadToString(this IFileInfo fi)
         {
             //open for read operation
@@ -186,10 +221,13 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Reads to string list.
+        ///     Reads to string list.
         /// </summary>
-        /// <param name="fi">The fi.</param>
-        /// <returns></returns>
+        /// <param name="fi">
+        ///     The fi.
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static List<string> ReadToStringList(this IFileInfo fi)
         {
             List<string> result = new();
@@ -219,10 +257,13 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Gets the package root.
+        ///     Gets the package root.
         /// </summary>
-        /// <returns></returns>
-        /// <exception cref="CliException">Cannot find package root. Are you in a valid package directory?</exception>
+        /// <returns>
+        /// </returns>
+        /// <exception cref="CliException">
+        ///     Cannot find package root. Are you in a valid package directory?
+        /// </exception>
         public static IDirectoryInfo GetPackageRoot(IFileSystem fileSystem, string workingDir = null)
         {
             var cwd = fileSystem.DirectoryInfo.New(workingDir ?? fileSystem.Directory.GetCurrentDirectory());
@@ -236,11 +277,16 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Gets the project root.
+        ///     Gets the project root.
         /// </summary>
-        /// <returns></returns>
-        /// <exception cref="CliException">Cannot find project root. Are you in a valid project directory?</exception>
-        /// <exception cref="CliException">Cannot find project root. Are you in a valid project directory?</exception>
+        /// <returns>
+        /// </returns>
+        /// <exception cref="CliException">
+        ///     Cannot find project root. Are you in a valid project directory?
+        /// </exception>
+        /// <exception cref="CliException">
+        ///     Cannot find project root. Are you in a valid project directory?
+        /// </exception>
         public static IDirectoryInfo GetProjectRoot(IFileSystem fileSystem, bool throwException = false)
         {
             var cwd = fileSystem.DirectoryInfo.New(fileSystem.Directory.GetCurrentDirectory());
@@ -259,13 +305,22 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Gets the package root of type package root.
+        ///     Gets the package root of type package root.
         /// </summary>
-        /// <param name="directoryName">The current working directory</param>
-        /// <param name="packageType">Type of the package.</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns></returns>
-        /// <exception cref="CliException">Cannot find project root. Are you in a valid project directory?</exception>
+        /// <param name="directoryName">
+        ///     The current working directory
+        /// </param>
+        /// <param name="packageType">
+        ///     Type of the package.
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        /// </returns>
+        /// <exception cref="CliException">
+        ///     Cannot find project root. Are you in a valid project directory?
+        /// </exception>
         public static IDirectoryInfo GetPackageRootByType(string directoryName, PackageType packageType, IFileSystem fileSystem)
         {
             var cwd = fileSystem.DirectoryInfo.New(directoryName);
@@ -289,11 +344,37 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Reads the environment configuration.
+        ///     Retrieves all CmfPackages and orders them by PackageId, including the root CmfPackage at the beginning.
         /// </summary>
-        /// <param name="envConfigName">Name of the env configuration.</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns></returns>
+        /// <param name="IFileSystem">
+        ///     FileSystem
+        /// </param>
+        /// <returns>
+        ///     `CmfPackageCollection` object that contains all the CmfPackages loaded from subdirectories within the project root directory. The CmfPackages
+        ///     are ordered by their PackageId, and the Root CmfPackage is added to the beginning of the collection.
+        /// </returns>
+        public static CmfPackageCollection GetAllPackages(IFileSystem fileSystem)
+        {
+            IDirectoryInfo projectRoot = GetProjectRoot(fileSystem);
+            CmfPackageCollection packages = new CmfPackageCollection();
+
+            // Load all CmfPackages and Order by PackageId and add Root CmfPackage to the beginning of the sequence
+            Log.Status("Loading all CmfPackages", (_) => packages.AddRange(projectRoot.LoadCmfPackagesFromSubDirectories().OrderBy(p => p.PackageId).Prepend(CmfPackage.Load(fileSystem.FileInfo.New(fileSystem.Path.Join(projectRoot.FullName, CoreConstants.CmfPackageFileName))))));
+
+            return packages;
+        }
+
+        /// <summary>
+        ///     Reads the environment configuration.
+        /// </summary>
+        /// <param name="envConfigName">
+        ///     Name of the env configuration.
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static JsonDocument ReadEnvironmentConfig(string envConfigName, IFileSystem fileSystem)
         {
             if (!envConfigName.EndsWith(".json"))
@@ -311,9 +392,10 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Reads the project configuration.
+        ///     Reads the project configuration.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// </returns>
         [Obsolete("Use ExecutionContext.Instance.ProjectConfig")]
         public static JsonDocument ReadProjectConfig(IFileSystem fileSystem)
         {
@@ -325,10 +407,14 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Read DF repositories config from filesystem
+        ///     Read DF repositories config from filesystem
         /// </summary>
-        /// <param name="fileSystem">The filesystem object</param>
-        /// <returns>a RepositoriesConfig object</returns>
+        /// <param name="fileSystem">
+        ///     The filesystem object
+        /// </param>
+        /// <returns>
+        ///     a RepositoriesConfig object
+        /// </returns>
         public static RepositoriesConfig ReadRepositoriesConfig(IFileSystem fileSystem)
         {
             var cwd = fileSystem.DirectoryInfo.New(fileSystem.Directory.GetCurrentDirectory());
@@ -360,10 +446,14 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Copies the contents of input to output. Doesn't close either stream.
+        ///     Copies the contents of input to output. Doesn't close either stream.
         /// </summary>
-        /// <param name="input">The input.</param>
-        /// <param name="output">The output.</param>
+        /// <param name="input">
+        ///     The input.
+        /// </param>
+        /// <param name="output">
+        ///     The output.
+        /// </param>
         public static void CopyStream(Stream input, Stream output)
         {
             byte[] buffer = new byte[8 * 1024];
@@ -375,11 +465,17 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Copies the install dependencies.
+        ///     Copies the install dependencies.
         /// </summary>
-        /// <param name="packageOutputDir">The package output dir.</param>
-        /// <param name="packageType">Type of the package.</param>
-        /// <param name="fileSystem">the underlying file system</param>
+        /// <param name="packageOutputDir">
+        ///     The package output dir.
+        /// </param>
+        /// <param name="packageType">
+        ///     Type of the package.
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
         public static void CopyInstallDependenciesFiles(IDirectoryInfo packageOutputDir, PackageType packageType, IFileSystem fileSystem)
         {
             string sourceDirectory = fileSystem.Path.Join(AppDomain.CurrentDomain.BaseDirectory, CoreConstants.FolderInstallDependencies, packageType.ToString());
@@ -387,12 +483,19 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Gets the output dir.
+        ///     Gets the output dir.
         /// </summary>
-        /// <param name="cmfPackage">The CMF package.</param>
-        /// <param name="outputDir">The output dir.</param>
-        /// <param name="force">if set to <c>true</c> [force].</param>
-        /// <returns></returns>
+        /// <param name="cmfPackage">
+        ///     The CMF package.
+        /// </param>
+        /// <param name="outputDir">
+        ///     The output dir.
+        /// </param>
+        /// <param name="force">
+        ///     if set to <c>true</c> [force].
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static IDirectoryInfo GetOutputDir(CmfPackage cmfPackage, IDirectoryInfo outputDir, bool force)
         {
             // Create OutputDir
@@ -421,12 +524,19 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Gets the package output dir.
+        ///     Gets the package output dir.
         /// </summary>
-        /// <param name="cmfPackage">The CMF package.</param>
-        /// <param name="packageDirectory">The package directory.</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns></returns>
+        /// <param name="cmfPackage">
+        ///     The CMF package.
+        /// </param>
+        /// <param name="packageDirectory">
+        ///     The package directory.
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static IDirectoryInfo GetPackageOutputDir(CmfPackage cmfPackage, IDirectoryInfo packageDirectory, IFileSystem fileSystem)
         {
             // Clear and Create packageOutputDir
@@ -444,10 +554,12 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get Manifest File From package
+        ///     Get Manifest File From package
         /// </summary>
-        /// <param name="packageFile"></param>
-        /// <returns></returns>
+        /// <param name="packageFile">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static XDocument GetManifestFromPackage(string packageFile, IFileSystem fileSystem = null)
         {
             fileSystem ??= new FileSystem();
@@ -473,11 +585,14 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get File Content From package
+        ///     Get File Content From package
         /// </summary>
-        /// <param name="packageFile"></param>
-        /// <param name="filename"></param>
-        /// <returns></returns>
+        /// <param name="packageFile">
+        /// </param>
+        /// <param name="filename">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static string GetFileContentFromPackage(string packageFile, string filename)
         {
             using (FileStream zipToOpen = new FileInfo(packageFile).OpenRead())
@@ -497,12 +612,19 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Create a Zip file at filePath from the directory content
+        ///     Create a Zip file at filePath from the directory content
         /// </summary>
-        /// <param name="fileSystem">The file system implementation</param>
-        /// <param name="filePath">The path of the resulting zip file</param>
-        /// <param name="directory">The directory to zip</param>
-        /// <returns></returns>
+        /// <param name="fileSystem">
+        ///     The file system implementation
+        /// </param>
+        /// <param name="filePath">
+        ///     The path of the resulting zip file
+        /// </param>
+        /// <param name="directory">
+        ///     The directory to zip
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static void ZipDirectory(IFileSystem fileSystem, string filePath, IDirectoryInfo directory)
         {
             using (var memoryStream = new MemoryStream())
@@ -531,10 +653,12 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get Directory from a FileSystem dependending if Uri is UNC
+        ///     Get Directory from a FileSystem dependending if Uri is UNC
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static IDirectoryInfo GetDirectory(this Uri uri)
         {
             string path = uri.IsUnc ? uri.OriginalString : uri.LocalPath;
@@ -543,20 +667,24 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get Directory Name from a FileSystem dependending if Uri is UNC
+        ///     Get Directory Name from a FileSystem dependending if Uri is UNC
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static string GetDirectoryName(this Uri uri)
         {
             return GetDirectory(uri).FullName;
         }
 
         /// <summary>
-        /// Get File from a FileSystem dependending if Uri is UNC
+        ///     Get File from a FileSystem dependending if Uri is UNC
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static IFileInfo GetFile(this Uri uri)
         {
             string path = uri.IsUnc ? uri.OriginalString : uri.LocalPath;
@@ -565,24 +693,28 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get Directory Name from a FileSystem dependending if Uri is UNC
+        ///     Get Directory Name from a FileSystem dependending if Uri is UNC
         /// </summary>
-        /// <param name="uri"></param>
-        /// <returns></returns>
+        /// <param name="uri">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static string GetFileName(this Uri uri)
         {
             return GetFile(uri).FullName;
         }
 
-        #endregion
+        #endregion Public Methods
 
         #region Private Methods
 
         /// <summary>
-        /// Get all files and folders from a directory
+        ///     Get all files and folders from a directory
         /// </summary>
-        /// <param name="dir"></param>
-        /// <returns></returns>
+        /// <param name="dir">
+        /// </param>
+        /// <returns>
+        /// </returns>
         private static IEnumerable<IFileSystemInfo> AllFilesAndFolders(this IDirectoryInfo dir)
         {
             foreach (var f in dir.GetFiles())
@@ -595,6 +727,6 @@ namespace Cmf.CLI.Utilities
             }
         }
 
-        #endregion
+        #endregion Private Methods
     }
 }

--- a/core/Utilities/GenericUtilities.cs
+++ b/core/Utilities/GenericUtilities.cs
@@ -1,28 +1,35 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.IO.Abstractions;
 using Cmf.CLI.Core;
+using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
 using Spectre.Console;
+using System;
+using System.Collections.Generic;
+using System.Data.SqlClient;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Security.Principal;
 
 namespace Cmf.CLI.Utilities
 {
     /// <summary>
-    ///
     /// </summary>
     public static class GenericUtilities
     {
         #region Public Methods
 
         /// <summary>
-        /// Will create a new version based on the old and new inputs
+        ///     Will create a new version based on the old and new inputs
         /// </summary>
-        /// <param name="currentVersion"></param>
-        /// <param name="version"></param>
-        /// <param name="buildNr"></param>
+        /// <param name="currentVersion">
+        /// </param>
+        /// <param name="version">
+        /// </param>
+        /// <param name="buildNr">
+        /// </param>
         /// <returns>
-        /// the new version
+        ///     the new version
         /// </returns>
         public static string RetrieveNewVersion(string currentVersion, string version, string buildNr)
         {
@@ -39,13 +46,16 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Will create a new version based on the old and new inputs
+        ///     Will create a new version based on the old and new inputs
         /// </summary>
-        /// <param name="currentVersion"></param>
-        /// <param name="version"></param>
-        /// <param name="buildNr"></param>
+        /// <param name="currentVersion">
+        /// </param>
+        /// <param name="version">
+        /// </param>
+        /// <param name="buildNr">
+        /// </param>
         /// <returns>
-        /// the new version
+        ///     the new version
         /// </returns>
         public static string RetrieveNewPresentationVersion(string currentVersion, string version, string buildNr)
         {
@@ -61,14 +71,17 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get current version based on string, for
-        /// the format 1.0.0-1234
-        /// where 1.0.0 will be the version
-        /// and the 1234 will be the build number
+        ///     Get current version based on string, for the format 1.0.0-1234 where 1.0.0 will be the version and the 1234 will be the build number
         /// </summary>
-        /// <param name="source">Source information to be parsed</param>
-        /// <param name="version">Version Number</param>
-        /// <param name="buildNr">Build Number</param>
+        /// <param name="source">
+        ///     Source information to be parsed
+        /// </param>
+        /// <param name="version">
+        ///     Version Number
+        /// </param>
+        /// <param name="buildNr">
+        ///     Build Number
+        /// </param>
         public static void GetCurrentPresentationVersion(string source, out string version, out string buildNr)
         {
             version = string.Empty;
@@ -86,15 +99,27 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Get Package from Repository
+        ///     Get Package from Repository
         /// </summary>
-        /// <param name="outputDir">Target directory for the package</param>
-        /// <param name="repoUri">Repository Uri</param>
-        /// <param name="force"></param>
-        /// <param name="packageId">Package Identifier</param>
-        /// <param name="packageVersion">Package Version</param>
-        /// <param name="fileSystem">the underlying file system</param>
-        /// <returns></returns>
+        /// <param name="outputDir">
+        ///     Target directory for the package
+        /// </param>
+        /// <param name="repoUri">
+        ///     Repository Uri
+        /// </param>
+        /// <param name="force">
+        /// </param>
+        /// <param name="packageId">
+        ///     Package Identifier
+        /// </param>
+        /// <param name="packageVersion">
+        ///     Package Version
+        /// </param>
+        /// <param name="fileSystem">
+        ///     the underlying file system
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static bool GetPackageFromRepository(IDirectoryInfo outputDir, Uri repoUri, bool force, string packageId, string packageVersion, IFileSystem fileSystem)
         {
             bool packageFound = false;
@@ -142,12 +167,19 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Flatten a tree
+        ///     Flatten a tree
         /// </summary>
-        /// <param name="items">The top level tree items</param>
-        /// <param name="getChildren">a function that for each tree node returns its children</param>
-        /// <typeparam name="T">The tree node type</typeparam>
-        /// <returns></returns>
+        /// <param name="items">
+        ///     The top level tree items
+        /// </param>
+        /// <param name="getChildren">
+        ///     a function that for each tree node returns its children
+        /// </param>
+        /// <typeparam name="T">
+        ///     The tree node type
+        /// </typeparam>
+        /// <returns>
+        /// </returns>
         public static IEnumerable<T> Flatten<T>(
             this IEnumerable<T> items,
             Func<T, IEnumerable<T>> getChildren)
@@ -170,10 +202,12 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Converts a JsonObject to an Uri
+        ///     Converts a JsonObject to an Uri
         /// </summary>
-        /// <param name="value"></param>
-        /// <returns></returns>
+        /// <param name="value">
+        /// </param>
+        /// <returns>
+        /// </returns>
 #nullable enable
 
         public static Uri? JsonObjectToUri(dynamic value)
@@ -182,9 +216,11 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Builds a tree representation of a CmfPackage dependency tree
+        ///     Builds a tree representation of a CmfPackage dependency tree
         /// </summary>
-        /// <param name="pkg">the root package</param>
+        /// <param name="pkg">
+        ///     the root package
+        /// </param>
         public static Tree BuildTree(CmfPackage pkg)
         {
             var tree = new Tree($"{pkg.PackageId}@{pkg.Version} [[{pkg.Location.ToString()}]]");
@@ -216,14 +252,395 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        ///
         /// </summary>
-        /// <param name="envVarName"></param>
-        /// <returns></returns>
+        /// <param name="envVarName">
+        /// </param>
+        /// <returns>
+        /// </returns>
         public static bool IsEnvVarTruthy(string envVarName)
         {
             var enableConsoleExporter = System.Environment.GetEnvironmentVariable(envVarName);
             return enableConsoleExporter is "1" or "true" or "TRUE" or "True";
+        }
+
+        /// <summary>
+        ///     Gets all packages of a specified type and allows the user to choose from multiple packages if more than one is found.
+        /// </summary>
+        /// <param name="fileSystem">
+        ///     FileSystem
+        /// </param>
+        /// <param name="packageType">
+        ///     <see cref="PackageType"/> to select
+        /// </param>
+        /// <returns>
+        ///     Selected <see cref="CmfPackage"/>
+        /// </returns>
+        public static CmfPackage SelectPackage(IFileSystem fileSystem, PackageType packageType)
+        {
+            CmfPackageCollection packages = new CmfPackageCollection();
+
+            Log.Status($"Loading {packageType} CmfPackages", (_) =>
+            {
+                IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+
+                // Get Packages of given Type
+                packages = projectRoot.LoadCmfPackagesFromSubDirectories(packageType);
+            });
+
+            int packageIndex = 0;
+
+            // If there are more than 1 package
+            if (packages.Count > 1)
+            {
+                Log.Verbose($"Multiple {packageType} Packages found.");
+                Log.Verbose("Select the Package:");
+                int index = 0;
+                foreach (CmfPackage package in packages)
+                {
+                    Log.Verbose($"{index + 1} - {package.PackageId}");
+                    index++;
+                }
+                int option = ReadIntValueFromConsole(prompt: "Option:", minValue: 1, maxValue: packages.Count);
+                packageIndex = option - 1;
+            }
+
+            return packages[packageIndex];
+        }
+
+        /// <summary>
+        ///     Clears the console screen and removes all previous output.
+        /// </summary>
+        public static void FullConsoleClear()
+        {
+            Console.Clear();
+            Console.WriteLine("\x1b[3J");
+            Console.Clear();
+        }
+
+        /// <summary>
+        ///     Reads a value of type T from the console until the value is valid (not null or of type T).
+        /// </summary>
+        /// <param name="prompt">
+        ///     Message or question that will be displayed to the user when they are prompted to enter a value in the console.
+        /// </param>
+        /// <returns>
+        ///     Value of type `T` that is read from the console input after converting it from a string. If the input is null, the method recursively calls
+        ///     itself until a non-null input is provided. If the input cannot be converted to type `T` due to a <see cref="FormatException"/>, an error message
+        ///     is logged, and the method recursively calls itself in order to read a new value from the console.
+        /// </returns>
+        public static T? ReadValueFromConsole<T>(string prompt, bool allowEmptyValueInput = false)
+        {
+            Console.Write($"  {prompt} ");
+            string? input = Console.ReadLine();
+
+            try
+            {
+                // If empty value is received but not allowed
+                if (!allowEmptyValueInput && input?.Length == 0)
+                {
+                    throw new CliException();
+                }
+                else if (allowEmptyValueInput && input?.Length == 0)
+                {
+                    return default;
+                }
+
+                return (T)Convert.ChangeType(input, typeof(T));
+            }
+            catch (Exception ex) when (ex is CliException || ex is FormatException)
+            {
+                Log.Error("Invalid input. Try again.");
+                return ReadValueFromConsole<T>(prompt); // Recursively call until valid input
+            }
+        }
+
+        /// <summary>
+        ///     Reads an integer value from the console with optional minimum and maximum value constraints.
+        /// </summary>
+        /// <param name="prompt">
+        ///     Message or question that will be displayed to the user when they are prompted to enter a value in the console.
+        /// </param>
+        /// <param name="minValue">
+        ///     Minimum value that the user input must be greater than or equal to in order to be considered valid. If a `minValue` is not specified, the user
+        ///     input will not be validated in this scenario.
+        /// </param>
+        /// <param name="maxValue">
+        ///     Maximum value that the user input must be less than or equal to in order to be considered valid. If a `maxValue` is not specified, the user
+        ///     input will not be validated in this scenario.
+        /// </param>
+        /// <returns>
+        ///     An integer value that is read from the console input, after validating it against optional minimum and maximum values.
+        /// </returns>
+        public static int ReadIntValueFromConsole(string prompt, int? minValue = null, int? maxValue = null, bool allowEmptyValueInput = false)
+        {
+            string errorMessage = string.Empty;
+            int value = ReadValueFromConsole<int>(prompt: prompt, allowEmptyValueInput: allowEmptyValueInput);
+
+            if (allowEmptyValueInput && value == 0)
+            {
+                return value;
+            }
+
+            bool hasMinAndMaxValue = !minValue.IsNullOrEmpty() && !maxValue.IsNullOrEmpty();
+            bool hasMinValue = !minValue.IsNullOrEmpty() && maxValue.IsNullOrEmpty();
+            bool hasMaxValue = minValue.IsNullOrEmpty() && !maxValue.IsNullOrEmpty();
+
+            // If we have a `minValue` and the `value` is greater than or equal to the `minValue`
+            bool isValueGraterThanOrEqualToMinValue = !minValue.IsNullOrEmpty() && value >= minValue;
+            // If we have a `maxValue` and the `value` is less than or equal to the `maxValue`
+            bool isValueLessThanOrEqualToMaxValue = !maxValue.IsNullOrEmpty() && value <= maxValue;
+
+            if (hasMinAndMaxValue && isValueGraterThanOrEqualToMinValue && isValueLessThanOrEqualToMaxValue)
+            {
+                return value;
+            }
+            else if (hasMinValue && isValueGraterThanOrEqualToMinValue)
+            {
+                return value;
+            }
+            else if (hasMaxValue && isValueLessThanOrEqualToMaxValue)
+            {
+                return value;
+            }
+            else if (!hasMinAndMaxValue)
+            {
+                return value;
+            }
+
+            // Build error messages
+            if (hasMinAndMaxValue)
+            {
+                errorMessage = $"The value must be between {minValue} and {maxValue}. Try again.";
+            }
+            else if (hasMinValue)
+            {
+                errorMessage = $"The value must be grater than or equal to {minValue}. Try again.";
+            }
+            else if (hasMaxValue)
+            {
+                errorMessage = $"The value must be less than or equal to {maxValue}. Try again.";
+            }
+
+            Log.Error(errorMessage);
+            return ReadIntValueFromConsole(prompt, minValue, maxValue);
+        }
+
+        /// <summary>
+        ///     Reads a string value from the console with validation for allowed values and empty input.
+        /// </summary>
+        /// <param name="prompt">
+        ///     Message or question that will be displayed to the user when they are prompted to enter a value in the console.
+        /// </param>
+        /// <param name="allowEmptyValueInput">
+        ///     Determines whether an empty value input is allowed or not. If set to `true`, the user can input an empty string as a value. If set to `false`,
+        ///     the user must provide a non-empty string.
+        /// </param>
+        /// <returns>
+        ///     A string value that is read from the console input.
+        /// </returns>
+        public static string? ReadStringValueFromConsole(string prompt, bool allowEmptyValueInput = false, params string[] allowedValues)
+        {
+            string errorMessage = string.Empty;
+            string? value = ReadValueFromConsole<string>(prompt: prompt, allowEmptyValueInput: allowEmptyValueInput);
+
+            bool isValueAllowed = allowedValues.Length > 0 && allowedValues.Contains(value, StringComparer.OrdinalIgnoreCase);
+            bool isEmptyAndAllowedEmptyValue = allowEmptyValueInput && string.IsNullOrEmpty(value);
+
+            if (
+                (allowedValues.Length == 0 && isEmptyAndAllowedEmptyValue)
+                || (allowedValues.Length > 0 && isEmptyAndAllowedEmptyValue)
+                || allowedValues.Length == 0
+                || isValueAllowed
+                || (isValueAllowed && isEmptyAndAllowedEmptyValue)
+            )
+            {
+                return value;
+            }
+
+            if (!isValueAllowed)
+            {
+                errorMessage = "The value is not allowed. Try again.";
+            }
+
+            Log.Error(errorMessage);
+            return ReadStringValueFromConsole(prompt, allowEmptyValueInput, allowedValues);
+        }
+
+        /// <summary>
+        ///     Determines the appropriate PowerShell executable based on the operating system platform.
+        /// </summary>
+        /// <returns>
+        ///     <para>Path to the PowerShell executable based on the operating system.</para>
+        ///     <para>On Windows, it checks if `pwsh.exe` exists in the default path, and if not, it returns `powershell.exe`.</para>
+        ///     <para>On Unix-like systems (Linux, macOS), it returns `/usr/bin/pwsh`.</para>
+        /// </returns>
+        public static string GetPowerShellExecutable()
+        {
+            // Check if pwsh is installed on Windows
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+            {
+                if (File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "PowerShell", "7", "pwsh.exe")))
+                {
+                    return "pwsh.exe";
+                }
+                else
+                {
+                    return "powershell.exe";
+                }
+            }
+            else // Assume Unix-like systems (Linux, macOS)
+            {
+                return "/usr/bin/pwsh";
+            }
+        }
+
+        /// <summary>
+        ///     <para>Executes a PowerShell command with specified arguments and outputs the result.</para>
+        ///     <para>
+        ///         This function was created because, for some reason, the "CmdCommand" doesn't always work as expected. E.g.: when trying to open a tab in
+        ///         WindowsTerminal, it opens 2 tabs, one of those not executing any command.
+        ///     </para>
+        /// </summary>
+        /// <param name="command">
+        ///     PowerShell command to execute.
+        /// </param>
+        /// <param name="arguments">
+        ///     OPTIONAL. Arguments to add to the comment.
+        /// </param>
+        public static void ExecutePowerShellCommand(string command, params string[] arguments)
+        {
+            try
+            {
+                // Create a ProcessStartInfo object to configure the process to start
+                ProcessStartInfo psi = new ProcessStartInfo
+                {
+                    FileName = GetPowerShellExecutable(),
+                    Arguments = $"-NoProfile -ExecutionPolicy unrestricted -Command \"{command} {string.Join(' ', arguments)}\";",
+                    UseShellExecute = false, // Don't use the system shell to execute the command
+                    RedirectStandardOutput = true // Redirect the standard output of the command
+                };
+
+                // Create and start the process
+                Process process = new Process
+                {
+                    StartInfo = psi
+                };
+                process.Start();
+
+                // Read the output of the command and display it
+                string output = process.StandardOutput.ReadToEnd();
+                Console.WriteLine(output);
+
+                // Wait for the process to exit
+                process.WaitForExit();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine("Error executing PowerShell command: " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        ///     Checks if Windows Terminal is installed and throws an exception if it is not.
+        /// </summary>
+        public static void EnsureWindowsTerminalIsInstalled()
+        {
+            if (!File.Exists(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Microsoft", "WindowsApps", "wt.exe")))
+            {
+                throw new CliException("Windows Terminal is not installed");
+            }
+        }
+
+        /// <summary>
+        ///     Checks if the CLI is running as an administrator on a Windows platform and throws an exception if it is not.
+        /// </summary>
+        public static void EnsureIsRunningAsAdmin()
+        {
+            if (Environment.OSVersion.Platform == PlatformID.Win32NT && !new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator))
+            {
+                throw new CliException("CLI not running as Administrator.");
+            }
+        }
+
+        /// <summary>
+        ///     Write DB Name to "CurrentDB" file
+        /// </summary>
+        /// <param name="fileSystem">
+        ///     FileSystem
+        /// </param>
+        /// <param name="dbToSet">
+        ///     Name of the database to be set as the current database.
+        /// </param>
+        public static void SetCurrentDb(IFileSystem fileSystem, string dbToSet)
+        {
+            File.WriteAllText(fileSystem.Path.Combine(FileSystemUtilities.GetProjectRoot(fileSystem).FullName, "LocalEnvironment", "DBDumps", "CurrentDB"), dbToSet);
+        }
+
+        /// <summary>
+        ///     Gets the DB Name from "CurrentDB" file
+        /// </summary>
+        /// <param name="fileSystem">
+        ///     FileSystem
+        /// </param>
+        /// <returns>
+        ///     Current DB Name
+        /// </returns>
+        public static string GetCurrentDb(IFileSystem fileSystem)
+        {
+            string curentDbFilePath = fileSystem.Path.Combine(FileSystemUtilities.GetProjectRoot(fileSystem).FullName, "LocalEnvironment", "DBDumps", "CurrentDB");
+
+            if (!File.Exists(curentDbFilePath))
+            {
+                SetCurrentDb(fileSystem, $"{ExecutionContext.Instance.ProjectConfig.EnvironmentName}");
+                return $"{ExecutionContext.Instance.ProjectConfig.EnvironmentName}";
+            }
+            else
+            {
+                return File.ReadAllText(curentDbFilePath);
+            }
+        }
+
+        /// <summary>
+        ///     Gets existing/available DB Backups from `DBDumps` folder
+        /// </summary>
+        /// <param name="fileSystem">
+        ///     FileSystem
+        /// </param>
+        /// <returns>
+        ///     File paths to backup files
+        /// </returns>
+        public static string[] GetBdBackups(IFileSystem fileSystem)
+        {
+            string dbDumpsDirectoryPath = fileSystem.Path.Combine(FileSystemUtilities.GetProjectRoot(fileSystem).FullName, "LocalEnvironment", "DBDumps");
+
+            return Directory.GetFiles(dbDumpsDirectoryPath, "*.bak").Where(file => Path.GetFileNameWithoutExtension(file).StartsWith("Custom-")).ToArray();
+        }
+
+        /// <summary>
+        ///     Executes a SQL command
+        /// </summary>
+        /// <param name="connectionString">
+        ///     String that contains information needed to establish a connection to a database.
+        ///     <code>
+        ///Data Source=*IP*,*PORT*;Initial Catalog=master;User ID=*USERNAME*;Password=*PASSWORD*
+        ///     </code>
+        /// </param>
+        /// <param name="sqlCommand">
+        ///     SQL query or command that you want to execute
+        /// </param>
+        public static void ExecuteSqlCommand(string connectionString, string sqlCommand)
+        {
+            // Creating a SqlConnection object to connect to the database
+            using SqlConnection connection = new SqlConnection(connectionString);
+
+            // Opening the connection
+            connection.Open();
+
+            // Creating a SqlCommand object with the SQL command and SqlConnection
+            using SqlCommand command = new SqlCommand(sqlCommand, connection);
+
+            // Executing the SQL command
+            command.ExecuteNonQuery();
         }
 
         #endregion Public Methods

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -25,6 +25,7 @@
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.4.0" />
       <PackageReference Include="Spectre.Console" Version="0.46.0" />
       <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />
+      <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
       <PackageReference Include="System.IO.Abstractions" Version="19.2.1" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
       <PackageReference Include="Microsoft.TemplateEngine.Edge" Version="6.0.406" />


### PR DESCRIPTION
This PR aims to implement the `cmf menu` command.
It is a command that allows the user to do several environment and project related tasks/actions with a few keypresses.
All the options below have their own commands that can be used without the `cmf menu` (basically, all of them are independent commands).
![Menu options](https://github.com/criticalmanufacturing/cli/assets/32930044/8ea729c2-ad7b-427e-93d4-12e44ef4a551)

I tried to refactor the release notes `.ps1` script, but I'm having issues with the response from the TFS server.




Sorry about all the changes in summaries. It was my code clean-up 😅.