### PR TITLE
Fixed manifest generation for packages with multiple master data packages targeting different platforms

### DIFF
--- a/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
+++ b/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
@@ -118,7 +118,7 @@ namespace Cmf.CLI.Handlers
                             AutomationWorkflowFileBasePath = this.FilesToPack.Find(f => f.ContentToPack.ContentType == ContentType.AutomationWorkFlows)?.ContentToPack.Target,
                             MappingFileBasePath = this.FilesToPack.Find(f => f.ContentToPack.ContentType == ContentType.Maps)?.ContentToPack.Target,
                             ImportXMLObjectPath = this.FilesToPack.Find(f => f.ContentToPack.ContentType == ContentType.ExportedObjects)?.ContentToPack.Target,
-                            TargetPlatform = this.FilesToPack.Find(f => f.ContentToPack.ContentType == ContentType.MasterData)?.ContentToPack.TargetPlatform 
+                            TargetPlatform = this.FilesToPack.Find(f => f.ContentToPack.ContentType == ContentType.MasterData && f.ContentToPack.TargetPlatform != null && f.ContentToPack.TargetPlatform == ftp.ContentToPack.TargetPlatform)?.ContentToPack.TargetPlatform
                                 ?? MasterDataTargetPlatformType.Self,
                             Title = "Master Data",
                         },


### PR DESCRIPTION
This PR fixes an issue causing the target platform of the first master data package in the cmfpackage.json to be copied to all other master data package entries. Modified test Data_MasterData to account for this scenario.