### PR TITLE
feat(security portal): new handler to preserve tokens in config.json

### DIFF
--- a/cmf-cli/Factories/PackageTypeFactory.cs
+++ b/cmf-cli/Factories/PackageTypeFactory.cs
@@ -1,5 +1,4 @@
-﻿
-using Cmf.CLI.Core;
+﻿using Cmf.CLI.Core;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Interfaces;
 using Cmf.CLI.Core.Objects;
@@ -64,7 +63,13 @@ namespace Cmf.CLI.Factories
                 PackageType.ExportedObjects => new ExportedObjectsPackageTypeHandler(cmfPackage),
                 PackageType.Database => new DatabasePackageTypeHandler(cmfPackage),
                 PackageType.Tests => new TestPackageTypeHandler(cmfPackage),
-                PackageType.SecurityPortal => SecurityPortalHandler(cmfPackage),
+                PackageType.SecurityPortal => cmfPackage.HandlerVersion switch
+                {
+                    3 => new SecurityPortalPackageTypeHandlerV3(cmfPackage),
+                    2 => new SecurityPortalPackageTypeHandlerV2(cmfPackage),
+                    1 => new SecurityPortalPackageTypeHandler(cmfPackage),
+                    _ => SecurityPortalHandler(cmfPackage)
+                },
                 PackageType.Grafana => new GrafanaPackageTypeHandler(cmfPackage),
                 _ => throw new CliException(string.Format(CoreMessages.PackageTypeHandlerNotImplemented, cmfPackage.PackageType.ToString()))
             };
@@ -98,7 +103,7 @@ namespace Cmf.CLI.Factories
 
         /// <summary>
         /// Creates the specific Security Portal package handler.
-        /// 
+        ///
         /// If the ProjectConfig's MESVersion is less than 10.0.0, a <seealso cref="SecurityPortalPackageTypeHandler"/> is created and returned.
         /// Otherwise, a <seealso cref="SecurityPortalPackageTypeHandlerV2"/> is created and returned.
         /// </summary>
@@ -108,6 +113,7 @@ namespace Cmf.CLI.Factories
         {
             var targetVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
             var minimumVersion = new Version("10.0.0");
+
             if (targetVersion.CompareTo(minimumVersion) < 0)
             {
                 return new SecurityPortalPackageTypeHandler(cmfPackage);

--- a/cmf-cli/Handlers/PackageType/SecurityPortalPackageTypeHandlerV3.cs
+++ b/cmf-cli/Handlers/PackageType/SecurityPortalPackageTypeHandlerV3.cs
@@ -1,0 +1,70 @@
+﻿using Cmf.CLI.Constants;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+
+namespace Cmf.CLI.Handlers
+{
+    public class SecurityPortalPackageTypeHandlerV3 : PackageTypeHandler
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecurityPortalPackageTypeHandlerV3" /> class.
+        /// </summary>
+        /// <param name="cmfPackage"></param>
+        public SecurityPortalPackageTypeHandlerV3(CmfPackage cmfPackage) : base(cmfPackage)
+        {
+            cmfPackage.SetDefaultValues
+            (
+                targetDirectory:
+                    "SecurityPortal",
+                targetLayer:
+                    "securityportal",
+                steps:
+                    new List<Step>
+                    {
+                        new(StepType.TransformFile)
+                        {
+                            File = "config.json",
+                            TagFile = true,
+                            RelativePath = "./src/"
+                        }
+                    }
+            );
+
+            cmfPackage.DFPackageType = PackageType.Business;
+        }
+
+        /// <summary>
+        /// Packs the specified package output dir.
+        /// </summary>
+        /// <param name="packageOutputDir">The package output dir.</param>
+        /// <param name="outputDir">The output dir.</param>
+        public override void Pack(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir)
+        {
+            Log.Debug("Generating SecurityPortal package");
+            string path = $"{packageOutputDir.FullName}{Path.DirectorySeparatorChar}{CliConstants.CmfPackageSecurityPortalConfig}";
+
+            IDirectoryInfo cmfPackageDirectory = CmfPackage.GetFileInfo().Directory;
+
+            dynamic configJson = cmfPackageDirectory.GetFile(CliConstants.CmfPackageSecurityPortalConfig);
+
+            if (configJson != null)
+            {
+                GenerateDeploymentFrameworkManifest(packageOutputDir);
+
+                FinalArchive(packageOutputDir, outputDir);
+
+                Log.Debug($"{outputDir.FullName}{Path.DirectorySeparatorChar}{CmfPackage.ZipPackageName} created");
+                Log.Information($"{CmfPackage.PackageName} packed");
+            }
+            else
+            {
+                throw new CliException("No config.json was provided");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implemented a new Handler that does not replace tokens in the Security Portal's config.json.

#183