### PR TITLE
fix(): post install's artifact fetch not working behind a proxy

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -29,7 +29,8 @@
   ],
   "dependencies": {
     "adm-zip": "^0.5.12",
-    "axios": "^1.6.8",
+    "axios": "^1.7.9",
+    "proxy-agent": "^6.5.0",
     "debug": "^4.3.4",
     "global-dirs": "3.0.0",
     "mkdirp": "^2.1.6",

--- a/npm/package.json
+++ b/npm/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "adm-zip": "^0.5.12",
     "axios": "^1.7.9",
-    "proxy-agent": "^6.5.0",
+    "proxy-agent": "^5.0.0",
     "debug": "^4.3.4",
     "global-dirs": "3.0.0",
     "mkdirp": "^2.1.6",


### PR DESCRIPTION
# What's Changed
The request to download the portal-sdk binary, through `axios`, is not working. It **may** be related with this [issue](https://github.com/axios/axios/issues/4533).

1. Check for proxy (through env vars, thanks to `proxy-from-env`) and build the appropriate `httpAgent` and `httpsAgent`.
2. Send the `httpAgent` and `httpsAgent` to the `axios` `GET` request.
3. Bumped `axios` dependency to `^1.7.9`.
4. Included `proxy-agent@^5.0.0`.

Check this portal-sdk's [pull-request](https://github.com/criticalmanufacturing/portal-sdk/pull/96) for more information and the test of `npm i`.