### PR TITLE
feat(init): Add App environment configuration

### DIFF
--- a/cmf-cli/resources/template_feed/init/.project-config.json
+++ b/cmf-cli/resources/template_feed/init/.project-config.json
@@ -34,6 +34,7 @@
   "HTMLPort": "<%= $CLI_PARAM_HTMLPort %>",
   "GatewayPort": "<%= $CLI_PARAM_GatewayPort %>",
   "ReleaseEnvironmentConfig": "<%= $CLI_PARAM_ReleaseEnvironmentConfig %>",
+  "AppEnvironmentConfig": "<%= $CLI_PARAM_AppEnvironmentConfig %>",
   "ISOLocation": "<%= $CLI_PARAM_ISOLocation_JSON %>",
   "DeploymentDir": "<%= $CLI_PARAM_DeploymentDir %>",
   "DeliveredRepo": "<%= $CLI_PARAM_DeliveredRepo %>",

--- a/cmf-cli/resources/template_feed/init/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/init/.template.config/template.json
@@ -509,6 +509,12 @@
       "datatype": "string",
       "defaultValue": "",
       "replaces": "<%= $CLI_PARAM_AppIcon %>"
+    },
+    "AppEnvironmentConfig": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "replaces": "<%= $CLI_PARAM_AppEnvironmentConfig %>"
     }
   },
   "forms": {

--- a/core/Objects/ProjectConfig/ProjectConfigV1.cs
+++ b/core/Objects/ProjectConfig/ProjectConfigV1.cs
@@ -56,6 +56,7 @@ public class ProjectConfigV1
     [JsonNumberHandling(JsonNumberHandling.AllowReadingFromString)]
     public int? GatewayPort { get; set; }
     public string ReleaseEnvironmentConfig { get; set; }
+    public string AppEnvironmentConfig { get; set; }
     public Uri ISOLocation { get; set; }
     [Newtonsoft.Json.JsonConverter(typeof(UriConverter))]
     public Uri DeploymentDir { get; set; }

--- a/tests/Specs/Init.cs
+++ b/tests/Specs/Init.cs
@@ -314,7 +314,7 @@ namespace tests.Specs
             var appDescription = "Some description";
             var targetFramework = "10.2.0";
             var licensedApplication = "Test app";
-            var icon = "";
+            var icon = $"assets/{CliConstants.DefaultAppIcon}";
 
             var cur = Directory.GetCurrentDirectory();
             try


### PR DESCRIPTION
This PR adds a new flag to allow adding an app configuration to the App project.

It also fixes an existing issue where the App Icon path is incorrectly configured.