### PR TITLE
fix(Pack): use cmfapp.json from project root when it doesn't exist locally

### DIFF
--- a/cmf-cli/Handlers/PackageType/RootPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/RootPackageTypeHandler.cs
@@ -66,18 +66,21 @@ namespace Cmf.CLI.Handlers
         /// <exception cref="CliException"></exception>
         internal virtual void GenerateAppFiles(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir)
         {
-            Log.Debug("Generating App manifest");
-
             IFileInfo cmfAppFile = fileSystem.FileInfo.New(CliConstants.CmfAppFileName);
+            if (!cmfAppFile.Exists)
+            {
+                Log.Debug($"{CliConstants.CmfAppFileName} not found! No need to generate app manifest");
+                return;
+            }
+            
+            Log.Debug("Generating App manifest");
 
             CmfApp = CmfApp.Load(cmfAppFile, fileSystem);
 
             if (string.IsNullOrWhiteSpace(CmfApp.Content.App.Image.File))
             {
-                string defaultIconPath = fileSystem.Path.Join(FileSystemUtilities.GetProjectRoot(fileSystem, throwException: true).FullName,
-                    CliConstants.AssetsFolder,
-                    CliConstants.DefaultAppIcon);
-
+                string projectRootPath = FileSystemUtilities.GetProjectRoot(fileSystem, throwException: true).FullName;
+                string defaultIconPath = fileSystem.Path.Join(projectRootPath, CliConstants.AssetsFolder, CliConstants.DefaultAppIcon);
                 CmfApp.Content.App.Image.File = defaultIconPath;
             }
             else if (!AppIconUtilities.IsIconValid(CmfApp.Content.App.Image.File))


### PR DESCRIPTION
Fixes `cmfapp.json not found!` issue when packing a feature inside an app repository type