### PR TITLE
fix(new iot): angular package generation flag for MES >= 10.2.7

### DIFF
--- a/cmf-cli/Commands/new/IoTCommand.cs
+++ b/cmf-cli/Commands/new/IoTCommand.cs
@@ -7,6 +7,7 @@ using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Services;
 using Cmf.CLI.Utilities;
 using Microsoft.Extensions.DependencyInjection;
+using System;
 using System.Collections.Generic;
 using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
@@ -47,7 +48,7 @@ namespace Cmf.CLI.Commands.New
                 description: "Location of the HTML Package"
             ));
 
-            cmd.AddOption(new Option<string>(
+            cmd.AddOption(new Option<bool>(
                 aliases: new[] { "--isAngularPackage" },
                 description: "Customization package with angular"
             ));
@@ -97,17 +98,15 @@ namespace Cmf.CLI.Commands.New
         /// <param name="htmlPackageLocation">location of html package</param>
         public void Execute(IDirectoryInfo workingDir, string version, string htmlPackageLocation, bool isAngularPackage)
         {
-            if (ExecutionContext.Instance.ProjectConfig.MESVersion.Major > 9)
+            var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
+            if (mesVersion.Major > 9)
             {
                 // (ATL) Automation Task Library Package
                 // only introduced in v10.2.7
-                var executeV10ATL = !isAngularPackage &&
-                                        (ExecutionContext.Instance.ProjectConfig.MESVersion.Major == 10 &&
-                                            ExecutionContext.Instance.ProjectConfig.MESVersion.Minor >= 2 &&
-                                            ExecutionContext.Instance.ProjectConfig.MESVersion.Build >= 7);
+                var executeV10ATL = !isAngularPackage && mesVersion >= new Version(10, 2, 7) && mesVersion < new Version(11, 0, 0);
 
                 // only introduced in v11
-                var executeV11ATL = !isAngularPackage && ExecutionContext.Instance.ProjectConfig.MESVersion.Major == 11;
+                var executeV11ATL = !isAngularPackage && mesVersion >= new Version(11, 0, 0);
 
                 if (executeV10ATL)
                 {

--- a/cmf-cli/Commands/new/IoTCommand.cs
+++ b/cmf-cli/Commands/new/IoTCommand.cs
@@ -145,11 +145,15 @@ namespace Cmf.CLI.Commands.New
 
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.New($"{workingDir}/{packageName}/{CliConstants.CmfPackageFileName}");
             var cmfPackage = CmfPackage.Load(cmfpackageFile, setDefaultValues: true, this.fileSystem);
-            cmfPackage.LoadDependencies(null, null, true);
-
-            var iotCustomPackage = cmfPackage.Dependencies.FirstOrDefault(package => package.CmfPackage?.PackageType == PackageType.IoT).CmfPackage;
-
+            
             var iotRoot = cmfPackage.GetFileInfo().Directory;
+            var iotCustomPackage = iotRoot.LoadCmfPackagesFromSubDirectories(packageType: PackageType.IoT).FirstOrDefault();
+
+            if (iotCustomPackage == null)
+            {
+                throw new CliException($"Failed to find a CMF Package with type '${PackageType.IoT}' inside folder '{iotRoot.FullName}'");
+            }
+
             var iotCustomPackageWorkDir = iotCustomPackage.GetFileInfo().Directory;
             var iotCustomPackageName = base.GeneratePackageName(iotCustomPackageWorkDir)!.Value.Item1;
 
@@ -211,11 +215,15 @@ namespace Cmf.CLI.Commands.New
 
             IFileInfo cmfpackageFile = this.fileSystem.FileInfo.New($"{workingDir}/{packageName}/{CliConstants.CmfPackageFileName}");
             var cmfPackage = CmfPackage.Load(cmfpackageFile, setDefaultValues: true, this.fileSystem);
-            cmfPackage.LoadDependencies(null, null, true);
-
-            var iotCustomPackage = cmfPackage.Dependencies.FirstOrDefault(package => package.CmfPackage?.PackageType == PackageType.IoT).CmfPackage;
 
             var iotRoot = cmfPackage.GetFileInfo().Directory;
+            var iotCustomPackage = iotRoot.LoadCmfPackagesFromSubDirectories(packageType: PackageType.IoT).FirstOrDefault();
+
+            if (iotCustomPackage == null)
+            {
+                throw new CliException($"Failed to find a CMF Package with type '${PackageType.IoT}' inside folder '{iotRoot.FullName}'");
+            }
+            
             var iotCustomPackageWorkDir = iotCustomPackage.GetFileInfo().Directory;
             var iotCustomPackageName = base.GeneratePackageName(iotCustomPackageWorkDir)!.Value.Item1;
 

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -308,10 +308,11 @@ namespace tests.Specs
 
         [Theory]
         [InlineData("9.0.0")]
-        [InlineData("10.0.0"), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
-        [InlineData("10.0.0", true, true), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
-        [InlineData("10.2.0", false), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
-        public void IoT(string mesVersion, bool htmlPackageLocationFullPath = false, bool isAngularPackage = false)
+        [InlineData("10.2.5", true), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
+        [InlineData("10.2.5", true, true), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
+        [InlineData("10.2.7", true, true), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
+        [InlineData("10.2.7"), Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Internal")]
+        public void IoT(string mesVersion, bool htmlPackageLocationFullPath = false, bool isAngularPackageFlag = false)
         {
             string dir = TestUtilities.GetTmpDirectory();
             string packageId = "Cmf.Custom.IoT";
@@ -322,6 +323,9 @@ namespace tests.Specs
             string packageIdData = "Cmf.Custom.IoT.Data";
             string packageFolderData = mesVersion == "9.0.0" ? "IoTData" : packageIdData;
 
+            // Before v10.2.7, all packages were Angular packages, even if the flag was not passed explicitly
+            bool isAngularPackage = isAngularPackageFlag || Version.Parse(mesVersion) < new Version(10, 2, 7);
+
             CopyNewFixture(dir, mesVersion: mesVersion);
             if (mesVersion == "9.0.0")
             {
@@ -331,10 +335,17 @@ namespace tests.Specs
             {
                 var htmlPackageName = "Cmf.Custom.HTML";
                 var targetDir = new DirectoryInfo(dir);
-
+                
                 TestUtilities.CopyFixturePackage(htmlPackageName, targetDir);
                 string htmlPackageLocation = htmlPackageLocationFullPath ? htmlPackageName : Path.Join(targetDir.FullName, htmlPackageName);
-                RunNew(new IoTCommand(), packageId, mesVersion: mesVersion, scaffoldingDir: dir, extraArguments: new string[] { "--htmlPackageLocation", htmlPackageLocation, "--isAngularPackage", "true" });
+
+                var extraArguments = new List<string> { "--htmlPackageLocation", htmlPackageLocation };
+                if (isAngularPackageFlag)
+                {
+                    extraArguments.Add("--isAngularPackage");
+                }
+
+                RunNew(new IoTCommand(), packageId, mesVersion: mesVersion, scaffoldingDir: dir, extraArguments: extraArguments.ToArray());
             }
             else
             {
@@ -370,6 +381,8 @@ namespace tests.Specs
                 relatedPackages.GetProperty("postBuild").GetBoolean().Should().BeTrue();
                 relatedPackages.GetProperty("prePack").GetBoolean().Should().BeFalse();
                 relatedPackages.GetProperty("postPack").GetBoolean().Should().BeTrue();
+
+                File.Exists($"{packageId}/{packageFolderPackages}/angular.json").Should().BeTrue();
             }
             else
             {

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -376,7 +376,7 @@ namespace tests.Specs
             else if (isAngularPackage)
             {
                 var relatedPackages = TestUtilities.GetPackage($"{packageId}/{packageFolderPackages}/cmfpackage.json").GetProperty("relatedPackages")[0];
-                relatedPackages.GetProperty("path").GetString().Should().Be(MockUnixSupport.Path("..\\..\\Cmf.Custom.Html"));
+                relatedPackages.GetProperty("path").GetString().Should().Be(MockUnixSupport.Path("..\\..\\Cmf.Custom.HTML"));
                 relatedPackages.GetProperty("preBuild").GetBoolean().Should().BeFalse();
                 relatedPackages.GetProperty("postBuild").GetBoolean().Should().BeTrue();
                 relatedPackages.GetProperty("prePack").GetBoolean().Should().BeFalse();


### PR DESCRIPTION
The `--isAngularPackage` flag type was incorrectly marked as string, which was making it so that it was never recognized as true.

Furthermore, there was a bug in the logic of version comparison (missing parentheses were causing, even with the `--isAngularPackage` flag set to true, on MES versions 10.2.7/8, the generation to happen for ATL packages instead of Angular ones. This part of the code was refactored to make it more readable.

The test cases were updated to cover both the cases where the flag is explicitly passed or not, and for both versions prior and subsequent to 10.2.7. Additionally, a check was added to make sure angular package was indeed being generated (thought the presence of the file `angular.json`). All tests are passing now:
![imagem](https://github.com/user-attachments/assets/34a9cdcd-34c7-49aa-acbd-128f2ea9eefb)

Fixes #470.
