### PR TITLE
feat: repository clients

### DIFF
--- a/cmf-cli/Commands/publish/PublishCommand.cs
+++ b/cmf-cli/Commands/publish/PublishCommand.cs
@@ -1,0 +1,81 @@
+using System;
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.IO.Abstractions;
+using System.Linq;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Cmf.CLI.Commands;
+
+[CmfCommand("publish", Id = "publish", Description = "Publishes a local package to the specified repository")]
+public class PublishCommand : BaseCommand
+{
+    public override void Configure(Command cmd)
+    {
+        cmd.AddArgument(new Argument<IFileInfo>(
+            name: "file",
+            parse: (argResult) => Parse<IFileInfo>(argResult),
+            isDefault: false)
+        {
+            Description = "Package file"
+        });
+        
+        cmd.AddOption(new Option<Uri>(
+            aliases: new string[] { "--repository" },
+            description: "Repository the package should be published to"));
+
+        cmd.IsHidden =
+            !(ExecutionContext.ServiceProvider?.GetService<IFeaturesService>()?.UseRepositoryClients ?? false);
+        
+        // Add the handler
+        cmd.Handler = CommandHandler.Create<IFileInfo, Uri>(Execute);
+    }
+
+    public void Execute(IFileInfo file, Uri repository)
+    {
+        using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
+
+        if (!file.Exists || file.Directory == null)
+        {
+            throw new CliException(
+                $"Could not find package file {file.FullName}, make sure the file exists and is valid");
+        }
+
+        if (file.Extension != ".zip" && file.Extension != ".tgz")
+        {
+            throw new CliException(
+                $"The package needs to be in a zip or gzipped tar file (with .tgz extension). Use the `pack` command to get a valid file to publish.");
+        }
+
+        // request a client for the specific file, not its directory. This way the List call below always returns a single file.
+        // NOTE: this is only guaranteed in the Local and Archive repo clients!
+        //  It is possible to invoke this command from Linux with a share path which would return a CIFSRepositoryClient,
+        //  which does not support file as root but also does not support List
+        var client = ExecutionContext.ServiceProvider?.GetService<IRepositoryLocator>()
+            .GetRepositoryClient(new Uri(file.FullName), file.FileSystem);
+        if (client == null)
+        {
+            throw new CliException($"Could not determine repository type for {file.FullName}!");
+        }
+        Log.Debug($"Got client {client.GetType().Name} for package file {file.FullName}");
+        var repoClient = ExecutionContext.ServiceProvider?.GetService<IRepositoryLocator>()
+            .GetRepositoryClient(repository, file.FileSystem);
+        if (repoClient == null)
+        {
+            throw new CliException($"Could not determine repository type for {repository.AbsoluteUri}!");
+        }
+        Log.Debug($"Got client {repoClient.GetType().Name} for repository URL {repository.AbsoluteUri}");
+        var pkg = client.List().GetAwaiter().GetResult().FirstOrDefault();
+        Log.Debug($"Got package {pkg!.PackageAtRef} from origin repository");
+        var ctlr = new CmfPackageController(pkg, fileSystem);
+        Log.Debug($"Publishing package with target repository client...");
+        repoClient.Put(ctlr.CmfPackage).GetAwaiter().GetResult();
+        Log.Debug("Publish completed!");
+    }
+}

--- a/cmf-cli/Commands/restore/RestoreCommand.cs
+++ b/cmf-cli/Commands/restore/RestoreCommand.cs
@@ -44,16 +44,17 @@ namespace Cmf.CLI.Commands.restore
                 description: "Repositories where dependencies are located (folder)"));
 
             var packageRoot = FileSystemUtilities.GetPackageRoot(this.fileSystem);
-            var arg = new Argument<IDirectoryInfo>(
-                name: "packagePath",
-                description: "Package path");
-            cmd.AddArgument(arg);
-
+            var packagePath = ".";
             if (packageRoot != null)
             {
-                var packagePath = this.fileSystem.Path.GetRelativePath(this.fileSystem.Directory.GetCurrentDirectory(), packageRoot.FullName);
-                arg.SetDefaultValue(this.fileSystem.DirectoryInfo.New(packagePath));
+                packagePath = this.fileSystem.Path.GetRelativePath(this.fileSystem.Directory.GetCurrentDirectory(), packageRoot.FullName);
             }
+            var arg = new Argument<IDirectoryInfo>(
+                name: "packagePath",
+                parse: (argResult) => Parse<IDirectoryInfo>(argResult, packagePath),
+                isDefault: true,
+                description: "Package path");
+            cmd.AddArgument(arg);
             cmd.Handler = CommandHandler.Create<IDirectoryInfo, Uri[]>(Execute);
         }
 
@@ -71,6 +72,7 @@ namespace Cmf.CLI.Commands.restore
             {
                 ExecutionContext.Instance.RepositoriesConfig.Repositories.InsertRange(0, repos);
             }
+           
             packageTypeHandler.RestoreDependencies(ExecutionContext.Instance.RepositoriesConfig.Repositories.ToArray());
         }
     }

--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -18,6 +18,8 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Xml.Linq;
 using System.Xml.Serialization;
+using Cmf.CLI.Core.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 [assembly: InternalsVisibleTo("tests")]
 
@@ -611,6 +613,81 @@ namespace Cmf.CLI.Handlers
         /// <exception cref="CliException">thrown when a repo uri is not available or in an incorrect format</exception>
         public virtual void RestoreDependencies(Uri[] repoUris)
         {
+            if (ExecutionContext.ServiceProvider?.GetService<IFeaturesService>()?.UseRepositoryClients ?? false)
+            {
+                RestoreDependenciesUsingRepoClients(repoUris);
+            }
+            else
+            {
+                RestoreDependenciesLegacy(repoUris);
+            }
+        }
+        private void RestoreDependenciesUsingRepoClients(Uri[] repoUris)
+        {
+            Log.Debug($"Using repos at {string.Join(", ", repoUris.Select(r => r.OriginalString))}");
+            Log.Debug($"Targeting dependencies folder at {this.DependenciesFolder.FullName}");
+            var rootIdentifier = $"{this.CmfPackage.PackageId}@{this.CmfPackage.Version}";
+            Log.Status($"Loading {rootIdentifier} dependency tree...", ctx =>
+            {
+                var client = ExecutionContext.ServiceProvider?.GetService<IRepositoryLocator>()
+                    .GetRepositoryClient(new Uri(this.CmfPackage.GetFileInfo().FullName), this.fileSystem);
+                var cmfPackage = client.Find(null, null).GetAwaiter().GetResult();
+                var ctrlr = new CmfPackageController(cmfPackage, this.fileSystem);
+                ctrlr.LoadDependencies(repoUris, ctx, true).GetAwaiter().GetResult();
+                ctx.Status($"Restoring {rootIdentifier} dependency tree...");
+                if (ctrlr.CmfPackage.Dependencies == null)
+                {
+                    Log.Information($"No dependencies declared for package {rootIdentifier}");
+                    return;
+                }
+
+                // flatten dependency tree. We need to obtain all dependencies
+                var allDependencies = ctrlr.CmfPackage.Dependencies.Flatten(
+                    dependency => dependency.IsMissing || dependency.IsIgnorable ?
+                        new DependencyCollection() :
+                        dependency.CmfPackageV1.Dependencies).ToArray();
+
+                var missingDependencies = allDependencies.Where(d => d.IsMissing).ToArray();
+                if (missingDependencies.Any())
+                {
+                    Log.Warning($"Dependencies missing:{Environment.NewLine}{string.Join(Environment.NewLine, missingDependencies.Select(d => $"{d.Id}@{d.Version}"))}");
+                }
+
+                var foundDependencies = allDependencies.Where(d => !d.IsMissing && d.CmfPackageV1.SourceManifestFile == null).ToArray();
+                if (!foundDependencies.Any())
+                {
+                    Log.Information("No present remote dependencies to restore. Exiting...");
+                    return;
+                }
+                else
+                {
+                    Log.Verbose($"Found {foundDependencies.Length} actionable dependencies in the {rootIdentifier} dependency tree. Restoring...");
+                }
+
+                if (this.DependenciesFolder.Exists)
+                {
+                    Log.Debug($"Deleting directory {this.DependenciesFolder.FullName} and all its contents");
+                    this.DependenciesFolder.Delete(true);
+                }
+                if (!this.DependenciesFolder.Exists)
+                {
+                    this.DependenciesFolder.Create();
+                    Log.Debug($"Created Dependencies directory at {this.DependenciesFolder.FullName}");
+                }
+                foreach (var dependency in foundDependencies)
+                {
+                    var identifier = $"{dependency.Id}@{dependency.Version}";
+                    Log.Debug($"Processing dependency {identifier}...");
+                    Log.Debug($"Found package {identifier} at {dependency.CmfPackageV1.Client.RepositoryRoot}");
+                    var scopedDepDir = this.fileSystem.Path.Join(this.DependenciesFolder.FullName,
+                        omitIdentifier ? null : identifier);
+                    var depPkgDir = dependency.CmfPackageV1.Client.Extract(dependency.CmfPackageV1, this.fileSystem.DirectoryInfo.New(scopedDepDir)).GetAwaiter().GetResult();
+                    Log.Debug($"Extracted {identifier} to {depPkgDir.FullName}");
+                }
+            });
+        }
+        private void RestoreDependenciesLegacy(Uri[] repoUris)
+        {
             Log.Debug($"Using repos at {string.Join(", ", repoUris.Select(r => r.OriginalString))}");
             Log.Debug($"Targeting dependencies folder at {this.DependenciesFolder.FullName}");
             var rootIdentifier = $"{this.CmfPackage.PackageId}@{this.CmfPackage.Version}";
@@ -677,7 +754,6 @@ namespace Cmf.CLI.Handlers
                 }
             });
         }
-
         private void ExtractZip(Stream zipToOpen, string identifier)
         {
             using (ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read))

--- a/core/Enums/StepType.cs
+++ b/core/Enums/StepType.cs
@@ -83,6 +83,8 @@
         /// <summary>
         /// Sync Automation Business Scenarios libraries
         /// </summary>
-        AutomationBusinessScenariosSync = 15
+        AutomationBusinessScenariosSync = 15,
+        
+        RestoreDatabaseFromBackup = 16
     }
 }

--- a/core/Interfaces/IRepositoryClient.cs
+++ b/core/Interfaces/IRepositoryClient.cs
@@ -1,0 +1,18 @@
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Objects;
+
+namespace Cmf.CLI.Core.Interfaces;
+
+public interface IRepositoryClient
+{
+    Task<CmfPackageV1> Find(string packageId, string version);
+    Task<CmfPackageV1Collection> List();
+    Task Put(CmfPackageV1 package);
+    Task<IFileInfo> Get(CmfPackageV1 package, IDirectoryInfo targetDirectory);
+    Task<IDirectoryInfo> Extract(CmfPackageV1 package, IDirectoryInfo targetDirectory);
+    
+    string RepositoryRoot { get; }
+    
+    bool Unreacheable { get; }
+}

--- a/core/Interfaces/IRepositoryLocator.cs
+++ b/core/Interfaces/IRepositoryLocator.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Objects;
+
+namespace Cmf.CLI.Core.Interfaces;
+
+public interface IRepositoryLocator
+{
+    IRepositoryClient GetRepositoryClient(Uri uri, IFileSystem fileSystem);
+
+    IRepositoryClient GetSourceClient(IFileSystem fileSystem);
+
+    void InitializeClientsForRepositories(IFileSystem fileSystem, IEnumerable<Uri> repoUris);
+    
+    void InitializeClientsForRepositories(IFileSystem fileSystem);
+
+    Task<CmfPackageV1> FindPackage(string packageId, string packageVersion);
+}

--- a/core/Objects/CmfPackage/CmfPackageV1.cs
+++ b/core/Objects/CmfPackage/CmfPackageV1.cs
@@ -1,0 +1,316 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Interfaces;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Cmf.CLI.Core.Objects;
+
+[JsonObject]
+public class CmfPackageV1 : IEquatable<CmfPackageV1>
+{
+    /// <summary>
+    /// Gets the file name of the package.
+    /// </summary>
+    /// <value>
+    /// The file name of the package.
+    /// </value>
+    [JsonIgnore]
+    public string PackageDotRef => $"{PackageId}.{Version}";
+    
+    [JsonIgnore]
+    public string PackageAtRef => $"{PackageId}@{Version}";
+    
+    [JsonIgnore]
+    public IRepositoryClient Client { get; set; }
+    
+    // [JsonIgnore]
+    // public Stream Stream { get; set; }
+    
+    [JsonIgnore]
+    public IFileInfo SourceManifestFile { get; set; }
+    
+    /// <summary>
+    /// Should we set the defaults values as described in the package handler?
+    /// </summary>
+    internal bool IsToSetDefaultValues;
+    
+    #region Serializable Properties
+    /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
+        [JsonProperty(Order = 0)]
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the package identifier.
+        /// </summary>
+        /// <value>
+        /// The package identifier.
+        /// </value>
+        [JsonProperty(Order = 1)]
+        public string PackageId { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the version.
+        /// </summary>
+        /// <value>
+        /// The version.
+        /// </value>
+        [JsonProperty(Order = 2)]
+        public string Version { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the description.
+        /// </summary>
+        /// <value>
+        /// The description.
+        /// </value>
+        [JsonProperty(Order = 3)]
+        public string Description { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the type of the package.
+        /// </summary>
+        /// <value>
+        /// The type of the package.
+        /// </value>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty(Order = 4)]
+        public PackageType PackageType { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the target directory where the package contents should be installed.
+        /// This is used when the package is installed using Deployment Framework and ignored when it is installed using Environment Manager.
+        /// </summary>
+        /// <value>
+        /// The target directory.
+        /// </value>
+        [JsonProperty(Order = 5)]
+        public string TargetDirectory { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the target layer, which means the container in which the packages contents should be installed.
+        /// This is used when the package is installed using Environment Manager and ignored when it is installed using Deployment Framework.
+        /// </summary>
+        /// <value>
+        /// The target layer.
+        /// </value>
+        [JsonProperty(Order = 6)]
+        public string TargetLayer { get; private set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance is installable.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this instance is installable; otherwise, <c>false</c>.
+        /// </value>
+        [JsonProperty(Order = 7)]
+        public bool? IsInstallable { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the is unique install.
+        /// </summary>
+        /// <value>
+        /// The is unique install.
+        /// </value>
+        [JsonProperty(Order = 8)]
+        public bool? IsUniqueInstall { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the is root package.
+        /// </summary>
+        /// <value>
+        /// The is root package.
+        /// </value>
+        [JsonProperty(Order = 9)]
+        [JsonIgnore]
+        public string Keywords { get; private set; }
+
+        /// <summary>
+        /// Should we set the default steps as described in the handler?
+        /// </summary>
+        /// <value>
+        /// true to set the default steps; otherwise, false.
+        /// </value>
+        [JsonProperty(Order = 10)]
+        [JsonIgnore]
+        public bool? IsToSetDefaultSteps { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the dependencies.
+        /// </summary>
+        /// <value>
+        /// The dependencies.
+        /// </value>
+        [JsonProperty(Order = 11)]
+        public DependencyCollection Dependencies { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the steps.
+        /// </summary>
+        /// <value>
+        /// The steps.
+        /// </value>
+        [JsonProperty(Order = 12)]
+        public List<Step> Steps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content to pack.
+        /// </summary>
+        /// <value>
+        /// The content to pack.
+        /// </value>
+        [JsonProperty(Order = 13)]
+        public List<ContentToPack> ContentToPack { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the deployment framework UI file.
+        /// </summary>
+        /// <value>
+        /// The deployment framework UI file.
+        /// </value>
+        [JsonProperty(Order = 14)]
+        public List<string> XmlInjection { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the Test Package Id.
+        /// </summary>
+        /// <value>
+        /// The Test Package Id.
+        /// </value>
+        [JsonProperty(Order = 15)]
+        public DependencyCollection TestPackages { get; set; }
+        
+        /// <summary>
+        /// Handler Version
+        /// </summary>
+        [JsonProperty(Order = 17)]
+        public int HandlerVersion { get; private set; }
+
+        /// <summary>
+        /// Should the Deployment Framework wait for the Integration Entries created by the package
+        /// This fails the package installation if any Integration Entry fails
+        /// </summary>
+        [JsonProperty(Order = 18)]
+        public bool? WaitForIntegrationEntries { get; private set; }
+        
+        /// <summary>
+        /// The df package type
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty(Order = 20)]
+        public PackageType? DFPackageType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the build steps.
+        /// </summary>
+        /// <value>
+        /// The build steps.
+        /// </value>
+        [JsonProperty(Order = 21)]
+        public List<ProcessBuildStep> BuildSteps { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Related packages, and sets what are the expected behavior.
+        /// </summary>
+        /// <value>
+        /// Packages that should be built/packed before/after the context package
+        /// </value>
+        [JsonProperty(Order = 22)]
+        public RelatedPackageCollection RelatedPackages { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target directory where the dependencies contents should be extracted.
+        /// This is used when the package dependencies are restored in the restore and build commands.
+        /// </summary>
+        /// <value>
+        /// The dependencies target directory.
+        /// </value>
+        [JsonProperty(Order = 23)]
+        public string DependenciesDirectory { get; set; }
+    #endregion
+
+    #region constructors
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CmfPackage"/> class.
+    /// </summary>
+    /// <param name="name">The name.</param>
+    /// <param name="packageId">The package identifier.</param>
+    /// <param name="version">The version.</param>
+    /// <param name="description">The description.</param>
+    /// <param name="packageType">Type of the package.</param>
+    /// <param name="targetDirectory">The target directory.</param>
+    /// <param name="targetLayer">The target layer.</param>
+    /// <param name="isInstallable">The is installable.</param>
+    /// <param name="isUniqueInstall">The is unique install.</param>
+    /// <param name="keywords">The keywords.</param>
+    /// <param name="isToSetDefaultSteps">The is to set default steps.</param>
+    /// <param name="dependencies">The dependencies.</param>
+    /// <param name="steps">The steps.</param>
+    /// <param name="contentToPack">The content to pack.</param>
+    /// <param name="xmlInjection">The XML injection.</param>
+    /// <param name="waitForIntegrationEntries">should wait for integration entries to complete</param>
+    /// <param name="testPackages">The test Packages.</param>
+    [JsonConstructor]
+    public CmfPackageV1(string name, string packageId, string version, string description, PackageType packageType,
+                      string targetDirectory, string targetLayer, bool? isInstallable, bool? isUniqueInstall, string keywords,
+                      bool? isToSetDefaultSteps, DependencyCollection dependencies, List<Step> steps,
+                      List<ContentToPack> contentToPack, List<string> xmlInjection, bool? waitForIntegrationEntries, DependencyCollection testPackages = null) : this()
+    {
+        Name = name;
+        PackageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
+        Version = version ?? throw new ArgumentNullException(nameof(version));
+        Description = description;
+        PackageType = packageType;
+        TargetDirectory = targetDirectory;
+        TargetLayer = targetLayer;
+        IsInstallable = isInstallable ?? true;
+        IsUniqueInstall = isUniqueInstall ?? false;
+        Keywords = keywords;
+        IsToSetDefaultSteps = isToSetDefaultSteps ?? true;
+        Dependencies = dependencies;
+        Steps = steps;
+        ContentToPack = contentToPack;
+        XmlInjection = xmlInjection;
+        WaitForIntegrationEntries = waitForIntegrationEntries;
+        TestPackages = testPackages;
+    }
+    
+    /// <summary>
+    /// initialize an empty CmfPackage
+    /// </summary>
+    public CmfPackageV1()
+    {
+    }
+    #endregion
+    
+    public bool Equals(CmfPackageV1 other)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override bool Equals(object obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((CmfPackageV1)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        return this.PackageId.GetHashCode();
+    }
+}
+
+public class CmfPackageV1Collection : List<CmfPackageV1>
+{
+    
+}

--- a/core/Objects/CmfPackageCollection.cs
+++ b/core/Objects/CmfPackageCollection.cs
@@ -7,7 +7,7 @@ namespace Cmf.CLI.Core.Objects
     /// <summary>
     ///
     /// </summary>
-    /// <seealso cref="System.Collections.Generic.List{Objects.CmfPackage}" />
+    /// <seealso cref="CmfPackage" />
     public class CmfPackageCollection : List<CmfPackage>
     {
         /// <summary>

--- a/core/Objects/ContentToPack.cs
+++ b/core/Objects/ContentToPack.cs
@@ -10,7 +10,7 @@ namespace Cmf.CLI.Core.Objects
     /// <summary>
     /// Represents the content to be packed into a DF Package
     /// </summary>
-    /// <seealso cref="System.IEquatable{Cmf.CLI.Core.Objects.ContentToPack}" />
+    /// <seealso cref="ContentToPack" />
     public class ContentToPack : IEquatable<ContentToPack>
     {
         #region Public Properties

--- a/core/Objects/Dependency.cs
+++ b/core/Objects/Dependency.cs
@@ -47,6 +47,14 @@ namespace Cmf.CLI.Core.Objects
         [JsonProperty(Order = 3)]
         [JsonIgnore]
         public CmfPackage CmfPackage { get; set; }
+        
+        
+        /// <summary>
+        /// The CmfPackage that satisfies this dependency
+        /// </summary>
+        [JsonProperty(Order = 3)]
+        [JsonIgnore]
+        public CmfPackageV1 CmfPackageV1 { get; set; }
 
         /// <summary>
         /// Is this package missing, i.e. we could not find it anywhere to satisfy this dependency
@@ -54,7 +62,7 @@ namespace Cmf.CLI.Core.Objects
         [JsonProperty(Order = 4)]
         [JsonIgnore]
         [XmlIgnore]
-        public bool IsMissing => this.CmfPackage == null;
+        public bool IsMissing => this.CmfPackage == null && this.CmfPackageV1 == null;
 
         #endregion Public Properties
 

--- a/core/Objects/DependencyCollection.cs
+++ b/core/Objects/DependencyCollection.cs
@@ -7,7 +7,7 @@ namespace Cmf.CLI.Core.Objects
     /// <summary>
     ///
     /// </summary>
-    /// <seealso cref="System.Collections.Generic.List{Cmf.CLI.Core.Objects.Dependency}" />
+    /// <seealso cref="Dependency" />
     public class DependencyCollection : List<Dependency>
     {
         /// <summary>

--- a/core/Objects/NPMClient.cs
+++ b/core/Objects/NPMClient.cs
@@ -1,12 +1,22 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Security.Cryptography;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Utilities;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Cmf.CLI.Core.Objects
 {
@@ -31,6 +41,17 @@ namespace Cmf.CLI.Core.Objects
         IPackage[] FindPlugins(Uri[] registries);
     }
 
+    public interface INPMClientEx : INPMClient
+    {
+        Task<List<string>> SearchPackages(string query);
+        
+        Task<CmfPackageV1> FetchPackageVersion(string packageName, string version);
+
+        Task<IFileInfo> DownloadPackage(string packageName, string version, IFileInfo output);
+
+        Task PublishPackage(IFileInfo package);
+    }
+
     public interface IPackage
     {
         public string Name { get; set; }
@@ -50,9 +71,10 @@ namespace Cmf.CLI.Core.Objects
     /// <summary>
     /// A live implementation of the NPM Registry client
     /// </summary>
-    public class NPMClient : INPMClient
+    public class NPMClient : INPMClientEx
     {
         private readonly HttpClient client;
+        private readonly string baseUrl;
 
         private record SearchResults
         {
@@ -75,13 +97,15 @@ namespace Cmf.CLI.Core.Objects
             public List<PackageResult> Objects { get; set; }
         }
 
-        public NPMClient()
+        public NPMClient(string baseUrl = CoreConstants.NpmJsUrl, HttpClient client = null)
         {
+            this.baseUrl = baseUrl.TrimEnd('/');
+            this.client = client ?? this.GetClient();
         }
 
-        public NPMClient(object client)
+        public NPMClient(object client) : this(client: client as HttpClient)
         {
-            this.client = client as HttpClient;
+            
         }
 
         
@@ -93,9 +117,10 @@ namespace Cmf.CLI.Core.Objects
         public async Task<string> GetLatestVersion(bool preRelease = false)
         {
             var client = this.GetClient();
+            client.Timeout = TimeSpan.FromSeconds(10);
             try
             {
-                var res = await client.GetAsync($"{CoreConstants.NpmJsUrl.TrimEnd('/')}/{ExecutionContext.PackageId}");
+                var res = await client.GetAsync($"{this.baseUrl}/{ExecutionContext.PackageId}");
                 var body = await res.Content.ReadFromJsonAsync<JsonElement>();
                 return (body).GetProperty("dist-tags").GetProperty(preRelease ? "next" : "latest").GetString();
             }
@@ -113,7 +138,7 @@ namespace Cmf.CLI.Core.Objects
             var client = this.GetClient();
             try
             {
-                IEnumerable<IPackage>[] results = (registries ?? new[] { new Uri(CoreConstants.NpmJsUrl) }).Select(async registry =>
+                IEnumerable<IPackage>[] results = (registries ?? new[] { new Uri(this.baseUrl) }).Select(async registry =>
                 {
                     var queryUri = $"{registry.AbsoluteUri.TrimEnd('/')}/-/v1/search?text=+keywords:cmf-cli-plugin";
                     Log.Debug($"Querying {queryUri} for packages with keyword 'cmf-cli-plugin'...");
@@ -146,6 +171,204 @@ namespace Cmf.CLI.Core.Objects
 
             return Array.Empty<IPackage>();
         }
+        
+        public async Task<List<string>> SearchPackages(string query)
+        {
+            var client = this.GetClient();
+            var url = $"{this.baseUrl}/-/v1/search?text={query}";
+            var res = await client.GetAsync(url);
+            Log.Debug($"Got response HTTP code {res.StatusCode}");
+            if (res.StatusCode != HttpStatusCode.OK)
+            {
+                Log.Error($"Search request to {CoreConstants.NpmJsUrl} failed: {res.StatusCode}");
+                return [];
+            }
+            var searchResult = await res.Content.ReadFromJsonAsync<SearchResults>();
+
+            return searchResult.Objects.Select(package => package.Package.Name).ToList();
+        }
+        
+        public async Task<NpmPackageVersion> FetchPackageInfo(string packageName, string version)
+        {
+            var client = this.GetClient();
+            var url = $"{this.baseUrl}/{packageName}";
+            var res = await client.GetAsync(url);
+            Log.Debug($"Got response HTTP code {res.StatusCode}");
+            if (res.StatusCode != HttpStatusCode.OK)
+            {
+                Log.Error($"Could not get package {packageName}@{version} from {this.baseUrl}: {res.StatusCode}");
+                return null;
+            }
+            var body = await res.Content.ReadAsStringAsync();
+            
+            var packageVersion = JsonConvert.DeserializeObject<NpmPackageInfo>(body);
+
+            return !packageVersion.Versions.ContainsKey(version) ? null : packageVersion.Versions[version];
+        }
+        
+        public async Task<CmfPackageV1> FetchPackageVersion(string packageName, string version)
+        {
+            var client = this.GetClient();
+            var url = $"{this.baseUrl}/{packageName}";
+            var res = await client.GetAsync(url);
+            Log.Debug($"Got response HTTP code {res.StatusCode}");
+            if (res.StatusCode != HttpStatusCode.OK)
+            {
+                Log.Debug($"Could not get package {packageName}@{version} from {this.baseUrl}: {res.StatusCode}");
+                return null;
+            }
+            var body = await res.Content.ReadAsStringAsync();
+            
+            // Parse the JSON string into a JObject
+            var bodyJson = JObject.Parse(body);
+
+            // Extract the 'address' property as a JObject
+            var versions = (JObject)bodyJson["versions"];
+
+            if (!versions.ContainsKey(version))
+            {
+                return null;
+            }
+            
+            // Convert the address JObject back into a string
+            string versionManifest = versions[version].ToString();
+
+            var ctrlr = new CmfPackageController(CmfPackageController.FromJson(versionManifest), null);
+
+            return ctrlr.CmfPackage;
+        }
+
+        public async Task<IFileInfo> DownloadPackage(string packageName, string version, IFileInfo output)
+        {
+            var client = this.GetClient();
+            
+            var pkg = await this.FetchPackageInfo(packageName, version);
+            if (pkg == null)
+            {
+                return null;
+            }
+            
+            // Get the HTTP response as a stream
+            // Open a FileStream for writing the downloaded file
+            if (!output.Exists)
+            {
+                await using var stream = output.Create();
+            }
+            await using var fileStream = output.OpenWrite();
+            Log.Warning($"Downloading package {pkg.Dist.Tarball}");
+            // Get the HTTP response as a stream
+            using var response = await client.GetAsync(pkg.Dist.Tarball, HttpCompletionOption.ResponseHeadersRead);
+            response.EnsureSuccessStatusCode(); // Throw if not successful
+            Log.Debug("Download got a successful code, saving to temp file");
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+            // Open the content stream from the HTTP response
+            await using var contentStream = await response.Content.ReadAsStreamAsync();
+            Log.Debug("Got response");
+            // Stream the content directly into the file
+            await contentStream.CopyToAsync(fileStream);
+            Log.Debug($"Saving to file {output.FullName} finished, took {stopwatch.ElapsedMilliseconds}ms");
+            return output;
+        }
+
+        public async Task PublishPackage(IFileInfo package)
+        {
+            var toLowerCase = true; // TODO: complete implementation
+           
+            var ctrlr = new CmfPackageController(package, package.FileSystem);
+            
+            var manifest = ctrlr.ToJson(toLowerCase);
+
+            var name = toLowerCase ? ctrlr.CmfPackage.PackageId.ToLowerInvariant() : ctrlr.CmfPackage.PackageId;
+            var tgz = $"{name}-{ctrlr.CmfPackage.Version}.tgz";
+            Log.Debug($"Trying to publish {name} to {this.baseUrl}");
+            JObject root = null;
+            
+            try
+            {
+                Log.Debug("Load package content...");
+                using var fileStream = package.OpenRead();
+                using var memoryStream = new MemoryStream();
+                
+                fileStream.CopyTo(memoryStream);  // this can lead to large memory consumption
+                byte[] fileBytes = memoryStream.ToArray();
+
+                string dataBase64 = Convert.ToBase64String(fileBytes);
+
+                using SHA1 sha1 = SHA1.Create();
+                byte[] sha1HashBytes = sha1.ComputeHash(fileBytes);
+                var sha1Hash = BitConverter.ToString(sha1HashBytes).Replace("-", "").ToLower();
+
+                using SHA512 sha512 = SHA512.Create();
+                byte[] sha512HashBytes = sha512.ComputeHash(fileBytes);
+                var sha512_64 = Convert.ToBase64String(sha512HashBytes);
+                // var sha512Hash = BitConverter.ToString(sha512HashBytes).Replace("-", "").ToLower();
+                var sha512Hash = $"sha512-{sha512_64}";
+                Log.Debug($"Package content with hash {sha512Hash} and checksum {sha1Hash}");
+                
+                root = JObject.Parse(
+                    $$"""
+                    { 
+                        "_id": "{{name}}",
+                        "name": "{{name}}",
+                        "description": "{{ctrlr.CmfPackage.Description}}",
+                        "dist-tags": { "latest": "{{ctrlr.CmfPackage.Version}}" },
+                        "versions": {
+                            "{{ctrlr.CmfPackage.Version}}" : {{manifest}}
+                        },
+                        "access": null,
+                        "_attachments": {
+                          "{{tgz}}": {
+                            "content_type": "application/octet-stream",
+                            "data": "{{dataBase64}}",
+                            "length": {{package.Length}}
+                          }
+                        }
+                    }
+                    """);
+                // patch version manifest
+                root["versions"][ctrlr.CmfPackage.Version]["_id"] = $"{name}@{ctrlr.CmfPackage.Version}";
+                root["versions"][ctrlr.CmfPackage.Version]["_cliVersion"] = ExecutionContext.CurrentVersion;
+                root["versions"][ctrlr.CmfPackage.Version]["_integrity"] = sha512Hash;
+                root["versions"][ctrlr.CmfPackage.Version]["dist"] = JObject.Parse($$"""
+                      {
+                        "integrity": "{{sha512Hash}}",
+                        "shasum": "{{sha1Hash}}",
+                        "tarball": "{{this.baseUrl.Replace("https://", "http://")}}/{{name}}/-/{{tgz}}"
+                      }
+                      """);
+            }
+            catch (Exception ex)
+            {
+                throw new CliException($"Could not publish package {ctrlr.CmfPackage.PackageAtRef}!", ex);
+            }
+            
+            var payload = root.ToString(Formatting.None);
+            var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            // var content = JsonContent.Create(root);
+            content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            Log.Debug($"PUTing package to {this.baseUrl}...");
+            try
+            {
+                var httpClient = this.GetClient();
+                httpClient.Timeout = TimeSpan.FromMinutes(5);
+                var response = await httpClient.PutAsync($"{this.baseUrl}/{name}", content);
+                if (!response.IsSuccessStatusCode)
+                {
+                    Log.Debug($"Failed to publish the package: {(int)response.StatusCode} {response.ReasonPhrase}");
+                    Log.Warning(await response.Content.ReadAsStringAsync());
+                    throw new CliException(
+                        $"{(int)response.StatusCode} {response.ReasonPhrase}");
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Debug($"Failed to publish the package: {e.Message}{Environment.NewLine}{e.StackTrace}");
+                throw new CliException(
+                    $"Failed to publish package: {e.Message}");
+            }
+            
+        }
 
         private HttpClient GetClient()
         {
@@ -154,10 +377,53 @@ namespace Cmf.CLI.Core.Objects
                 return this.client;
             }
             var client = new HttpClient();
-            // remove the scope @ as it's not a valid user agent character
-            client.DefaultRequestHeaders.Add("User-Agent",
-                $"{ExecutionContext.PackageId.Replace("@", "")} v{ExecutionContext.CurrentVersion}");
+
+            // handle authentication
+            char[] strip = ['/', '.', '-'];
+            var uri = new Uri(this.baseUrl, UriKind.Absolute);
+            var envvarPrefix = new string($"{uri.Host}{uri.PathAndQuery.TrimEnd('/')}".Select(ch => strip.Contains(ch) ? '_' : ch).ToArray());
+            var type = Environment.GetEnvironmentVariable($"{envvarPrefix}__AUTH_TYPE");
+            var username = Environment.GetEnvironmentVariable($"{envvarPrefix}__USERNAME");
+            var token = Environment.GetEnvironmentVariable($"{envvarPrefix}__TOKEN");
+            switch (type?.ToLowerInvariant())
+            {
+                case "bearer":
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    break;
+                case "basic":
+                    var authValue = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{token}"));
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", authValue);
+                    break;
+            }
+            
+            if (this.baseUrl != CoreConstants.NpmJsUrl)
+            {
+                // remove the scope @ as it's not a valid user agent character
+                client.DefaultRequestHeaders.Add("User-Agent",
+                    $"{ExecutionContext.PackageId.Replace("@", "")} v{ExecutionContext.CurrentVersion}");
+            }
             return client;
         }
+    }
+
+    public class NpmPackageInfo
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+        public Dictionary<string, string> DistTags { get; set; }
+        public Dictionary<string, NpmPackageVersion> Versions { get; set; }
+    }
+    
+    public class NpmPackageVersion
+    {
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public NpmPackageDist Dist { get; set; }
+    }
+
+    public class NpmPackageDist
+    {
+        public string ShaSum { get; set; }
+        public string Tarball { get; set; }
     }
 }

--- a/core/Objects/RelatedPackage.cs
+++ b/core/Objects/RelatedPackage.cs
@@ -9,7 +9,7 @@ namespace Cmf.CLI.Core.Objects
     /// <summary>
     /// Represents the content to be packed into a DF Package
     /// </summary>
-    /// <seealso cref="System.IEquatable{Cmf.CLI.Core.Objects.RelatedPackage}" />
+    /// <seealso cref="RelatedPackage" />
     public class RelatedPackage : IEquatable<RelatedPackage>
     {
         #region Public Properties

--- a/core/Repository/ArchiveRepositoryClient.cs
+++ b/core/Repository/ArchiveRepositoryClient.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Utilities;
+
+namespace Cmf.CLI.Core.Repository;
+
+public class ArchiveRepositoryClient : ICIFSRepositoryClient
+{
+    private IDirectoryInfo root;
+    private IFileInfo file;
+
+    public ArchiveRepositoryClient(string rootPath) : this(rootPath, new FileSystem())
+    {
+    }
+    
+    public ArchiveRepositoryClient(string rootPath, IFileSystem fileSystem)
+    {
+        root = fileSystem.DirectoryInfo.New(rootPath.Replace("file:", ""));
+        var checkFile = fileSystem.FileInfo.New(rootPath.Replace("file:", ""));
+        if (!root.Exists && checkFile.Exists)
+        {
+            file = checkFile;
+            root = checkFile.Directory;
+        }
+    }
+    
+    public async Task<CmfPackageV1> Find(string packageId, string version)
+    {
+        ArgumentNullException.ThrowIfNull(version);
+
+        string dependencyFileName = $"{packageId}.{version}.*";
+        return (await GetPackages(dependencyFileName)).FirstOrDefault();
+    }
+
+    public async Task<CmfPackageV1Collection> List()
+    {
+        return await GetPackages("*");
+    }
+
+    public Task Put(CmfPackageV1 package)
+    {
+        var targetFilePath = root.FileSystem.Path.Join(root.FullName, $"{package.PackageDotRef}.zip");
+        // using var fileStream = root.FileSystem.FileInfo.New(filePath).Create();
+        // package.Stream.Seek(0, SeekOrigin.Begin);
+        // package.Stream.CopyTo(fileStream);
+        var originFile = package.Client.Get(package, root);
+        return Task.CompletedTask;
+    }
+
+    public Task<IFileInfo> Get(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        var files = this.Unreacheable ? [] : (this.file != null ? [file] : root?.GetFiles($"{package.PackageDotRef}.*", SearchOption.TopDirectoryOnly));
+        return Task.FromResult(files?.Where(f => f.Extension is ".tgz" or ".zip").FirstOrDefault());
+    }
+
+    public async Task<IDirectoryInfo> Extract(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        IDirectoryInfo depPkgDir = null;
+        var fileSystem = targetDirectory.FileSystem;
+        var pkgFile = await this.Get(package, fileSystem.DirectoryInfo.New(fileSystem.Path.GetTempPath()));
+        using (Stream zipToOpen = pkgFile.OpenRead())
+        {
+            using (ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read))
+            {
+                // these tuples allow us to rewrite entry paths
+                var entriesToExtract = new List<Tuple<ZipArchiveEntry, string>>();
+                entriesToExtract.AddRange(zip.Entries.Select(entry => new Tuple<ZipArchiveEntry, string>(entry, entry.FullName)));
+    
+                foreach (var entry in entriesToExtract)
+                {
+                    var target = fileSystem.Path.Join(targetDirectory.FullName, entry.Item2);
+                    var targetDir = fileSystem.Path.GetDirectoryName(target);
+                    if (target.EndsWith("/"))
+                    {
+                        // this a dotnet bug: if a folder contains a ., the library assumes it's a file and adds it as an entry
+                        // however, afterwards all folder contents are separate entries, so we can just skip these
+                        continue;
+                    }
+    
+                    if (!fileSystem.File.Exists(target)) // TODO: support overwriting if requested
+                    {
+                        var overwrite = false;
+                        Log.Debug($"Extracting {entry.Item1.FullName} to {target}");
+                        if (!string.IsNullOrEmpty(targetDir))
+                        {
+                            depPkgDir = fileSystem.Directory.CreateDirectory(targetDir);
+                        }
+    
+                        entry.Item1.ExtractToFile(target, overwrite, fileSystem);
+                    }
+                    else
+                    {
+                        Log.Debug($"Skipping {target}, file exists");
+                    }
+                }
+            }
+        }
+
+        return depPkgDir;
+    }
+
+    public string RepositoryRoot => this.root.FullName;
+    public bool Unreacheable => !this.root.Exists;
+
+    private Task<CmfPackageV1Collection> GetPackages(string dependencyFileName)
+    {
+        CmfPackageV1Collection cmfPackages = [];
+        
+        var files = this.Unreacheable ? [] : (this.file != null ? [file] : root?.GetFiles(dependencyFileName));
+
+        foreach (var file in files ?? [])
+        {
+            var ctrlr = new CmfPackageController(file);
+            ctrlr.CmfPackage.Client = this;
+            cmfPackages.Add(ctrlr.CmfPackage);
+        }
+        return Task.FromResult(cmfPackages);
+    }
+}

--- a/core/Repository/CIFSRepositoryClient.cs
+++ b/core/Repository/CIFSRepositoryClient.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Utilities;
+using Core.Objects;
+
+namespace Cmf.CLI.Core.Repository;
+
+public class CIFSRepositoryClient : ICIFSRepositoryClient
+{
+    private ICIFSClient client = null;
+    private Uri root = null;
+
+    public CIFSRepositoryClient(string rootPath, IFileSystem fileSystem)
+    {
+        this.root = new Uri(rootPath, UriKind.Absolute);
+        var host = this.root.Host;
+        this.client = new CIFSClient(host, [this.root]);
+    }
+    
+    public Task<CmfPackageV1> Find(string packageId, string version)
+    {
+        string dependencyFileName = $"{packageId}.{version}.*";
+        return GetFromRepository(dependencyFileName, true);
+    }
+
+    public Task<CmfPackageV1Collection> List()
+    {
+        throw new NotSupportedException("Cannot list packages from CIFS share!");
+    }
+
+    public Task Put(CmfPackageV1 package)
+    {
+        throw new NotSupportedException("Cannot publish packages to CIFS share!");
+    }
+
+    public Task<IFileInfo> Get(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        var targetFile =
+            targetDirectory.FileSystem.FileInfo.New(
+                targetDirectory.FileSystem.Path.Join(targetDirectory.FullName,
+                    $"{package.PackageId}.{package.Version}.zip"));
+        
+        string dependencyFileName = $"{package.PackageId}.{package.Version}.*";
+        this.DownloadFile(dependencyFileName, targetFile);
+        return Task.FromResult(targetFile);
+    }
+
+    public async Task<IDirectoryInfo> Extract(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        IDirectoryInfo depPkgDir = targetDirectory;
+        var fileSystem = targetDirectory.FileSystem;
+        var pkgFile = await this.Get(package, fileSystem.DirectoryInfo.New(fileSystem.Path.GetTempPath()));
+        using (Stream zipToOpen = pkgFile.OpenRead())
+        {
+            using (ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read))
+            {
+                // these tuples allow us to rewrite entry paths
+                var entriesToExtract = new List<Tuple<ZipArchiveEntry, string>>();
+                entriesToExtract.AddRange(zip.Entries.Select(entry => new Tuple<ZipArchiveEntry, string>(entry, entry.FullName)));
+    
+                foreach (var entry in entriesToExtract)
+                {
+                    var target = fileSystem.Path.Join(targetDirectory.FullName, entry.Item2);
+                    var targetDir = fileSystem.Path.GetDirectoryName(target);
+                    if (target.EndsWith("/"))
+                    {
+                        // this a dotnet bug: if a folder contains a ., the library assumes it's a file and adds it as an entry
+                        // however, afterwards all folder contents are separate entries, so we can just skip these
+                        continue;
+                    }
+    
+                    if (!fileSystem.File.Exists(target)) // TODO: support overwriting if requested
+                    {
+                        var overwrite = false;
+                        Log.Debug($"Extracting {entry.Item1.FullName} to {target}");
+                        if (!string.IsNullOrEmpty(targetDir))
+                        {
+                            fileSystem.Directory.CreateDirectory(targetDir);
+                        }
+    
+                        entry.Item1.ExtractToFile(target, overwrite, fileSystem);
+                    }
+                    else
+                    {
+                        Log.Debug($"Skipping {target}, file exists");
+                    }
+                }
+            }
+        }
+
+        return depPkgDir;
+    }
+
+    private Stream GetFileStream(string file)
+    {
+        var (_, stream) = this.client?.SharedFolders?.FirstOrDefault(sf => sf.Exists)?.GetFile(file) ?? new Tuple<Uri, Stream>(null, null);
+        return stream;
+    }
+    
+    private Task<CmfPackageV1> GetFromRepository(string dependencyFileName, bool fromManifest)
+    {
+        var stream = this.GetFileStream(dependencyFileName);
+        if(stream != null)
+        {                   
+            if(fromManifest)
+            {
+                using (ZipArchive zip = new(stream, ZipArchiveMode.Read))
+                {
+                    var manifest = zip.GetEntry(CoreConstants.DeploymentFrameworkManifestFileName);
+                    if (manifest != null)
+                    {
+                        using var manifStream = manifest.Open();
+                        using var reader = new StreamReader(manifStream);
+                        var pkg = CmfPackageController.FromXml(XDocument.Parse(reader.ReadToEnd()));
+                        return Task.FromResult(pkg);
+                    }
+                }
+            }
+            else
+            {
+                // cmfPackage = new CmfPackage(packageId, version, file.Item1);
+                // cmfPackage.SharedFolder = share;
+            }
+        }
+        return null;
+    }
+
+    private IFileInfo DownloadFile(string file, IFileInfo output)
+    {
+        if (!output.Exists)
+        {
+            output.Create();
+        }
+        using var fileStream = output.OpenWrite();
+        var stream = this.GetFileStream(file);
+        Log.Debug("Saving to temp file");
+        Stopwatch stopwatch = new Stopwatch();
+        stopwatch.Start();
+        // Stream the content directly into the file
+        stream.CopyTo(fileStream);
+        Log.Debug($"Saving to file {output.FullName} finished, took {stopwatch.ElapsedMilliseconds}ms");
+        return output;
+    }
+
+    public string RepositoryRoot => this.root?.OriginalString;
+    public bool Unreacheable => this.client?.IsConnected ?? false;
+}

--- a/core/Repository/ICIFSRepositoryClient.cs
+++ b/core/Repository/ICIFSRepositoryClient.cs
@@ -1,0 +1,8 @@
+using Cmf.CLI.Core.Interfaces;
+
+namespace Cmf.CLI.Core.Repository;
+
+public interface ICIFSRepositoryClient : IRepositoryClient
+{
+    
+}

--- a/core/Repository/LocalRepositoryClient.cs
+++ b/core/Repository/LocalRepositoryClient.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Services;
+
+namespace Cmf.CLI.Core.Repository;
+
+public class LocalRepositoryClient : IRepositoryClient
+{
+    private IDirectoryInfo root;
+    private IFileInfo file = null;
+    
+    public LocalRepositoryClient(string rootPath) : this(rootPath, new FileSystem())
+    {
+    }
+    
+    public LocalRepositoryClient(string rootPath, IFileSystem fileSystem)
+    {
+        // remove file handler
+        rootPath = new Uri(rootPath).AbsolutePath;
+        Log.Debug("Creating LocalRepositoryClient for path " + rootPath);
+        var checkFile = fileSystem.FileInfo.New(rootPath);
+        if (checkFile.Exists)
+        {
+            file = checkFile;
+            root = checkFile.Directory;
+        }
+        else
+        {
+            root = fileSystem.DirectoryInfo.New(rootPath);
+        }
+    }
+    
+    public async Task<CmfPackageV1> Find(string packageId, string version)
+    {
+        return (await this.List()).FirstOrDefault(p =>
+        {
+            var idMatch = string.IsNullOrEmpty(packageId) || p.PackageId == packageId;
+            var versionMatch = string.IsNullOrEmpty(version) || p.Version == version;
+            return idMatch && versionMatch;
+        });
+    }
+
+    public Task<CmfPackageV1Collection> List()
+    {
+        CmfPackageV1Collection cmfPackages = [];
+        IFileInfo[] cmfPackageFiles = this.file != null ? [this.file] : root.GetFiles(CoreConstants.CmfPackageFileName, SearchOption.AllDirectories);
+        foreach (IFileInfo cmfPackageFile in cmfPackageFiles)
+        {
+            var cmfPackage = CmfPackageController.FromSourceManifest(cmfPackageFile);
+            cmfPackage.Client = this;
+            cmfPackages.Add(cmfPackage);
+        }
+
+        return Task.FromResult(cmfPackages);
+    }
+
+    public Task Put(CmfPackageV1 package)
+    {
+        throw new NotSupportedException("Cannot publish to the local source repository!");
+    }
+
+    public Task<IFileInfo> Get(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        throw new NotSupportedException();
+    }
+
+    public Task<IDirectoryInfo> Extract(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        throw new NotSupportedException("Cannot extract packages from the local source repository!");
+    }
+
+    public string RepositoryRoot => this.root.FullName;
+    public bool Unreacheable => !this.root.Exists;
+}

--- a/core/Repository/NPMRepositoryClient.cs
+++ b/core/Repository/NPMRepositoryClient.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Utilities;
+
+namespace Cmf.CLI.Core.Repository;
+
+public class NPMRepositoryClient : IRepositoryClient
+{
+    private IFileSystem fileSystem;
+    private Uri registryUrl;
+    private INPMClientEx client;
+    public NPMRepositoryClient(string registryUrl, IFileSystem fileSystem = null, INPMClientEx client = null)
+    {
+        this.registryUrl = new Uri(registryUrl);
+        this.client = client ?? new NPMClient(registryUrl);
+        this.fileSystem = fileSystem ?? new FileSystem();
+    }
+    public async Task<CmfPackageV1> Find(string packageId, string version)
+    {
+        try
+        {
+            var pkg = await client.FetchPackageVersion(packageId.ToLowerInvariant(), version);
+            pkg.Client = this;
+            return pkg;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    public async Task<CmfPackageV1Collection> List()
+    {
+        // not all feeds support searching for keywords
+        var pkgs = await client.SearchPackages("keywords:cmf-deployment-package");
+        return new CmfPackageV1Collection();
+        // throw new System.NotImplementedException();
+    }
+
+    public async Task Put(CmfPackageV1 package)
+    {
+        var tmp = this.fileSystem.DirectoryInfo.New(this.fileSystem.Path.GetTempPath());
+        Log.Debug($"Downloading package {package.PackageAtRef} to {tmp.FullName}...");
+        var file = await package.Client.Get(package, tmp);
+        Log.Debug("Done!");
+        if (file.Extension == ".zip")
+        {
+            var zipFile = file;
+            file = this.fileSystem.FileInfo.New(this.fileSystem.Path.ChangeExtension(zipFile.FullName, "tgz"));
+            Log.Debug($"Package at {zipFile.FullName} is in Zip format, converting to tgz at {file.FullName}...");
+            CmfPackageController.ConvertZipToTarGz(zipFile, file);
+            Log.Debug("Done!");
+        }
+        else if (file.Extension == ".json")
+        {
+            // TODO: pack
+            throw new CliException("Please pack before publishing and publish the packed file.");
+        }
+        Log.Debug("Publishing via NPMClient...");
+        await this.client.PublishPackage(file);
+        Log.Debug("Publishing via NPMClient completed!");
+    }
+
+    public async Task<IFileInfo> Get(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        var tmp = targetDirectory.FileSystem.Path.GetTempFileName().Replace(".tmp", ".tgz");
+        var targetFile =
+            targetDirectory.FileSystem.FileInfo.New(
+                targetDirectory.FileSystem.Path.Join(targetDirectory.FullName,
+                $"{package.PackageId}.{package.Version}.tgz"));
+        var tgzPkg = await client.DownloadPackage(package.PackageId.ToLowerInvariant(), package.Version, targetDirectory.FileSystem.FileInfo.New(tmp));
+        if (tgzPkg == null)
+        {
+            throw new CliException($"Could not find package {package.PackageAtRef} at {registryUrl.OriginalString}");
+        }
+        CmfPackageController.ConvertTarGzToZip(tgzPkg, targetFile);
+        return targetFile;
+    }
+
+    public async Task<IDirectoryInfo> Extract(CmfPackageV1 package, IDirectoryInfo targetDirectory)
+    {
+        IDirectoryInfo depPkgDir = targetDirectory;
+        var fileSystem = targetDirectory.FileSystem;
+        var pkgFile = await this.Get(package, fileSystem.DirectoryInfo.New(fileSystem.Path.GetTempPath()));
+        // TODO: extract to utility
+        using (Stream zipToOpen = pkgFile.OpenRead())
+        {
+            using (ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read))
+            {
+                // these tuples allow us to rewrite entry paths
+                var entriesToExtract = new List<Tuple<ZipArchiveEntry, string>>();
+                entriesToExtract.AddRange(zip.Entries.Select(entry => new Tuple<ZipArchiveEntry, string>(entry, entry.FullName)));
+    
+                foreach (var entry in entriesToExtract)
+                {
+                    var target = fileSystem.Path.Join(targetDirectory.FullName, entry.Item2);
+                    var targetDir = fileSystem.Path.GetDirectoryName(target);
+                    if (target.EndsWith("/"))
+                    {
+                        // this a dotnet bug: if a folder contains a ., the library assumes it's a file and adds it as an entry
+                        // however, afterwards all folder contents are separate entries, so we can just skip these
+                        continue;
+                    }
+    
+                    if (!fileSystem.File.Exists(target)) // TODO: support overwriting if requested
+                    {
+                        var overwrite = false;
+                        Log.Debug($"Extracting {entry.Item1.FullName} to {target}");
+                        if (!string.IsNullOrEmpty(targetDir))
+                        {
+                            fileSystem.Directory.CreateDirectory(targetDir);
+                        }
+    
+                        entry.Item1.ExtractToFile(target, overwrite, fileSystem);
+                    }
+                    else
+                    {
+                        Log.Debug($"Skipping {target}, file exists");
+                    }
+                }
+            }
+        }
+
+        return depPkgDir;
+    }
+
+    public string RepositoryRoot => this.registryUrl.AbsoluteUri;
+    public bool Unreacheable => this.client == null;
+}

--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -1,0 +1,1514 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Abstractions;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Cmf.CLI.Core.Constants;
+using Cmf.CLI.Core.Enums;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using TarWriter = System.Formats.Tar.TarWriter;
+
+namespace Cmf.CLI.Core.Services;
+
+public class CmfPackageController
+{
+    private static List<CmfPackageV1> loadedPackages = new();
+    private CmfPackageV1 package;
+    private IFileSystem fileSystem;
+
+    public CmfPackageV1 CmfPackage => this.package; 
+    
+    public CmfPackageController(CmfPackageV1 package, IFileSystem fileSystem)
+    {
+        this.package = package;
+        this.fileSystem = fileSystem;
+    }
+    public CmfPackageController(IFileInfo file, IFileSystem fileSystem = null, bool setDefaultValues = false)
+    {
+        Log.Debug("Spinning up a controller for a CmfPackage file info: " + file.FullName);
+        #if DEBUG
+        // TODO: this is dumb
+        var stackTrace = new StackTrace();
+        var callingMethod = stackTrace.GetFrame(1).GetMethod(); // Get the calling method
+        var callerType = callingMethod.DeclaringType; // Get the caller's type
+
+        if (callerType.GetInterface(nameof(IRepositoryClient)) == null)
+        {
+            Log.Warning("This constructor can only be invoked from RepositoryClients!");
+        }
+        #endif
+        
+        this.fileSystem = fileSystem ?? file.FileSystem;
+        if (!file.Exists)
+        {
+            throw new CliException(string.Format(CoreMessages.NotFound, file.FullName));
+        }
+
+        if (file.Extension == ".json")
+        {
+            Log.Debug("File is a source package");
+            // source package
+            var cmfPackage = CmfPackageController.FromSourceManifest(file);
+            cmfPackage.Client = ExecutionContext.ServiceProvider.GetService<IRepositoryLocator>()
+                .GetRepositoryClient(new Uri(file.FullName), file.FileSystem); // this is a hack to avoid awaiting for the LocalRepositoryClient as it is async
+            // string fileContent = file.ReadToString();
+            // CmfPackage cmfPackage = JsonConvert.DeserializeObject<CmfPackage>(fileContent);
+            cmfPackage.IsToSetDefaultValues = setDefaultValues;
+            // cmfPackage.FileInfo = file;
+            // cmfPackage.Location = PackageLocation.Local;
+            // cmfPackage.fileSystem = fileSystem;
+
+            // TODO: restore this
+            // cmfPackage.RelatedPackages?.Load(cmfPackage);
+
+            this.package = cmfPackage;
+        }
+        else if (file.Extension == ".zip")
+        {
+            Log.Debug("File is a DF package in ZIP format");
+            using Stream zipToOpen = file.OpenRead();
+            using ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read);
+            var manifest = zip.GetEntry(CoreConstants.DeploymentFrameworkManifestFileName);
+            if (manifest != null)
+            {
+                using var stream = manifest.Open();
+                using var reader = new StreamReader(stream);
+                // TODO: make sure this is ok
+                // this.package = CmfPackageController.FromXmlManifest(reader.ReadToEnd(), setDefaultValues: true);
+                this.package = CmfPackageController.FromXml(XDocument.Parse(reader.ReadToEnd()));
+                // cmfPackage.Stream = zipToOpen;
+                // if (cmfPackage != null)
+                // {
+                //     cmfPackage.Uri = new(dependencyFile.FullName);
+                // }
+            }
+            else
+            {
+                var jsonManifest = zip.GetEntry("package.json");
+                if (jsonManifest == null)
+                {
+                    throw new CliException($"Zip file {file.FullName} does not contain a valid manifest!");
+                }
+
+                using var stream = jsonManifest.Open();
+                using var reader = new StreamReader(stream);
+                // TODO: make sure this is ok
+                // this.package = CmfPackageController.FromXmlManifest(reader.ReadToEnd(), setDefaultValues: true);
+                this.package = CmfPackageController.FromJson(reader.ReadToEnd());
+            }
+        }
+        else if (file.Extension is ".gz" or ".tgz")
+        {
+            Log.Debug("File is a DF package in TAR.GZ format");
+            using Stream zipToOpen = file.OpenRead();
+            using GZipStream gzipStream = new GZipStream(zipToOpen, CompressionMode.Decompress);
+            using TarReader tarReader = new(gzipStream);
+            var foundManifest = false;
+            while (tarReader.GetNextEntry() is { } entry)
+            {
+                // Check if this is the file you're looking for
+                if ((entry.Name == CoreConstants.DeploymentFrameworkManifestFileName || entry.Name == $"package/{CoreConstants.DeploymentFrameworkManifestFileName}" )&& entry.EntryType == TarEntryType.V7RegularFile)
+                {
+                    foundManifest = true;
+                    // Read the content of the file inside the TAR
+                    using var reader = new StreamReader(entry.DataStream);
+                   
+                    // TODO: make sure this is ok
+                    // this.package = CmfPackageController.FromXmlManifest(reader.ReadToEnd(), setDefaultValues: true);
+                    this.package = CmfPackageController.FromXml(XDocument.Parse(reader.ReadToEnd()));
+                    break;
+                }
+            }
+
+            if (!foundManifest)
+            {
+                using Stream zipToOpen2 = file.OpenRead();
+                using GZipStream gzipStream2 = new GZipStream(zipToOpen2, CompressionMode.Decompress);
+                using TarReader tarReader2 = new(gzipStream2);
+                while (tarReader2.GetNextEntry() is { } entry)
+                {
+                    // Check if this is the file you're looking for
+                    if ((entry.Name == "package.json" || entry.Name == $"package/package.json" )&& entry.EntryType == TarEntryType.V7RegularFile)
+                    {
+                        foundManifest = true;
+                        // Read the content of the file inside the TAR
+                        using var reader = new StreamReader(entry.DataStream);
+                   
+                        // TODO: make sure this is ok
+                        // this.package = CmfPackageController.FromXmlManifest(reader.ReadToEnd(), setDefaultValues: true);
+                        this.package = CmfPackageController.FromJson(reader.ReadToEnd());
+                        break;
+                    }
+                }
+            }
+
+            if (!foundManifest)
+            {
+                throw new CliException($"Tgz file {file.FullName} does not contain a valid manifest!");
+            }
+        }
+
+        
+    }
+    
+    public async Task LoadDependencies(IEnumerable<Uri> repoUris, StatusContext ctx, bool recurse = false)
+    {
+        using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity("CmfPackageController LoadDependencies");
+        activity?.SetTag("cmfPackage", $"{package.PackageId}.{package.Version}");
+        loadedPackages.Add(package);
+        ctx?.Status($"Working on {package.Name ?? (package.PackageId + "@" + package.Version)}");
+        
+        if (package.Dependencies.HasAny())
+        {
+            // IDirectoryInfo[] repoDirectories = repoUris?.Select(r => r.GetDirectory()).ToArray();
+            // var missingRepoDirectories = repoDirectories?.Where(r => r.Exists == false).ToArray();
+            // if (missingRepoDirectories.HasAny())
+            // {
+            //     throw new CliException($"Some of the provided repositories do not exist: {string.Join(", ", missingRepoDirectories.Select(d => d.FullName))}");
+            // }
+            foreach (var dependency in package.Dependencies)
+            {
+                ctx?.Status($"Working on dependency {dependency.Id}@{dependency.Version}");
+                Log.Debug($"Working on dependency {dependency.Id}@{dependency.Version}");
+
+                #region Get Dependencies from Dependencies Directory
+
+                // 1) check if we have found this package before
+                var dependencyPackage = loadedPackages.FirstOrDefault(x => x.PackageId.IgnoreCaseEquals(dependency.Id) && x.Version.IgnoreCaseEquals(dependency.Version));
+
+                // 2) check if package is in repository
+                if (dependencyPackage == null)
+                {
+                    // dependencyPackage = LoadFromRepo(repoDirectories, dependency.Id, dependency.Version);
+                    dependencyPackage = await ExecutionContext.ServiceProvider.GetService<IRepositoryLocator>()
+                        .FindPackage(dependency.Id, dependency.Version);
+                }
+
+                // 3) search in the source code repository (only if this is a local package)
+                if (dependencyPackage == null && (package.SourceManifestFile?.Exists ?? false))
+                {
+                    // dependencyPackage = FileInfo.Directory.LoadCmfPackagesFromSubDirectories(setDefaultValues: true).GetDependency(dependency);
+                    // if (dependencyPackage != null)
+                    // {
+                    //     dependencyPackage.Uri = new Uri(dependencyPackage.FileInfo.FullName);
+                    // }
+                    dependencyPackage = await ExecutionContext.ServiceProvider.GetService<IRepositoryLocator>().GetSourceClient(this.fileSystem)
+                        .Find(dependency.Id, dependency.Version);
+                }
+
+                if (dependencyPackage != null)
+                {
+                    loadedPackages.Add(dependencyPackage);
+                    dependency.CmfPackageV1 = dependencyPackage;
+                    if (recurse)
+                    {
+                        var ctrlr = new CmfPackageController(dependencyPackage, fileSystem);
+                        await ctrlr.LoadDependencies(repoUris, ctx, recurse);
+                    }
+                }
+            }
+
+            #endregion Get Dependencies from Dependencies Directory
+        }
+    }
+    
+    
+    
+    private static CmfPackageV1 FromXmlManifest(string manifest, bool setDefaultValues = false)
+    {
+        StringReader dFManifestReader = new(manifest);
+        XDocument dFManifestTemplate = XDocument.Load(dFManifestReader);
+        var tokens = new Dictionary<string, string>();
+
+        XElement rootNode = dFManifestTemplate.Element("deploymentPackage", true);
+        if (rootNode == null)
+        {
+            throw new CliException(string.Format(CoreMessages.InvalidManifestFile));
+        }
+        DependencyCollection deps = new();
+        DependencyCollection testPackages = new();
+        foreach (XElement element in rootNode.Elements())
+        {
+            // Get the Property Value based on the Token name
+            string token = element.Value.Trim();
+
+            if (element.Name.LocalName == "dependencies")
+            {
+                var deplist = element.Elements().Select(depEl => new Dependency(depEl.Attribute("id").Value, depEl.Attribute("version").Value));
+                deps.AddRange(deplist);
+            }
+
+            if (element.Name.LocalName == "testPackages")
+            {
+                var testPackagesList = element.Elements().Select(depEl => new Dependency(depEl.Attribute("id").Value, depEl.Attribute("version").Value));
+                testPackages.AddRange(testPackagesList);
+            }
+
+            if (string.IsNullOrEmpty(token))
+            {
+                continue;
+            }
+
+            tokens.Add(element.Name.LocalName.ToLowerInvariant(), token);
+        }
+
+        PackageType cliPackageType = PackageType.Generic;
+        if (tokens.ContainsKey("clipackagetype"))
+        {
+            Enum.TryParse(tokens["clipackagetype"], out cliPackageType);
+        }
+
+        // NOTE: we're extracting only the essentials here for `cmf ls` but we can get extra data from the manifests
+        var cmfPackage = new CmfPackageV1(
+            tokens.ContainsKey("name") ? tokens["name"] : null,
+            tokens["packageid"],
+            tokens["version"],
+            tokens.ContainsKey("description") ? tokens["description"] : null,
+            cliPackageType,
+            "",
+            "",
+            false,
+            false,
+            tokens.ContainsKey("keywords") ? tokens["keywords"] : null,
+            true,
+            deps,
+            null,
+            null,
+            null,
+            waitForIntegrationEntries: false,
+            testPackages
+            );
+
+        // cmfPackage.Location = PackageLocation.Repository;
+        // cmfPackage.fileSystem = fileSystem;
+
+        return cmfPackage;
+    }
+    
+    /// <summary>
+        /// Froms the XML.
+        /// </summary>
+        /// <param name="xml">The XML.</param>
+        /// <returns></returns>
+        /// <exception cref="PackageReadingException">
+        /// </exception>
+        public static CmfPackageV1 FromXml(XDocument xml)
+        {
+            // NOTE: We don't use an automatic serializer because we want full control
+            // on how the file is parsed in order to be able to version it
+
+            var rootNode = xml.Element("deploymentPackage", true);
+            if (rootNode == null)
+            {
+                throw new CliException("Invalid manifest");
+            }
+
+            // if (rootNode.Element("systemName", true) != null)
+            // {
+            //     package.AddMetadata(MetadataKey.ApplicationName, rootNode.Element("systemName", true).Value);
+            //
+            //     var targetSystemVersionText = rootNode.Element("systemVersion", true)?.Value;
+            //     if (!string.IsNullOrWhiteSpace(targetSystemVersionText))
+            //     {
+            //         package.AddMetadata(MetadataKey.ApplicationVersion, targetSystemVersionText);
+            //     }
+            // }
+
+            PackageType cliPackageType = PackageType.Generic;
+            Enum.TryParse(rootNode.Element("clipackagetype", true)?.Value, out cliPackageType);
+
+            var steps = new List<Step>();
+            var stepsElements = rootNode.Element("steps", true)?.Elements("step", true);
+            if (stepsElements != null)
+            {
+                foreach (var element in stepsElements)
+                {
+                    Step step = new Step(
+                        type: Enum.Parse(typeof(StepType), element.Attribute("type")?.Value) is StepType
+                            ? (StepType)Enum.Parse(typeof(StepType), element.Attribute("type")?.Value)
+                            : StepType.Generic,
+                        title: element.Attribute("title")?.Value,
+                        onExecute: element.Attribute("onExecute")?.Value,
+                        contentPath: element.Attribute("contentPath")?.Value,
+                        file: null,
+                        tagFile: element.Attribute("tagFile")?.Value != null ? bool.Parse(element.Attribute("tagFile")?.Value) : null,
+                        targetDatabase: element.Attribute("targetDatabase")?.Value,
+                        messageType: MessageType.ImportObject, // TODO: get value
+                        relativePath: null
+                    );
+                    
+                    // // Create an XmlSerializer for the Person type
+                    // XmlSerializer serializer = new XmlSerializer(typeof(Step));
+                    //
+                    // // Use StringReader to read the XML string
+                    // using var reader = element.CreateReader();
+                    // // Deserialize the XML string into a Person object
+                    // Step s = (Step)serializer.Deserialize(reader);
+                    steps.Add(step);
+                }
+            }
+
+            // #region PackageDemands Parsing
+            //
+            // var packageDemands = rootNode.Element("packageDemands", true)?.Elements("packageDemand", true);
+            // if (packageDemands != null)
+            // {
+            //     foreach (var item in packageDemands)
+            //     {
+            //         PackageDemand packageDemand = ParseDemand(item);
+            //
+            //         package.AddDemand(packageDemand);
+            //     }
+            // }
+            //
+            // #endregion
+
+            // var variables = rootNode.Element("variables", true)?.Elements("variable", true);
+            // if (variables != null)
+            // {
+            //     foreach (var element in variables)
+            //     {
+            //         var variable = ParseVariable(element);
+            //         package.AddVariable(variable);
+            //     }
+            // }
+
+            DependencyCollection deps = new();
+            DependencyCollection testPackages = new();
+            var dependenciesElements = rootNode.Element("dependencies", true)?.Elements("dependency", true);
+            if (dependenciesElements != null)
+            {
+                foreach (var dependenciesElement in dependenciesElements)
+                {
+                    var id = dependenciesElement.Attribute("id")?.Value;
+                    var versionRange = dependenciesElement.Attribute("version")?.Value;
+                    var mandatory = dependenciesElement.Attribute("mandatory");
+                    var conditional = dependenciesElement.Attribute("conditional");
+
+                    bool isMandatory = false;
+                    bool isConditional = false;
+
+                    if (mandatory != null)
+                    {
+                        isMandatory = (bool)mandatory;
+                    }
+
+                    if (conditional != null)
+                    {
+                        isConditional = (bool)conditional;
+                    }
+
+                    Dependency result = null;
+
+                    if (!string.IsNullOrWhiteSpace(id) && !string.IsNullOrWhiteSpace(versionRange))
+                    {
+                        result = new Dependency(id, versionRange) { Mandatory = isMandatory/*, isConditional*/};
+                    }
+                    // else if (!string.IsNullOrWhiteSpace(id))
+                    // {
+                    //     result = new Dependency(id) { Mandatory = isMandatory/*, isConditional*/};
+                    // }
+                    else
+                    {
+                        throw new CliException($"Could not load package {id}@{versionRange} dependencies");
+                    }
+
+                    // foreach (var attr in dependenciesElement.Attributes())
+                    // {
+                    //     if (attr.Name == "id" || attr.Name == "version")
+                    //     {
+                    //         continue;
+                    //     }
+                    //
+                    //     result.AddMetadata(attr.Name.LocalName, attr.Value);
+                    // }
+
+                    deps.Add(result);
+                }
+            }
+            
+            var testPksElements = rootNode.Element("testPackages", true)?.Elements("testPackages", true);
+            if (testPksElements != null)
+            {
+                foreach (var element in testPksElements)
+                {
+                    var testPackagesList = element.Elements().Select(depEl =>
+                        new Dependency(depEl.Attribute("id").Value, depEl.Attribute("version").Value));
+                    testPackages.AddRange(testPackagesList);
+                }
+            }
+
+            // var uiElements = rootNode.Element("ui", true)?.Elements("wizardStep", true);
+            // if (uiElements != null)
+            // {
+            //     foreach (var uiElement in uiElements)
+            //     {
+            //         var step = (PackageWizardStep)ParseGroup(uiElement, new PackageWizardStep());
+            //         step.Id = uiElement.Attribute("id")?.Value;
+            //         package.UserInterface.AddStep(step);
+            //     }
+            // }
+
+            // var metadataElements = rootNode.Element("metadata", true)?.Elements();
+            // if (metadataElements != null)
+            // {
+            //     foreach (var element in metadataElements)
+            //     {
+            //         package.AddMetadata(element.Name.LocalName, element.Value);
+            //     }
+            // }
+
+            // string manifestVersionString = rootNode.Element("manifestVersion", true)?.Value;
+            // int manifestVersion = -1;
+            // Int32.TryParse(manifestVersionString, out manifestVersion);
+            // package.ManifestVersion = manifestVersion;
+            //
+            // string minSqlCompatibilityString = rootNode.Element("minSqlCompatibility", true)?.Value;
+            // int minSqlCompatibility = -1;
+            // Int32.TryParse(minSqlCompatibilityString, out minSqlCompatibility);
+            // package.MinSqlCompatibility = minSqlCompatibility;
+            // package.TargetLayerDirectory = rootNode.Element("targetLayerDirectory", true)?.Value;
+            // package.IsToForceInstall = rootNode.Element("IsToForceInstall", true)?.Value != null ? bool.Parse(rootNode.Element("IsToForceInstall", true).Value) : false;
+            // package.BuildDate = rootNode.Element("buildDate", true)?.Value != null ? DateTime.ParseExact(rootNode.Element("buildDate", true).Value, "dd/MM/yyyy", System.Globalization.CultureInfo.InvariantCulture) : (DateTime?)null;
+            // package.IsRootPackage = (rootNode.Element("keywords", true)?.Value.Split(',').Any(k => k.Contains("cmf-root-package")) ?? false);
+            // package.ForceRerunAfterDatabaseRestore = bool.Parse(rootNode.Element("forceRerunAfterDatabaseRestore", true)?.Value ?? "false");
+            var cmfPackage = new CmfPackageV1(
+                rootNode.Element("name", true)?.Value,
+                rootNode.Element("packageId", true)?.Value,
+                rootNode.Element("version", true)?.Value,
+                rootNode.Element("description", true)?.Value,
+                cliPackageType,
+                rootNode.Element("targetDirectory", true)?.Value,
+                rootNode.Element("targetLayer", true)?.Value,
+                bool.Parse(rootNode.Element("isInstallable", true)?.Value ?? "false"),
+                rootNode.Element("isUniqueInstall", true)?.Value != null ? bool.Parse(rootNode.Element("isUniqueInstall", true).Value) : false,
+                rootNode.Element("keywords", true)?.Value,
+                true,
+                deps,
+                steps,
+                null,
+                null,
+                waitForIntegrationEntries: false,
+                testPackages
+            );
+            
+            return cmfPackage;
+        }
+
+    public static CmfPackageV1 FromJson(string manifest)
+    {
+        return FromJson(JsonConvert.DeserializeObject<JObject>(manifest));
+    }
+    
+    /// <summary>
+    /// Forms the PackageManifest from the json object.
+    /// </summary>
+    /// <param name="json">The JSON.</param>
+    /// <returns></returns>
+    /// <exception cref="PackageReadingException">
+    /// </exception>
+    public static CmfPackageV1 FromJson(JObject json)
+    {
+        // Confirm if it is a standard deployment package
+        bool isDeploymentPackage = false;
+        if (json.Property("keywords")?.Value != null && json.Property("keywords")?.Value.Type == JTokenType.Array)
+        {
+            var keywordsArray = (JArray)json.Property("keywords").Value;
+            if (keywordsArray != null)
+            {
+                isDeploymentPackage = keywordsArray.Any(k => ((JToken)k).ToString() == JSONPackageKeyword);
+            }
+        }
+
+        var rootNode = json.Property("deployment");
+
+        if (!isDeploymentPackage || rootNode == null)
+        {
+            throw new CliException("Invalid manifest file");
+        }
+
+        // if (!string.IsNullOrEmpty(json.Property("systemName")?.Value.ToString()))
+        // {
+        //     package.AddMetadata(PackageManifestReader.MetadataKey.ApplicationName, json.Property("systemName").Value.ToString());
+        //
+        //     var targetSystemVersionText = json.Property("systemVersion")?.Value.ToString();
+        //     if (!string.IsNullOrWhiteSpace(targetSystemVersionText))
+        //     {
+        //         package.AddMetadata(PackageManifestReader.MetadataKey.ApplicationVersion, targetSystemVersionText);
+        //     }
+        // }
+
+        var deploymentVariables = rootNode.Children<JObject>();
+        string packageType = null;
+        IEnumerable<string> keywords = new List<string>();
+        keywords = JsonConvert.DeserializeObject<List<string>>(json.Property("keywords")?.Value.ToString());
+
+        foreach (var entry in deploymentVariables)
+        {
+            // string manifestVersionString = entry.Property("manifestVersion")?.Value.ToString();
+            // int manifestVersion = -1;
+            // Int32.TryParse(manifestVersionString, out manifestVersion);
+            // package.ManifestVersion = manifestVersion;
+
+            // string minSqlCompatibilityString = entry.Property("minSqlCompatibility")?.Value.ToString();
+            // int minSqlCompatibility = -1;
+            // Int32.TryParse(minSqlCompatibilityString, out minSqlCompatibility);
+            // package.MinSqlCompatibility = minSqlCompatibility;
+
+            if (!string.IsNullOrEmpty(entry.Property("packageType")?.Value.ToString()))
+            {
+                packageType = entry.Property("packageType")?.Value.ToString();
+            }
+
+            // if (!string.IsNullOrEmpty(entry.Property("targetDirectory")?.Value.ToString()))
+            // {
+            //     targetDirectory = entry.Property("targetDirectory")?.Value.ToString();
+            // }
+            //
+            // if (!string.IsNullOrEmpty(entry.Property("targetLayerDirectory")?.Value.ToString()))
+            // {
+            //     package.TargetLayerDirectory = entry.Property("targetLayerDirectory")?.Value.ToString();
+            // }
+            //
+            // if (!string.IsNullOrEmpty(entry.Property("targetLayer")?.Value.ToString()))
+            // {
+            //     package.TargetLayer = entry.Property("targetLayer")?.Value.ToString();
+            // }
+
+            // if (!string.IsNullOrEmpty(entry.Property("buildDate")?.Value.ToString()))
+            // {
+            //     DateTime dt;
+            //     if (DateTime.TryParse(entry.Property("buildDate").Value.ToString(), out dt))
+            //         package.BuildDate = dt;
+            // }
+            // else
+            // {
+            //     package.BuildDate = (DateTime?)null;
+            // }
+            // package.IsInstallable = bool.Parse(entry.Property("isInstallable")?.Value.ToString() ?? "false");
+        }
+
+        var auxArr = (JObject)rootNode.Value;
+        var steps = new List<Step>();
+        if (auxArr.Property("steps").Value.Type == JTokenType.Array)
+        {
+            var stepsEl = (JArray)auxArr.Property("steps").Value;
+
+            if (stepsEl != null)
+            {
+                foreach (var element in stepsEl)
+                {
+                    if (element.Type == JTokenType.Object)
+                    {
+                        var elem = (JObject)element;
+
+                        Step step = new Step(
+                            type: Enum.Parse(typeof(StepType), elem.Property("type")?.Value.ToString()) is StepType
+                                ? (StepType)Enum.Parse(typeof(StepType), elem.Property("type")?.Value.ToString())
+                                : StepType.Generic,
+                            title: elem.Property("title")?.Value.ToString(),
+                            onExecute: elem.Property("onExecute")?.Value.ToString(),
+                            contentPath: elem.Property("contentPath")?.Value.ToString(),
+                            file: null,
+                            tagFile: elem.Property("tagFile")?.Value.ToString() != null ? bool.Parse(elem.Property("tagFile")?.Value.ToString()) : null,
+                            targetDatabase: elem.Property("targetDatabase")?.Value.ToString(),
+                            messageType: MessageType.ImportObject, // TODO: get value
+                            relativePath: null
+                        );
+                        steps.Add(step);
+                    }
+                }
+            }
+        }
+
+        #region PackageDemands Parsing
+
+        // var demandsAuxArr = (JObject)rootNode.Value;
+        // if (demandsAuxArr.Property("packageDemands")?.Value.Type == JTokenType.Array)
+        // {
+        //     var packageDemands = (JArray)demandsAuxArr.Property("packageDemands").Value;
+        //
+        //     if (packageDemands != null)
+        //     {
+        //         foreach (var item in packageDemands)
+        //         {
+        //             if (item.Type == JTokenType.Object)
+        //             {
+        //                 var element = (JObject)item;
+        //
+        //                 PackageDemand demand = ParseDemand(element);
+        //                 package.AddDemand(demand);
+        //             }
+        //         }
+        //     }
+        // }
+
+        #endregion
+
+        // var varsAuxArray = (JObject)rootNode.Value;
+        // if (varsAuxArray.Property("variables")?.Value != null)
+        // {
+        //     if (varsAuxArray.Property("variables").Value.Type == JTokenType.Array)
+        //     {
+        //         var variablesElements = (JArray)varsAuxArray.Property("variables").Value;
+        //         if (variablesElements != null)
+        //         {
+        //             foreach (JObject variableElement in variablesElements)
+        //             {
+        //                 var variable = ParseVariable(variableElement);
+        //                 package.AddVariable(variable);
+        //             }
+        //         }
+        //     }
+        // }
+
+        DependencyCollection deps = new();
+        DependencyCollection testPackages = new();
+        var dependenciesElements = json.Property("dependencies")?.Children<JObject>().Properties();
+
+        var mandatoryDependencies = ConvertFromJsonToDependencies(json.Property("mandatoryDependencies")?.Children<JObject>().Properties());
+        var conditionalDependencies = ConvertFromJsonToDependencies(json.Property("conditionalDependencies")?.Children<JObject>().Properties());
+
+        if (dependenciesElements != null)
+        {
+            foreach (var dependency in dependenciesElements)
+            {
+                var version = dependency.Value.ToString();
+                var id = dependency.Name;
+                
+
+                bool isDependencyMandatory = mandatoryDependencies.Any(item => item.Id.Equals(id) && item.Version.Equals(version));
+                bool isDependencyConditional = conditionalDependencies.Any(item => item.Id.Equals(id) && item.Version.Equals(version));
+
+                if (!string.IsNullOrWhiteSpace(id) && version != null)
+                {
+                    deps.Add(new Dependency(id, version) { Mandatory = isDependencyMandatory/*, isConditional*/});
+                }
+                // else if (!string.IsNullOrWhiteSpace(id))
+                // {
+                //     package.AddDependency(new PackageDependency(id, isDependencyMandatory, isDependencyConditional));
+                // }
+                else
+                {
+                    throw new CliException("Invalid manifest");
+                }
+            }
+        }
+
+        // var uiAuxArray = (JObject)rootNode.Value;
+        // if (uiAuxArray.Property("ui")?.Value.Type == JTokenType.Array)
+        // {
+        //     var uiElements = (JArray)varsAuxArray.Property("ui").Value;
+        //     if (uiElements != null)
+        //     {
+        //         foreach (JObject uiElement in uiElements)
+        //         {
+        //             var step = (PackageWizardStep)ParseGroup(uiElement, new PackageWizardStep());
+        //             step.Id = uiElement.Property("id")?.Value.ToString();
+        //             package.UserInterface.AddStep(step);
+        //         }
+        //     }
+        // }
+
+        // var metadata = (JObject)rootNode.Value;
+        // var metadataElements = metadata.Property("metadata")?.Children<JObject>().Properties();
+        // var aux = json.ToString();
+        // if (metadataElements != null)
+        // {
+        //     foreach (var element in metadataElements)
+        //     {
+        //         package.AddMetadata(element.Name, element.Value.ToString());
+        //     }
+        // }
+        
+        PackageType cliPackageType = PackageType.Generic;
+        Enum.TryParse(packageType, out cliPackageType);
+        
+        // package.IsRootPackage = keywords.Any(s => s.Equals(JSONPackageKeywordIsRootPackage)) ? true : false;
+        //
+        //
+        // package.PackageId = json.Property("name")?.Value.ToString();
+        // package.TargetDirectory = json.Property("targetDirectory")?.Value.ToString();
+        // package.TargetLayer = json.Property("targetLayer")?.Value.ToString();
+        // package.IsUniqueInstall = bool.Parse(json.Property("isUniqueInstall")?.Value.ToString() ?? "false");
+        // package.IsToForceInstall = bool.Parse(json.Property("isToForceInstall")?.Value.ToString() ?? "false");
+        // if (bool.TryParse(json.Property("forceRerunAfterDatabaseRestore")?.Value.ToString(), out bool forceRerunAfterDatabaseRestore))
+        // {
+        //     package.ForceRerunAfterDatabaseRestore = forceRerunAfterDatabaseRestore;
+        // }
+        // package.Version = Cmf.Core.Versioning.Version.Parse(json.Property("version")?.Value.ToString());
+        // string description = json.Property("description")?.Value.ToString();
+        // package.Description = string.IsNullOrEmpty(description) ? null : description;
+        // package.Name = json.Property("packageName")?.Value.ToString();
+        var cmfPackage = new CmfPackageV1(
+            json.Property("packageName")?.Value.ToString(),
+            json.Property("name")?.Value.ToString(),
+            json.Property("version")?.Value.ToString(),
+            json.Property("description")?.Value?.ToString(),
+            cliPackageType,
+            json.Property("targetDirectory")?.Value.ToString(),
+            json.Property("targetLayer")?.Value.ToString(),
+            bool.Parse(json.Property("isInstallable")?.Value.ToString() ?? "false"),
+            bool.Parse(json.Property("isUniqueInstall")?.Value.ToString() ?? "false"),
+            keywords: string.Join(", ", keywords),
+            true,
+            deps,
+            steps,
+            null,
+            null,
+            waitForIntegrationEntries: false,
+            testPackages
+        );
+
+        return cmfPackage;
+    }
+
+    public static string JSONPackageKeyword = "cmf-deployment-package";
+    public static string JSONPackageKeywordIsInstallable = "cmf-deployment-installable";
+    public static string JSONPackageKeywordIsRootPackage = "cmf-deployment-rootPackage";
+    
+    public string ToJson(bool lowercase = false)
+    {
+        #region assemble steps
+        JArray stepsArray = new JArray();
+
+        var jsonSerializerSettings = new JsonSerializerSettings()
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            PreserveReferencesHandling = PreserveReferencesHandling.None,
+        };
+
+        var jsonSerializer = JsonSerializer.Create(jsonSerializerSettings);
+
+        foreach (var step in package.Steps ?? Array.Empty<Step>().ToList())
+        {
+            var stepObject = JObject.FromObject(step, jsonSerializer);
+            // foreach (var attributeName in step.AttributeNames)
+            // {
+            //     if (stepObject[attributeName] == null)
+            //     {
+            //         stepObject.Add(attributeName, step.GetAttribute(attributeName));
+            //     }
+            // }
+            //
+            // var elementTypes = step.Elements.ToLookup(x => x.Name.LocalName);
+            //
+            // foreach (var element in elementTypes)
+            // {
+            //     stepObject.Add(element.Key, JArray.FromObject(element.ToArray(), jsonSerializer));
+            // }
+
+            stepsArray.Add(stepObject);
+        }
+
+
+        JObject jObject = new JObject();
+        foreach (JObject desc in stepsArray)
+        {
+            var children = desc.Value<JObject>();
+
+            if (children.Properties() != null)
+            {
+                var values = children.Value<JObject>();
+                foreach (var value in values)
+                {
+                    if (value.Value.Type == JTokenType.Array)
+                    {
+                        var entityTypes = value.Value;
+                        var entities = entityTypes.Values<JObject>();
+                        foreach (var entity in entities)
+                        {
+                            var x = entity.Value<JObject>();
+                            var xx = x.Value<JObject>();
+                            foreach (var xxx in xx)
+                            {
+                                var final = xxx.Value.Value<JObject>();
+                                foreach (var finalElement in final)
+                                {
+                                    if (finalElement.Key.StartsWith("@"))
+                                    {
+                                        var newValue = finalElement.Key.Replace("@", "");
+                                        JProperty newProperty = new JProperty(newValue, finalElement.Value);
+                                        jObject.Add(newProperty);
+                                    }
+                                }
+                                final.RemoveAll();
+                                final.Add(jObject.Properties());
+                                jObject.RemoveAll();
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        JObject j = new JObject(new JProperty("steps", stepsArray));
+        #endregion
+
+        #region assemble wizardSteps
+        JArray uiArray = new JArray();
+        JArray variablesArray = new JArray();
+
+        var jsonSerializerSettingsUI = new JsonSerializerSettings()
+        {
+            NullValueHandling = NullValueHandling.Ignore,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            PreserveReferencesHandling = PreserveReferencesHandling.None,
+        };
+
+        // var jsonSerializerUI = JsonSerializer.Create(jsonSerializerSettingsUI);
+        //
+        // foreach (var wizardStep in package.UserInterface.Steps)
+        // {
+        //     var wizardStepObject = JObject.FromObject(wizardStep, jsonSerializerUI);
+        //     uiArray.Add(wizardStepObject);
+        // }
+        //
+        // foreach (var variable in package.Variables)
+        // {
+        //     var variablesObject = JObject.FromObject(variable, jsonSerializerUI);
+        //     variablesArray.Add(variablesObject);
+        // }
+
+        #endregion
+
+        #region assemble dependencies
+        var dependecies = new JObject();
+        var mandatoryDependecies = new JObject();
+        var conditionalDependencies = new JObject();
+
+        foreach (var dependency in package.Dependencies)
+        {
+            var property = new JProperty(dependency.Id, dependency.Version);
+            dependecies.Add(property);
+
+            if (dependency.Mandatory)
+            {
+                mandatoryDependecies.Add(property);
+            }
+            //
+            // if (dependency.IsConditional)
+            // {
+            //     conditionalDependencies.Add(property);
+            // }
+        }
+
+        #endregion
+
+        #region assemble metadata
+        var metadata = new JObject();
+        // foreach (var meta in package.extendedMetadata)
+        // {
+        //     var property = new JProperty(meta.Key, meta.Value);
+        //     metadata.Add(property);
+        // }
+        #endregion
+
+        #region assemble keywords 
+
+        // Add keywords to enable searching for packages on an package registry
+        var keywordsList = new List<string>();
+
+        // Default DF package keyword
+        keywordsList.Add(JSONPackageKeyword);
+
+        if (package.IsInstallable ?? false)
+        {
+            keywordsList.Add(JSONPackageKeywordIsInstallable);
+        }
+        // if (package.IsRootPackage)
+        // {
+        //     keywordsList.Add(JSONPackageKeywordIsRootPackage);
+        // }
+
+        var keywords = JArray.FromObject(keywordsList);
+
+        #endregion
+
+        #region assemble package demands
+
+        JArray demandsArray = new JArray();
+
+        // foreach (var demand in package.Demands)
+        // {
+        //     var demandObject = JObject.FromObject(demand, jsonSerializer);
+        //     foreach (var attributeName in demand.AttributeNames)
+        //     {
+        //         demandObject.Add(attributeName, demand.GetAttribute(attributeName));
+        //     }
+        //
+        //     var elementTypes = demand.Elements.ToLookup(x => x.Name.LocalName);
+        //
+        //     foreach (var element in elementTypes)
+        //     {
+        //         demandObject.Add(element.Key, JArray.FromObject(element.ToArray(), jsonSerializer));
+        //     }
+        //
+        //     demandsArray.Add(demandObject);
+        // }
+
+
+        foreach (JObject desc in demandsArray)
+        {
+            var children = desc.Value<JObject>();
+
+            if (children.Properties() != null)
+            {
+                var values = children.Value<JObject>();
+                foreach (var value in values)
+                {
+                    if (value.Value.Type == JTokenType.Array)
+                    {
+                        var entityTypes = value.Value;
+                        var entities = entityTypes.Values<JObject>();
+                        foreach (var entity in entities)
+                        {
+                            var entityValueAux = entity.Value<JObject>();
+                            var entityValues = entityValueAux.Value<JObject>();
+                            foreach (var entityValue in entityValues)
+                            {
+                                var final = entityValue.Value.Value<JObject>();
+                                foreach (var finalElement in final)
+                                {
+                                    if (finalElement.Key.StartsWith("@"))
+                                    {
+                                        var newValue = finalElement.Key.Replace("@", "");
+                                        JProperty newProperty = new JProperty(newValue, finalElement.Value);
+                                        jObject.Add(newProperty);
+                                    }
+                                }
+                                final.RemoveAll();
+                                final.Add(jObject.Properties());
+                                jObject.RemoveAll();
+                            }
+                        }
+                    }
+                }
+            }
+
+        }
+
+        #endregion
+
+        JObject jsonObject = new JObject(
+                                new JProperty("name", lowercase ? package.PackageId.ToLowerInvariant() : package.PackageId),
+                                new JProperty("description", package.Description),
+                                new JProperty("packageName", package.Name != null ? package.Name : package.PackageId),
+                                new JProperty("version", package.Version?.ToString()),
+                                new JProperty("author", "Critical Manufacturing"),
+                                new JProperty("keywords", keywords),
+                                // new JProperty("isToForceInstall", package.IsToForceInstall),
+                                new JProperty("isUniqueInstall", package.IsUniqueInstall),
+                                // new JProperty("forceRerunAfterDatabaseRestore", package.ForceRerunAfterDatabaseRestore),
+                                new JProperty("deployment", new JObject(
+                                                                // new JProperty("manifestVersion", package.ManifestVersion),
+                                                                new JProperty("isInstallable", package.IsInstallable),
+                                                                new JProperty("packageType", package.PackageType),
+                                                                new JProperty("targetDirectory", !String.IsNullOrEmpty(package.TargetDirectory) ? package.TargetDirectory : ""),
+                                                                // new JProperty("targetLayerDirectory", !String.IsNullOrEmpty(package.TargetLayerDirectory) ? package.TargetLayerDirectory : ""),
+                                                                new JProperty("targetLayer", !String.IsNullOrEmpty(package.TargetLayer) ? package.TargetLayer : ""),
+                                                                // new JProperty("buildDate", package.BuildDate?.ToString()),
+                                                                new JProperty("steps", stepsArray),
+                                                                new JProperty("packageDemands", demandsArray))),
+                                new JProperty("dependencies", dependecies),
+                                new JProperty("mandatoryDependencies", mandatoryDependecies),
+                                new JProperty("conditionalDependencies", conditionalDependencies));
+
+        // if (package.MinSqlCompatibility > 0)
+        // {
+        //     jsonObject["deployment"]["minSqlCompatibility"] = package.MinSqlCompatibility;
+        // }
+
+        if (uiArray.Count > 0)
+        {
+            var uiProperty = new JProperty("ui", uiArray);
+            var jsonFinal = (JObject)jsonObject.Property("deployment").Value;
+            jsonFinal.Add(uiProperty);
+            jsonObject.Property("deployment").Value = jsonFinal;
+
+
+        }
+        if (variablesArray.Count > 0)
+        {
+            var varProperty = new JProperty("variables", variablesArray);
+            var jsonFinal = (JObject)jsonObject.Property("deployment").Value;
+            jsonFinal.Add(varProperty);
+            jsonObject.Property("deployment").Value = jsonFinal;
+        }
+        if (metadata.HasValues)
+        {
+            var metadataProperty = new JProperty("metadata", metadata);
+            var jsonFinal = (JObject)jsonObject.Property("deployment").Value;
+            jsonFinal.Add(metadataProperty);
+            jsonObject.Property("deployment").Value = jsonFinal;
+        }
+
+        return JsonConvert.SerializeObject(jsonObject, Formatting.Indented);
+    }
+    
+    #region utils
+    // private static PackageWizardStepGroup ParseGroup(JObject uiElement, PackageWizardStepGroup result = null)
+    //     {
+    //         result = result ?? new PackageWizardStepGroup();
+    //
+    //         result.Id = uiElement.Property("id")?.Value.ToString();
+    //         result.Order = int.Parse(uiElement.Property("order")?.Value.ToString() ?? "0");
+    //         result.Title = uiElement.Property("title")?.Value.ToString();
+    //         result.Type = uiElement.Property("type")?.Value.ToString();
+    //         result.RequiresValidation = bool.Parse(uiElement.Property("requiresValidation")?.Value.ToString() ?? "false");
+    //         result.IsAdvanced = bool.Parse(uiElement.Property("isAdvanced")?.Value.ToString() ?? "false");
+    //         result.Condition = uiElement.Property("condition")?.Value.ToString();
+    //
+    //         var groupElements = uiElement.Property("groups")?.Value;
+    //         if (groupElements?.Type == JTokenType.Array)
+    //         {
+    //             var groupArray = (JArray)groupElements;
+    //             if (groupArray != null)
+    //             {
+    //                 foreach (JObject groupElement in groupArray)
+    //                 {
+    //                     var group = ParseGroup(groupElement);
+    //                     result.Groups.Add(group);
+    //                 }
+    //             }
+    //         }
+    //
+    //         var variableElements = uiElement.Property("variables")?.Value;
+    //         if (variableElements?.Type == JTokenType.Array)
+    //         {
+    //             var variablesArray = (JArray)variableElements;
+    //             if (variablesArray != null)
+    //             {
+    //                 foreach (JObject variableElement in variablesArray)
+    //                 {
+    //                     var variable = ParseVariable(variableElement);
+    //                     result.Variables.Add(variable);
+    //                 }
+    //             }
+    //         }
+    //
+    //         return result;
+    //     }
+    //
+    //     private static VariableDefinition ParseVariable(XElement element)
+    //     {
+    //         var result = new VariableDefinition
+    //         {
+    //             Name = element.Attribute("name")?.Value,
+    //             ValueType = element.Attribute("valueType")?.Value,
+    //             IsRequired = bool.Parse(element.Attribute("isRequired")?.Value ?? "false"),
+    //             GroupName = element.Attribute("groupName")?.Value,
+    //             Label = element.Attribute("label")?.Value,
+    //             ReadOnly = bool.Parse(element.Attribute("readOnly")?.Value ?? "false"),
+    //             ValidationConfiguration = element.Attribute("validationConfiguration")?.Value,
+    //             Placeholder = element.Attribute("placeholder")?.Value,
+    //             Default = element.Attribute("default")?.Value,
+    //             IsToValidate = bool.Parse(element.Attribute("isToValidate")?.Value ?? "true"),
+    //         };
+    //
+    //         return result;
+    //     }
+    //
+    //     private static VariableDefinition ParseVariable(JObject element)
+    //     {
+    //         var result = new VariableDefinition
+    //         {
+    //             Name = element.Property("name")?.Value.ToString(),
+    //             ValueType = element.Property("valueType")?.Value.ToString(),
+    //             IsRequired = bool.Parse(element.Property("isRequired")?.Value.ToString() ?? "false"),
+    //             GroupName = element.Property("groupName")?.Value.ToString(),
+    //             Label = element.Property("label")?.Value.ToString(),
+    //             ReadOnly = bool.Parse(element.Property("readOnly")?.Value.ToString() ?? "false"),
+    //             ValidationConfiguration = element.Property("validationConfiguration")?.Value.ToString(),
+    //             Placeholder = element.Property("placeholder")?.Value.ToString(),
+    //             Default = element.Property("default")?.Value.ToString(),
+    //             IsToValidate = bool.Parse(element.Property("isToValidate")?.Value.ToString() ?? "true"),
+    //         };
+    //
+    //         return result;
+    //     }
+    //
+    //
+    //     private static PackageStep ParseStep(JObject element)
+    //     {
+    //         var coreAttributes = new string[]
+    //         {
+    //             "type",
+    //             "id",
+    //             "title",
+    //             "onInitialize",
+    //             "onAquire",
+    //             "onValidate",
+    //             "onPrepare",
+    //             "onExecute",
+    //             "onComplete",
+    //             "onCleanup",
+    //             "packageIds",
+    //             "contentPath"
+    //         };
+    //
+    //         PackageStep step;
+    //
+    //         if (element.Property("reevaluatePlan") != null || element.Property("packageId") != null)
+    //         {
+    //             var packageDeploymentStep = new PackageDeploymentStep();
+    //
+    //             packageDeploymentStep.ReevaluatePlan = bool.Parse(element.Property("reevaluatePlan")?.Value.ToString() ?? "false");
+    //             packageDeploymentStep.PackageId = element.Property("packageId")?.Value.ToString();
+    //             step = packageDeploymentStep;
+    //         }
+    //         else
+    //         {
+    //             step = new PackageStep();
+    //         }
+    //
+    //         step.Type = element.Property("type")?.Value.ToString();
+    //         step.Id = element.Property("id")?.Value.ToString();
+    //         step.Title = element.Property("title")?.Value.ToString();
+    //         step.ContentPath = element.Property("contentPath")?.Value.ToString();
+    //         step.OnInitialize = element.Property("onInitialize")?.Value.ToString();
+    //         step.OnAquire = element.Property("onAquire")?.Value.ToString();
+    //         step.OnValidate = element.Property("onValidate")?.Value.ToString();
+    //         step.OnPrepare = element.Property("onPrepare")?.Value.ToString();
+    //         step.OnExecute = element.Property("onExecute")?.Value.ToString();
+    //         step.OnComplete = element.Property("onComplete")?.Value.ToString();
+    //         step.OnCleanup = element.Property("onCleanup")?.Value.ToString();
+    //
+    //         var extraAttributes = element.Properties().Where(a => !coreAttributes.Contains(a.Name)).ToList();
+    //         foreach (var a in extraAttributes)
+    //         {
+    //             step.AddAttribute(a.Name, a.Value.ToString());
+    //         }
+    //
+    //         foreach (var innerElement in element.Children())
+    //         {
+    //             if (innerElement.Type == JTokenType.Object)
+    //             {
+    //                 var elem = (JObject)innerElement;
+    //                 step.AddElement(elem);
+    //             }
+    //         }
+    //
+    //         return step;
+    //     }
+        
+        
+        // /// <summary>
+        // /// Parse PackageDemand elements from a XElement.
+        // /// </summary>
+        // /// <param name="element">Element to be parsed.</param>
+        // /// <returns></returns>
+        // private static PackageDemand ParseDemand(XElement element)
+        // {
+        //     var coreAttributes = new string[]
+        //     {
+        //         "type",
+        //         "id",
+        //         "title",
+        //         "value",
+        //         "onInitialize",
+        //         "onAquire",
+        //         "onValidate",
+        //         "onPrepare",
+        //         "onExecute",
+        //         "onComplete",
+        //         "onCleanup",
+        //         "packageIds"
+        //     };
+        //
+        //     PackageDemand demand = new PackageDemand();
+        //
+        //     demand.Type = (PackageDemandType)Enum.Parse(typeof(PackageDemandType), element.Attribute("type")?.Value);
+        //     demand.Id = element.Attribute("id")?.Value;
+        //     demand.Title = element.Attribute("title")?.Value;
+        //     demand.Value = element.Attribute("value")?.Value;
+        //
+        //     var extraAttributes = element.Attributes().Where(a => !coreAttributes.Contains(a.Name.LocalName)).ToList();
+        //     foreach (var a in extraAttributes)
+        //     {
+        //         demand.AddAttribute(a.Name.LocalName, a.Value);
+        //     }
+        //
+        //     foreach (var innerElement in element.Elements())
+        //     {
+        //         demand.AddElement(innerElement);
+        //     }
+        //
+        //     return demand;
+        // }
+        //
+        // /// <summary>
+        // /// Parse PackageDemand elements from a JObject.
+        // /// </summary>
+        // /// <param name="element">Element to be parsed.</param>
+        // /// <returns></returns>
+        // private static PackageDemand ParseDemand(JObject element)
+        // {
+        //     var coreAttributes = new string[]
+        //     {
+        //         "type",
+        //         "id",
+        //         "title",
+        //         "value",
+        //         "onInitialize",
+        //         "onAquire",
+        //         "onValidate",
+        //         "onPrepare",
+        //         "onExecute",
+        //         "onComplete",
+        //         "onCleanup",
+        //         "packageIds"
+        //     };
+        //
+        //     PackageDemand demand = new PackageDemand();
+        //
+        //     demand.Type = (PackageDemandType)Enum.Parse(typeof(PackageDemandType), element.Property("type")?.Value.ToString());
+        //     demand.Id = element.Property("id")?.Value.ToString();
+        //     demand.Title = element.Property("title")?.Value.ToString();
+        //     demand.Value = element.Property("value")?.Value.ToString();
+        //
+        //     var extraAttributes = element.Properties().Where(a => !coreAttributes.Contains(a.Name)).ToList();
+        //     foreach (var a in extraAttributes)
+        //     {
+        //         demand.AddAttribute(a.Name, a.Value.ToString());
+        //     }
+        //
+        //     foreach (var innerElement in element.Children())
+        //     {
+        //         if (innerElement.Type == JTokenType.Object)
+        //         {
+        //             var elem = (JObject)innerElement;
+        //             demand.AddElement(elem);
+        //         }
+        //     }
+        //
+        //     return demand;
+        // }
+        
+        /// <summary>
+        /// Convert json array of dependecies to list
+        /// </summary>
+        /// <param name="dependenciesJson">Dependecies json</param>
+        /// <returns>Array of dependencies</returns>
+        private static List<Dependency> ConvertFromJsonToDependencies(IJEnumerable<JProperty> dependenciesJson)
+        {
+            List<Dependency> dependencies = new List<Dependency>();
+        
+            if(dependenciesJson != null && dependenciesJson.Count() > 0)
+            {
+                foreach (JProperty item in dependenciesJson)
+                {
+                    var packageAux = item.Value.ToString();
+                    var id = item.Name;
+                    string range;
+                    if (packageAux.Contains("~") || packageAux.Contains("^") || packageAux.Contains("*"))
+                    {
+                        continue;
+                    }
+                    try
+                    {
+                        range = packageAux;
+                    }
+                    catch
+                    {
+                        //explicity silenced
+                        continue;
+                    }
+        
+                    if (!string.IsNullOrWhiteSpace(id) && range != null)
+                    {
+                        dependencies.Add(new Dependency(id, range));
+                    }
+                    else if (!string.IsNullOrWhiteSpace(id))
+                    {
+                        dependencies.Add(new Dependency(id, null));
+                    }
+                    else
+                    {
+                        throw new CliException("Invalid manifest");
+                    }
+                }
+            }
+        
+            return dependencies;
+        }
+    #endregion
+    
+    public static CmfPackageV1 FromSourceManifest(IFileInfo cmfPackageFile)
+    {
+        string fileContent = cmfPackageFile.ReadToString();
+        var cmfPackage = JsonConvert.DeserializeObject<CmfPackageV1>(fileContent);
+        cmfPackage.IsToSetDefaultValues = true;
+        cmfPackage.SourceManifestFile = cmfPackageFile;
+        return cmfPackage;
+    }
+
+    // this does not work if the archive contains an entry with a name with more than 100 characters
+    public static void ConvertZipToTarGz_NET(IFileInfo package)
+    {
+        using Stream zipToOpen = package.OpenRead();
+        using ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read);
+        var tgz = package.FileSystem.FileInfo.New(package.FullName.Replace(".zip", ".tgz"));
+        using var tarWriter = new TarWriter(tgz.OpenWrite());
+        foreach (var zipEntry in zip.Entries)
+        {
+            using var entryStream = zipEntry.Open();
+            // Create the tar entry and copy the content from the zip entry
+            var tarEntry = new V7TarEntry(TarEntryType.V7RegularFile, zipEntry.FullName);
+            // tarEntry.DataStream.Seek(0, SeekOrigin.Begin);
+            tarEntry.DataStream = entryStream;
+            tarWriter.WriteEntry(tarEntry);
+        }
+    }
+
+    public static void ConvertZipToTarGz(IFileInfo zipFile, IFileInfo tarGzFile, bool lowercase = false)
+    {
+        // Open the Zip file
+        using var zipStream = zipFile.OpenRead();
+        using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Read))
+        {
+            // Create a TarGz file stream
+            using var tarStream = tarGzFile.Create();
+            // use SharpCompress for compatibility with Product Deployment packages which are created with the same library
+            using (var tarWriter = new SharpCompress.Writers.Tar.TarWriter(tarStream, new SharpCompress.Writers.Tar.TarWriterOptions(SharpCompress.Common.CompressionType.GZip, finalizeArchiveOnClose: true)))
+            {
+                foreach (ZipArchiveEntry zipEntry in zipArchive.Entries)
+                {
+                    var entryName = zipEntry.FullName;
+                    // Open the entry stream from the Zip archive
+                    using (Stream zipEntryStream = zipEntry.Open())
+                    {
+                        // if we found the XML manifest and do not have a JSON manifest, convert it now
+                        if (entryName == "manifest.xml" && !zipArchive.Entries.Any(ze => ze.FullName == "package.json"))
+                        {
+                            using (StreamReader reader = new StreamReader(zipEntryStream, Encoding.UTF8))
+                            {
+                                var manifest = reader.ReadToEnd();
+                                var pkg = FromXml(XDocument.Parse(manifest));
+                                var ctrlr = new CmfPackageController(pkg, zipFile.FileSystem);
+                                var jsonManifest = ctrlr.ToJson(lowercase);
+                                using (MemoryStream tarEntryStream = new MemoryStream())
+                                {
+                                    using var streamWriter = new StreamWriter(tarEntryStream);
+                                    streamWriter.Write(jsonManifest);
+                                    streamWriter.Flush();
+                                    tarEntryStream.Seek(0, SeekOrigin.Begin);
+                                    tarWriter.Write("package/" + "package.json", tarEntryStream, DateTime.Now);
+                                }
+                                using (MemoryStream tarEntryStream = new MemoryStream())
+                                {
+                                    using var streamWriter = new StreamWriter(tarEntryStream);
+                                    streamWriter.Write(manifest);
+                                    streamWriter.Flush();
+                                    tarEntryStream.Seek(0, SeekOrigin.Begin);
+                                    tarWriter.Write("package/" + "manifest.xml", tarEntryStream, zipEntry.LastWriteTime.DateTime);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            // Add the file content to the Tar archive
+                            using (MemoryStream tarEntryStream = new MemoryStream())
+                            {
+                                zipEntryStream.CopyTo(tarEntryStream);
+                                tarEntryStream.Seek(0, SeekOrigin.Begin);
+
+                                // Create a tar entry in the Tar archive
+                                tarWriter.Write("package/" + entryName, tarEntryStream, zipEntry.LastWriteTime.DateTime);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    public static void ConvertTarGzToZip(IFileInfo package, IFileInfo zipFile)
+    {
+        // byte[] tarGzFileContent = package.FileSystem.File.ReadAllBytes(package.FullName);
+        // using var tarGzStream = new MemoryStream(tarGzFileContent);
+        // using var gzipStream = new GZipStream(tarGzStream, CompressionMode.Decompress);
+        using GZipStream gzipStream = new GZipStream(package.OpenRead(), CompressionMode.Decompress);
+        using TarReader tarReader = new(gzipStream);
+        // Prepare the output ZIP stream
+        using var zipStream = zipFile.OpenWrite();
+        using var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Create, false);
+        while (tarReader.GetNextEntry() is { } entry)
+        {
+            
+            // Check for the "package" folder and strip it out
+            string packageFolderName = "package/";
+
+            // Iterate through the files in the TAR archive
+            // If the file is in the "package" folder, strip it
+            var entryName = entry.Name.StartsWith(packageFolderName) ? entry.Name.Substring(packageFolderName.Length) : entry.Name;
+            
+            // NOTE: we're believing the archive always contains a manifest.xml here, so we are not doing any conversion. 
+            if (entryName == "package.json" && entry.EntryType == TarEntryType.V7RegularFile)
+            {
+                // // Read the content of the file inside the TAR
+                // using var reader = new StreamReader(entry.DataStream,leaveOpen: true);
+                // var jsonManifest = JsonConvert.DeserializeObject<JObject>(reader.ReadToEnd());
+                // var manifest = FromJson(jsonManifest);
+                // var xmlManifestEntry = zipArchive.CreateEntry("manifest.xml");
+                // using (var xmlManifestStream = xmlManifestEntry.Open())
+                // {
+                //     using var streamWriter = new StreamWriter(xmlManifestStream);
+                //     streamWriter.Write(manifest.ToXml());
+                //     streamWriter.Flush();
+                //     if (xmlManifestStream.CanSeek)
+                //     {
+                //         xmlManifestStream.Seek(0, SeekOrigin.Begin);
+                //     }
+                // }
+                //
+                // var jsonManifestEntry = zipArchive.CreateEntry("package.json");
+                // using (var jsonManifestStream = jsonManifestEntry.Open())
+                // {
+                //     using var jsonStreamWriter = new StreamWriter(jsonManifestStream);
+                //     jsonStreamWriter.Write(jsonManifest);
+                //     jsonStreamWriter.Flush();
+                //     if (jsonManifestStream.CanSeek)
+                //     {
+                //         jsonManifestStream.Seek(0, SeekOrigin.Begin);
+                //     }
+                // }
+                continue;
+            }
+            
+            
+            // Add the entry as is if it's not in the "package" folder
+            var zipEntry = zipArchive.CreateEntry(entryName);
+            zipEntry.LastWriteTime = entry.ModificationTime;
+
+            using (var zipEntryStream = zipEntry.Open())
+            {
+                // if (entry.DataStream != null)
+                // {
+                (entry.DataStream ?? MemoryStream.Null).CopyTo(zipEntryStream);    
+                // }
+                // else
+                // {
+                //     var sw = new StreamWriter(zipEntryStream);
+                //     sw.Write(String.Empty);
+                //     sw.Flush();
+                // }
+            }
+        }
+        // zipArchive.Dispose();
+    }
+}

--- a/core/Services/FeaturesService.cs
+++ b/core/Services/FeaturesService.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Cmf.CLI.Core.Services;
+
+public interface IFeaturesService
+{
+    public bool UseRepositoryClients {
+        get;
+    }
+}
+
+public class FeaturesService : IFeaturesService
+{
+    private readonly string envvarprefix;
+    
+    public bool UseRepositoryClients { get; }
+
+    public FeaturesService(string envvarprefix)
+    {
+        this.envvarprefix = envvarprefix;
+        this.UseRepositoryClients = GetFeatureState("use_repository_clients");
+    }
+
+    private bool GetFeatureState(string feature)
+    {
+        var featval = Environment.GetEnvironmentVariable($"{envvarprefix}_feature__{feature}");
+        
+        return (featval?.ToLowerInvariant() == "true" || featval == "1");
+    }
+    
+}

--- a/core/Services/RepositoryLocator.cs
+++ b/core/Services/RepositoryLocator.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Repository;
+using Cmf.CLI.Utilities;
+
+namespace Cmf.CLI.Core.Services;
+
+public class RepositoryLocator : IRepositoryLocator
+{
+    private Dictionary<string, IRepositoryClient> clients = new();
+    public IRepositoryClient GetRepositoryClient(Uri uri, IFileSystem fileSystem)
+    {
+        IRepositoryClient client = null;
+        if (clients.TryGetValue(uri.AbsoluteUri, out var repositoryClient))
+        {
+            client = repositoryClient;
+        }
+        else
+        {
+            switch (uri.Scheme)
+            {
+                case "http":
+                case "https":
+                    client = new NPMRepositoryClient(uri.AbsoluteUri, fileSystem);
+                    break;
+                case "file":
+                    if (uri.Host == "")
+                    {
+                        var file = fileSystem.FileInfo.New(uri.LocalPath);
+                        if (file.Exists && (file.Extension == ".zip" || file.Extension == ".tgz"))
+                        {
+                            client = new ArchiveRepositoryClient(uri.LocalPath, fileSystem);
+                        }
+                        else
+                        {
+                            client = new LocalRepositoryClient(uri.LocalPath, fileSystem);
+                        }
+                    }
+                    else
+                    {
+                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        {
+                            client = new ArchiveRepositoryClient(uri.AbsoluteUri, fileSystem);
+                        }
+                        else
+                        {
+                            client = new CIFSRepositoryClient(uri.AbsoluteUri, fileSystem);
+                        }
+                    }
+                    break;
+            }
+            clients.Add(uri.AbsoluteUri, client);
+        }
+        return client;
+    }
+
+    public IRepositoryClient GetSourceClient(IFileSystem fileSystem)
+    {
+        var root = FileSystemUtilities.GetProjectRoot(fileSystem);
+        return this.GetRepositoryClient(new Uri(root.FullName), fileSystem);
+    }
+
+    public void InitializeClientsForRepositories(IFileSystem fileSystem, IEnumerable<Uri> repoUris)
+    {
+        if (repoUris == null)
+        {
+            // load repositories from repositories.json
+            var repositories = FileSystemUtilities.ReadRepositoriesConfig(fileSystem);
+            repoUris = repositories.Repositories;
+        }
+        var clients = repoUris.Select(r => this.GetRepositoryClient(r,fileSystem)).Where(client => client != null);
+        if (clients.Count() != repoUris.Count())
+        {
+            Log.Debug("Could not obtain clients for all repositories!");
+        }
+    }
+
+    public void InitializeClientsForRepositories(IFileSystem fileSystem)
+    {
+        this.InitializeClientsForRepositories(fileSystem, null);
+    }
+
+    public async Task<CmfPackageV1> FindPackage(string packageId, string packageVersion)
+    {
+        var x = this.clients.Where(pair => !pair.Value.Unreacheable).Select((pair) =>
+        {
+            var client = pair.Value;
+            Log.Debug($"Looking for package {packageId}@{packageVersion} in repo {client.RepositoryRoot} handled by {client.GetType().Name}");
+            return client.Find(packageId, packageVersion);
+        }).ToList();
+        try
+        {
+            // var y = await Task.WhenAll(x);
+            // var z = y.FirstOrDefault(p => p != null);
+            // return z;
+
+            foreach (var taskPkg in x)
+            {
+                try 
+                {
+                    var pkg = await taskPkg;
+                    if (pkg != null)
+                    {
+                        return pkg;
+                    }
+                } 
+                catch (Exception e)
+                {
+                    Log.Debug(e.Message);
+                }
+            }
+            
+            return null;
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+}

--- a/core/Utilities/ExtensionMethods.cs
+++ b/core/Utilities/ExtensionMethods.cs
@@ -211,6 +211,24 @@ namespace Cmf.CLI.Utilities
             var elements = element.Elements().Where(e => e.Name.LocalName.ToString().ToLowerInvariant() == name.ToString().ToLowerInvariant());
             return !elements.Any() ? null : elements.First();
         }
+        
+        /// <summary>
+        /// Gets the children elements with the specified <see cref="XName" />.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <param name="name">The <see cref="XName" /> to match.</param>
+        /// <param name="ignoreCase">If set to <c>true</c> case will be ignored whilst searching for the <see cref="XElement" />.</param>
+        /// <returns>
+        /// A collection of <see cref="XElement" /> that matches the specified <see cref="XName" />, or null.
+        /// </returns>
+        public static IEnumerable<XElement> Elements(this XContainer element, XName name, bool ignoreCase)
+        {
+            if (!ignoreCase)
+                return null;
+
+            var elements = element.Elements().Where(e => e.Name.LocalName.ToString().ToLowerInvariant() == name.ToString().ToLowerInvariant());
+            return !elements.Any() ? null : elements.ToList();
+        }
 
         /// <summary>
         /// Gets the package json file.

--- a/core/Utilities/FileSystemUtilities.cs
+++ b/core/Utilities/FileSystemUtilities.cs
@@ -478,9 +478,10 @@ namespace Cmf.CLI.Utilities
         /// <param name="packageFile"></param>
         /// <param name="filename"></param>
         /// <returns></returns>
-        public static string GetFileContentFromPackage(string packageFile, string filename)
+        public static string GetFileContentFromPackage(string packageFile, string filename, IFileSystem fileSystem = null)
         {
-            using (FileStream zipToOpen = new FileInfo(packageFile).OpenRead())
+            fileSystem ??= new FileSystem();
+            using (var zipToOpen = fileSystem.FileInfo.New(packageFile).OpenRead())
             {
                 using (ZipArchive zip = new(zipToOpen, ZipArchiveMode.Read))
                 {

--- a/core/Utilities/GenericUtilities.cs
+++ b/core/Utilities/GenericUtilities.cs
@@ -214,6 +214,40 @@ namespace Cmf.CLI.Utilities
             }
             return tree;
         }
+        
+        /// <summary>
+        /// Builds a tree representation of a CmfPackage dependency tree
+        /// </summary>
+        /// <param name="pkg">the root package</param>
+        public static Tree BuildTree(CmfPackageV1 pkg)
+        {
+            var tree = new Tree($"{pkg.PackageId}@{pkg.Version} [[{pkg.Client.RepositoryRoot}]]");
+            if (pkg.Dependencies.HasAny())
+            {
+                for (int i = 0; i < pkg.Dependencies.Count; i++)
+                {
+                    Dependency dep = pkg.Dependencies[i];
+
+                    if (!dep.IsMissing)
+                    {
+                        var curNode = tree.AddNode($"{dep.CmfPackageV1.PackageId}@{dep.CmfPackageV1.Version} [[{dep.CmfPackageV1.Client.RepositoryRoot}]]");
+                        BuildTreeNodes(dep.CmfPackageV1, curNode);
+                    }
+                    else if (dep.IsMissing)
+                    {
+                        if (dep.Mandatory)
+                        {
+                            tree.AddNode($"[red]MISSING {dep.Id}@{dep.Version}[/]");
+                        }
+                        else
+                        {
+                            tree.AddNode($"[yellow]MISSING {dep.Id}@{dep.Version}[/]");
+                        }
+                    }
+                }
+            }
+            return tree;
+        }
 
         /// <summary>
         ///
@@ -242,6 +276,34 @@ namespace Cmf.CLI.Utilities
                     {
                         var curNode = node.AddNode($"{dep.CmfPackage.PackageId}@{dep.CmfPackage.Version} [[{dep.CmfPackage.Location.ToString()}]]");
                         BuildTreeNodes(dep.CmfPackage, curNode);
+                    }
+                    else if (dep.IsMissing)
+                    {
+                        if (dep.Mandatory)
+                        {
+                            node.AddNode($"[red]MISSING {dep.Id}@{dep.Version}[/]");
+                        }
+                        else
+                        {
+                            node.AddNode($"[yellow]MISSING {dep.Id}@{dep.Version}[/]");
+                        }
+                    }
+                }
+            }
+        }
+        
+        private static void BuildTreeNodes(CmfPackageV1 pkg, TreeNode node)
+        {
+            if (pkg.Dependencies.HasAny())
+            {
+                for (int i = 0; i < pkg.Dependencies.Count; i++)
+                {
+                    Dependency dep = pkg.Dependencies[i];
+
+                    if (!dep.IsMissing)
+                    {
+                        var curNode = node.AddNode($"{dep.CmfPackageV1.PackageId}@{dep.CmfPackageV1.Version} [[{dep.CmfPackageV1.Client.RepositoryRoot}]]");
+                        BuildTreeNodes(dep.CmfPackageV1, curNode);
                     }
                     else if (dep.IsMissing)
                     {

--- a/core/core.csproj
+++ b/core/core.csproj
@@ -24,6 +24,7 @@
       <PackageReference Include="OpenTelemetry" Version="1.8.1" />
       <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.8.1" />
       <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.8.1" />
+      <PackageReference Include="SharpCompress" Version="0.39.0" />
       <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
       <PackageReference Include="SMBLibrary" Version="1.5.3.5" />
       <PackageReference Include="Spectre.Console" Version="0.49.1" />

--- a/tests/Objects/DFTGZPackageBuilder.cs
+++ b/tests/Objects/DFTGZPackageBuilder.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO;
+using System.IO.Abstractions.TestingHelpers;
+using System.IO.Compression;
+using System.Linq;
+
+namespace tests.Objects
+{
+    public class DFTGZPackageBuilder : IDisposable
+    {
+        /// <summary>
+        ///
+        /// </summary>
+        private readonly MemoryStream memoryStream;
+
+        /// <summary>
+        ///
+        /// </summary>
+        private readonly GZipStream gzArchive;
+        
+        private readonly TarWriter tarArchive;
+
+        /// <summary>
+        ///
+        /// </summary>
+        public DFTGZPackageBuilder()
+        {
+            memoryStream = new MemoryStream();
+            
+            gzArchive = new GZipStream(memoryStream, CompressionLevel.NoCompression);
+            
+            tarArchive = new TarWriter(gzArchive);
+        }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="content"></param>
+        /// <returns></returns>
+        public DFTGZPackageBuilder CreateEntry(string fileName, string content)
+        {
+            var entry = new V7TarEntry(TarEntryType.V7RegularFile, fileName);
+            var entryStream = new MemoryStream();
+            using var streamWriter = new StreamWriter(entryStream);
+            streamWriter.Write(content);
+            streamWriter.Flush();
+            entryStream.Seek(0, SeekOrigin.Begin);
+            entry.DataStream = entryStream;
+            tarArchive.WriteEntry(entry);
+            
+            return this;
+        }
+
+        /// <summary>
+        /// Create DeploymentFramework manifest
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="version"></param>
+        /// <param name="dependencies"></param>
+        /// <returns></returns>
+        public DFTGZPackageBuilder CreateManifest(string id, string version, Dictionary<string, string> dependencies = null, Dictionary<string, string> testPackages = null)
+        {
+            return CreateEntry("manifest.xml",
+                    @$"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <deploymentPackage>
+                          <packageId>{id}</packageId>
+                          <version>{version}</version>
+                          {(dependencies != null
+                                ? "<dependencies>" + string.Join(System.Environment.NewLine, dependencies.Select(d => @$"<dependency id=""{d.Key}"" version=""{d.Value}"" />")) + "</dependencies>"
+                                : string.Empty)}
+                          {(testPackages != null
+                                ? "<testPackages>" + string.Join(System.Environment.NewLine, testPackages.Select(t => @$"<dependency id=""{t.Key}"" version=""{t.Value}"" />")) + "</testPackages>"
+                                : string.Empty)}
+                        </deploymentPackage>");
+        }
+
+        /// <summary>
+        /// ToByteArray
+        /// </summary>
+        /// <returns></returns>
+        public byte[] ToByteArray()
+        {
+            // Flush ZipArchive
+            // gzArchive.Flush();
+            gzArchive.Dispose();
+            byte[] result = memoryStream.ToArray();
+
+            // Dispose MemoryStream
+            memoryStream.Dispose();
+
+            return result;
+        }
+
+        public MockFileData ToMockFileData()
+        {
+            return new MockFileData(ToByteArray());
+        }
+
+        public void Dispose()
+        {
+            tarArchive.Dispose();
+            gzArchive.Dispose();
+            memoryStream.Dispose();
+        }
+    }
+}

--- a/tests/Specs/NPM.cs
+++ b/tests/Specs/NPM.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Objects;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Protected;
+using tests.Mocks;
+using tests.Objects;
+using Xunit;
+using ExecutionContext = Cmf.CLI.Core.Objects.ExecutionContext;
+
+namespace tests.Specs;
+
+public class NPM
+{
+    [Fact]
+    public async Task FindPackage()
+    {
+        var httpClient = new HttpClient();
+
+        var npmClient = new NPMClient(client: httpClient);
+
+        var pkgNames = await npmClient.SearchPackages("@criticalmanufacturing/cli");
+
+        pkgNames.Should().Contain("@criticalmanufacturing/cli");
+    }
+    
+    [Fact]
+    public async Task GetPackageVersion()
+    {
+        var httpClient = new HttpClient();
+
+        var npmClient = new NPMClient(client: httpClient);
+
+        var pkgInfo = await npmClient.FetchPackageInfo("@criticalmanufacturing/cli", "5.1.0");
+
+        pkgInfo.Name.Should().Be("@criticalmanufacturing/cli");
+        pkgInfo.Version.Should().Be("5.1.0");
+        pkgInfo.Dist.Tarball.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task DownloadPackage()
+    {
+        var httpClient = new HttpClient();
+        var npmClient = new NPMClient(client: httpClient);
+        var fs = new MockFileSystem(new Dictionary<string, MockFileData>()
+        {
+            { "/tmp/.gitkeep", new MockFileData("")} // ensure output directory exists
+        });
+        // var fs = new FileSystem();
+        var output = fs.FileInfo.New("/tmp/cli@5.1.0.tgz");
+        var outputFile = await npmClient.DownloadPackage("@criticalmanufacturing/cli", "5.1.0", output);
+        
+        outputFile.Should().NotBeNull();
+        outputFile.Exists.Should().BeTrue();
+        outputFile.Length.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task PublishPackage()
+    {
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IVersionService, MockVersionService>()
+            .BuildServiceProvider();
+
+        var feed = "https://example.repo/";
+        var packageId = "Cmf.Custom.Baseline.TarExample";
+        var version = "3.2.1";
+        
+        // Mock HttpMessageHandler to intercept the HttpClient request
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        
+        // Setup the protected method SendAsync
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.AbsoluteUri == $"{feed}{packageId}".ToLowerInvariant() && req.Content.Headers.GetValues("content-type").FirstOrDefault() == "application/json"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"status\":\"success\"}", Encoding.UTF8, "application/json")
+            });
+
+        // Create HttpClient with the mocked handler
+        var client = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri(feed.TrimEnd('/'))
+        };
+        
+        var npmClient = new NPMClient(baseUrl: feed, client: client);
+
+        
+        var repo = OperatingSystem.IsWindows() ? "\\\\share\\dir" : "/repoDir";
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { $"{repo}/{packageId}.{version}.tgz", new DFTGZPackageBuilder().CreateEntry("package.json",
+                $$"""
+                 {
+                    "dummy, will use manifest.xml first if available"
+                 }
+                 """).CreateEntry("manifest.xml", 
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId}</packageId>
+                                       <version>{version}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToMockFileData() }
+        });
+        var pkg = fileSystem.FileInfo.New($"{repo}/{packageId}.{version}.tgz");
+        pkg.Exists.Should().BeTrue();
+        await npmClient.PublishPackage(pkg);
+        
+        // Verify that the mocked handler was called as expected
+        mockHandler.Protected().Verify(
+            "SendAsync",
+            Times.Once(), // Ensure it was called once
+            ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"{feed}{packageId}".ToLowerInvariant()),
+            ItExpr.IsAny<CancellationToken>()
+        );
+    } 
+}

--- a/tests/Specs/Repositories.cs
+++ b/tests/Specs/Repositories.cs
@@ -1,0 +1,614 @@
+using System;
+using System.Collections.Generic;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
+using System.Linq;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Repository;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Utilities;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Moq.Protected;
+using tests.Mocks;
+using tests.Objects;
+using Xunit;
+using ExecutionContext = Cmf.CLI.Core.Objects.ExecutionContext;
+
+namespace tests.Specs;
+
+public class Repositories
+{
+    [Theory]
+    [InlineData("c:\\folder", typeof(LocalRepositoryClient))]
+    [InlineData("c:\\parent\\folder", typeof(LocalRepositoryClient))]
+    [InlineData("c:\\parent\\folder\\file.zip", typeof(ArchiveRepositoryClient))]
+    [InlineData("c:\\parent\\folder\\file.tgz", typeof(ArchiveRepositoryClient))]
+    [InlineData("\\\\server\\folder", typeof(ICIFSRepositoryClient))]
+    [InlineData("https://feed.example", typeof(NPMRepositoryClient))]
+    public void GetRepositoryClients(string path, Type client)
+    {
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IVersionService, MockVersionService>()
+            .BuildServiceProvider();
+        IRepositoryLocator loc = new RepositoryLocator();
+        var uri = new Uri(MockUnixSupport.Path(path), UriKind.Absolute);
+        var x = loc.GetRepositoryClient(uri, new MockFileSystem(new Dictionary<string, MockFileData>()
+        {
+            { MockUnixSupport.Path("c:\\parent\\folder\\file.zip"), string.Empty },
+            { MockUnixSupport.Path("c:\\parent\\folder\\file.tgz"), string.Empty }
+        }));
+        x.Should().BeAssignableTo(client);
+        if (client == typeof(ICIFSRepositoryClient))
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                x.Should().BeOfType<ArchiveRepositoryClient>();
+            }
+            else
+            {
+                x.Should().BeOfType<CIFSRepositoryClient>();
+            }
+        }
+    }
+    [Fact]
+    public void SingletonClientForUri()
+    {
+        var fs = new MockFileSystem();
+        IRepositoryLocator loc = new RepositoryLocator();
+        var uri = new Uri(MockUnixSupport.Path($"c:\\repo"), UriKind.Absolute);
+        var x = loc.GetRepositoryClient(uri, fs);
+        var y = loc.GetRepositoryClient(uri, fs);
+        
+        x.Should().NotBeNull("Repository client should be created");
+        x.Should().BeSameAs(y, "because the repository client should return the same instance for several requests for the same URI");
+    }
+
+    [Fact]
+    public async Task LocalRepositoryClient_Get()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { MockUnixSupport.Path("c:/test/cmfpackage.json"), new MockFileData(
+@"{
+  ""packageId"": ""Cmf.Custom.Package"",
+  ""version"": ""1.1.0"",
+  ""description"": ""This package deploys Critical Manufacturing Customization"",
+  ""packageType"": ""Root"",
+  ""isInstallable"": true,
+  ""isUniqueInstall"": false,
+  ""dependencies"": [
+    {
+         ""id"": ""Cmf.Custom.Business"",
+        ""version"": ""1.1.0""
+    },
+    {
+        ""id"": ""Cmf.Custom.HTML"",
+        ""version"": ""1.1.0""
+    },
+    {
+        ""id"": ""CriticalManufacturing.DeploymentMetadata"",
+        ""version"": ""8.1.1""
+    }
+  ]
+}") },
+            { MockUnixSupport.Path("c:/test/UI/html/cmfpackage.json"), new MockFileData(
+@"{
+  ""packageId"": ""Cmf.Custom.HTML"",
+  ""version"": ""1.1.0"",
+  ""description"": ""Cmf Custom HTML Package"",
+  ""packageType"": ""Html"",
+  ""isInstallable"": true,
+  ""isUniqueInstall"": false,
+  ""contentToPack"": [
+    {
+      ""source"": ""src/packages/*"",
+      ""target"": ""node_modules"",
+      ""ignoreFiles"": [
+        "".npmignore""
+      ]
+    }
+  ]
+}") },
+            { MockUnixSupport.Path("c:/test/Business/cmfpackage.json"), new MockFileData(
+@"{
+  ""packageId"": ""Cmf.Custom.Business"",
+  ""version"": ""1.1.0"",
+  ""description"": ""Cmf Custom Business Package"",
+  ""packageType"": ""Business"",
+  ""isInstallable"": true,
+  ""isUniqueInstall"": false,
+  ""contentToPack"": [
+    {
+      ""source"": ""Release/*.dll"",
+      ""target"": """"
+    }
+  ]
+}") }
+        });
+
+        ExecutionContext.Initialize(fileSystem);
+        var client = new LocalRepositoryClient(MockUnixSupport.Path("c:/test"), fileSystem);
+        var cmfPackage = await client.Find("Cmf.Custom.Package", "1.1.0");
+        cmfPackage.PackageId.Should().Be("Cmf.Custom.Package");
+        
+        var busPackage = await client.Find("Cmf.Custom.Business", "1.1.0");
+        busPackage.Should().NotBeNull();
+        busPackage.PackageId.Should().Be("Cmf.Custom.Business");
+        
+        var htmlPackage = await client.Find("Cmf.Custom.HTML", "1.1.0");
+        htmlPackage.Should().NotBeNull();
+        htmlPackage.PackageId.Should().Be("Cmf.Custom.HTML");
+    }
+    
+        [Fact]
+    public async Task LocalRepositoryClient_List()
+    {
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { MockUnixSupport.Path("c:/test/cmfpackage.json"), new MockFileData(
+@"{
+  ""packageId"": ""Cmf.Custom.Package"",
+  ""version"": ""1.1.0"",
+  ""description"": ""This package deploys Critical Manufacturing Customization"",
+  ""packageType"": ""Root"",
+  ""isInstallable"": true,
+  ""isUniqueInstall"": false,
+  ""dependencies"": [
+    {
+         ""id"": ""Cmf.Custom.Business"",
+        ""version"": ""1.1.0""
+    },
+    {
+        ""id"": ""Cmf.Custom.HTML"",
+        ""version"": ""1.1.0""
+    },
+    {
+        ""id"": ""CriticalManufacturing.DeploymentMetadata"",
+        ""version"": ""8.1.1""
+    }
+  ]
+}") },
+            { MockUnixSupport.Path("c:/test/UI/html/cmfpackage.json"), new MockFileData(
+@"{
+  ""packageId"": ""Cmf.Custom.HTML"",
+  ""version"": ""1.1.0"",
+  ""description"": ""Cmf Custom HTML Package"",
+  ""packageType"": ""Html"",
+  ""isInstallable"": true,
+  ""isUniqueInstall"": false,
+  ""contentToPack"": [
+    {
+      ""source"": ""src/packages/*"",
+      ""target"": ""node_modules"",
+      ""ignoreFiles"": [
+        "".npmignore""
+      ]
+    }
+  ]
+}") },
+            { MockUnixSupport.Path("c:/test/Business/cmfpackage.json"), new MockFileData(
+@"{
+  ""packageId"": ""Cmf.Custom.Business"",
+  ""version"": ""1.1.0"",
+  ""description"": ""Cmf Custom Business Package"",
+  ""packageType"": ""Business"",
+  ""isInstallable"": true,
+  ""isUniqueInstall"": false,
+  ""contentToPack"": [
+    {
+      ""source"": ""Release/*.dll"",
+      ""target"": """"
+    }
+  ]
+}") }
+        });
+
+        ExecutionContext.Initialize(fileSystem);
+        var client = new LocalRepositoryClient(MockUnixSupport.Path("c:/test"), fileSystem);
+        var cmfPackages = await client.List();
+        cmfPackages.Should().AllBeOfType<CmfPackageV1>();
+        cmfPackages.Should().ContainSingle(package => package.PackageId == "Cmf.Custom.Business");
+        cmfPackages.Should().ContainSingle(package => package.PackageId == "Cmf.Custom.Package");
+        cmfPackages.Should().ContainSingle(package => package.PackageId == "Cmf.Custom.HTML");
+    }
+    
+    [Fact]
+    public async Task WindowsShareRepositoryClient_Get()
+    {
+        var packageId = "CriticalManufacturing.DeploymentMetadata";
+        var version = "8.1.1";
+        var repo = OperatingSystem.IsWindows() ? "\\\\share\\dir" : "/repoDir";
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { $"{repo}/{packageId}.{version}.zip", new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml",
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId}</packageId>
+                                       <version>{version}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToByteArray()) }
+        });
+
+        var client = new ArchiveRepositoryClient(repo, fileSystem);
+        var pkg = await client.Find(packageId, version);
+        pkg.Should().NotBeNull();
+        pkg.Version.Should().Be(version);
+        pkg.PackageId.Should().Be(packageId);
+    }
+    
+    [Fact]
+    public async Task WindowsShareRepositoryClient_List()
+    {
+        var packageId = "CriticalManufacturing.DeploymentMetadata";
+        var version = "8.1.1";
+        var packageId2 = "Cmf.Custom.Baseline.Package";
+        var version2 = "1.2.3";
+        var packageId3 = "Cmf.Custom.Baseline.Metadata";
+        var version3 = "1.2.2";
+        var packageId4 = "Cmf.Custom.Baseline.Excluded";
+        var version4 = "9.9.9";
+        var packageId5 = "Cmf.Custom.Baseline.TarExample";
+        var version5 = "3.2.1";
+        var repo = OperatingSystem.IsWindows() ? "\\\\share\\dir" : "/repoDir";
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { $"{repo}/{packageId}.{version}.zip", new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml",
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId}</packageId>
+                                       <version>{version}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToByteArray()) },
+            { $"{repo}/{packageId2}.{version2}.zip", new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml",
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId2}</packageId>
+                                       <version>{version2}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToByteArray()) },
+            { $"{repo}/{packageId3}.{version3}.zip", new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml",
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId3}</packageId>
+                                       <version>{version3}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToByteArray()) },
+            { $"{repo}/inner/{packageId4}.{version4}.zip", new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml",
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId4}</packageId>
+                                       <version>{version4}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToByteArray()) },
+            { $"{repo}/{packageId5}.{version5}.tar.gz", new DFTGZPackageBuilder().CreateEntry("package.json",
+                $$"""
+                 {
+                    "name": "{{packageId5}}",
+                    "version": "{{version5}}",
+                     "dependencies": {
+                        "Cmf.Database": "[11.1.0, 11.1.0]"
+                     }
+                 }
+                 """).CreateEntry("manifest.xml", 
+                $"""
+                 <?xml version="1.0" encoding="utf-8"?>
+                                     <deploymentPackage>
+                                       <packageId>{packageId5}</packageId>
+                                       <version>{version5}</version>
+                                       <dependencies>
+                                         <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                       </dependencies>
+                                     </deploymentPackage>
+                 """).ToMockFileData() }
+        });
+
+        var client = new ArchiveRepositoryClient(repo, fileSystem);
+        var cmfPackages = await client.List();
+        cmfPackages.Should().NotBeNull();
+        cmfPackages.Should().AllBeOfType<CmfPackageV1>();
+        cmfPackages.Should().ContainSingle(package => package.PackageId == packageId);
+        cmfPackages.Should().ContainSingle(package => package.PackageId == packageId2);
+        cmfPackages.Should().ContainSingle(package => package.PackageId == packageId3);
+        cmfPackages.Should().NotContain(package => package.PackageId == packageId4);
+    }
+
+    [Fact]
+    public async Task NPMRepositoryClient_Publish()
+    {
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IVersionService, MockVersionService>()
+            .BuildServiceProvider();
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+                { MockUnixSupport.Path("c:/pkgs/Cmf.Custom.Data.1.0.0.zip"), new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml",
+                    $"""
+                    <?xml version="1.0" encoding="utf-8"?>
+                         <deploymentPackage>
+                           <packageId>Cmf.Custom.Data</packageId>
+                           <version>1.0.0</version>
+                           <steps>
+                             <step type="DeployFiles" contentPath="*.example" />
+                           </steps>
+                         </deploymentPackage>
+                    """).CreateEntry("payload.example", "this is an example payload")
+                    .ToByteArray()) }
+        });
+
+        var localRepoClient = new ArchiveRepositoryClient(MockUnixSupport.Path("c:/pkgs"), fileSystem);
+        var pkg = await localRepoClient.Find("Cmf.Custom.Data", "1.0.0");
+        var ctlr = new CmfPackageController(pkg, fileSystem);
+        var feed = "https://example.repo/";
+        // Mock HttpMessageHandler to intercept the HttpClient request
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        
+        // Setup the protected method SendAsync
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.AbsoluteUri == $"{feed}Cmf.Custom.Data".ToLowerInvariant() && req.Content.Headers.GetValues("content-type").FirstOrDefault() == "application/json"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"status\":\"success\"}", Encoding.UTF8, "application/json")
+            });
+
+        // Create HttpClient with the mocked handler
+        var httpClient = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri(feed.TrimEnd('/'))
+        };
+        var npmClient = new NPMClient(baseUrl: feed, client: httpClient);
+        var client = new NPMRepositoryClient(feed, fileSystem, npmClient);
+        await client.Put(ctlr.CmfPackage);
+    }
+    
+    [Fact]
+    public async Task NPMRepositoryClient_Get()
+    {
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IVersionService, MockVersionService>()
+            .BuildServiceProvider();
+        var packageId = "Cmf.Custom.Data";
+        var version = "1.0.0";
+        
+        var feed = "https://example.repo/";
+        // Mock HttpMessageHandler to intercept the HttpClient request
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        
+        // Setup the protected method SendAsync
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.AbsoluteUri == $"{feed}Cmf.Custom.Data".ToLowerInvariant()),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(
+                    """
+                    {
+                    "_id": "cmf.custom.data",
+                    "name": "cmf.custom.data",
+                    "dist-tags": {
+                      "latest": "1.0.0"
+                    },
+                    "versions": {
+                      "1.0.0": {
+                        "name": "cmf.custom.data",
+                        "version": "1.0.0",
+                        "author": "Critical Manufacturing",
+                        "keywords": [
+                          "cmf-deployment-package"
+                        ],
+                        "isUniqueInstall": false,
+                        "deployment": {
+                          "isInstallable": false,
+                          "packageType": 0,
+                          "targetDirectory": "",
+                          "targetLayer": "",
+                          "steps": [
+                            {
+                              "order": 0,
+                              "type": "DeployFiles",
+                              "messageType": "ImportObject",
+                              "contentPath": "*.example"
+                            }
+                          ],
+                          "packageDemands": []
+                        },
+                        "dependencies": {},
+                        "mandatoryDependencies": {},
+                        "conditionalDependencies": {},
+                        "_id": "cmf.custom.data@1.0.0",
+                        "dist": {
+                          "shasum": "1234",
+                          "tarball": "https://example.repo/cmf.custom.data/-/cmf.custom.data-1.0.0.tgz",
+                          "fileCount": 5,
+                          "integrity": "sha512-dummy",
+                          "signatures": [
+                            {
+                              "sig": "dummy",
+                              "keyid": "SHA256:dummy"
+                            }
+                          ],
+                          "unpackedSize": 10345
+                        },
+                        "_cliVersion": "9.9.9",
+                        "description": "Cmf Custom Data",
+                        "directories": {}
+                        },
+                    }}
+                    """
+                    , Encoding.UTF8, "application/json")
+            });
+
+        // Create HttpClient with the mocked handler
+        var httpClient = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri(feed.TrimEnd('/'))
+        };
+        var npmClient = new NPMClient(baseUrl: feed, client: httpClient);
+       
+        var client = new NPMRepositoryClient(feed, new MockFileSystem(), npmClient);
+        var pkg = await client.Find(packageId, version);
+        pkg.Should().NotBeNull();
+        pkg.Version.Should().Be(version);
+        pkg.PackageId.Should().Be(packageId.ToLowerInvariant()); // NPM package names are always lowercase
+    }
+    
+    [Fact]
+    public async Task NPMRepositoryClient_List()
+    {
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IVersionService, MockVersionService>()
+            .BuildServiceProvider();
+        var feed = "https://example.repo/";
+        // Mock HttpMessageHandler to intercept the HttpClient request
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        
+        // Setup the protected method SendAsync
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.AbsoluteUri == $"{feed}-/v1/search?text=keywords:cmf-deployment-package".ToLowerInvariant()),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent("""
+                                            {
+                                              "objects": [
+                                                {
+                                                  "score": {
+                                                    "detail": {
+                                                      "quality": 0.0,
+                                                      "popularity": 0.0,
+                                                      "maintenance": 0.0
+                                                    },
+                                                    "final": 0.0
+                                                  },
+                                                  "searchScore": 1.0,
+                                                  "package": {
+                                                    "name": "cmf.custom.data",
+                                                    "version": "1.0.0",
+                                                    "description": null,
+                                                    "keywords": [
+                                                      "cmf-deployment-package"
+                                                    ],
+                                                    "date": "1970-01-01T12:00:00.000Z",
+                                                    "links": {
+                                                      "npm": null,
+                                                      "homepage": null,
+                                                      "repository": null,
+                                                      "bugs": null
+                                                    },
+                                                    "publisher": {
+                                                      "username": "Critical Manufacturing",
+                                                      "email": null
+                                                    },
+                                                    "maintainers": [
+                                                      {
+                                                        "username": "Critical Manufacturing",
+                                                        "email": null
+                                                      }
+                                                    ]
+                                                  }
+                                                }
+                                              ],
+                                              "total": 1,
+                                              "time": "Sun Jan 1 1970 12:00:00 GMT+0000 (UTC)"
+                                            }
+                                            """, Encoding.UTF8, "application/json")
+            });
+
+        // Create HttpClient with the mocked handler
+        var httpClient = new HttpClient(mockHandler.Object)
+        {
+            BaseAddress = new Uri(feed.TrimEnd('/'))
+        };
+        var npmClient = new NPMClient(baseUrl: feed, client: httpClient);
+       
+        var client = new NPMRepositoryClient(feed, new MockFileSystem(), npmClient);
+        var pkgs = await client.List();
+        pkgs.Count.Should().Be(0);
+
+    }
+
+    // [Fact]
+    // public void ConvertZip()
+    // {
+    //     var fs = new FileSystem();
+    //     var zipFile = fs.DirectoryInfo.New(@"x:\repo\Cmf.Custom.IoT.Data")
+    //         .GetFiles("Cmf.Common.IoT.Utilities.IoTPackages.0.1.0.zip").FirstOrDefault();
+    //     var tarGzFile = zipFile.FileSystem.FileInfo.New(zipFile.FullName.Replace(".zip", ".tgz"));
+    //     CmfPackageController.ConvertZipToTarGz(zipFile, tarGzFile, true);
+    // }
+    
+    // [Fact]
+    // public void ConvertTGz()
+    // {
+    //     var fs = new FileSystem();
+    //     var tarGzFile = fs.DirectoryInfo.New(@"x:\repo\Cmf.Custom.IoT.Data")
+    //         .GetFiles("Cmf.Common.IoT.Utilities.IoTPackages.0.1.0.tgz").FirstOrDefault();
+    //     var zipFile = tarGzFile.FileSystem.FileInfo.New(tarGzFile.FullName.Replace(".tgz", ".zip"));
+    //     CmfPackageController.ConvertTarGzToZip(tarGzFile, zipFile);
+    // }
+    
+    [Fact]
+    public void Idempotent_Manifest_Conversion()
+    {
+        var packageId = "CriticalManufacturing.DeploymentMetadata";
+        var version = "8.1.1";
+        var repo = OperatingSystem.IsWindows() ? "\\\\share\\dir" : "/repoDir";
+        var manifestContent = $"""
+                               <?xml version="1.0" encoding="utf-8"?>
+                                                   <deploymentPackage>
+                                                     <packageId>{packageId}</packageId>
+                                                     <version>{version}</version>
+                                                     <dependencies>
+                                                       <dependency id="Inner.Package" version="0.0.1" mandatory="true" isMissing="true" />
+                                                     </dependencies>
+                                                   </deploymentPackage>
+                               """;
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { $"{repo}/{packageId}.{version}.zip", new MockFileData(new DFPackageBuilder().CreateEntry("manifest.xml", manifestContent).ToByteArray()) }
+        });
+
+        CmfPackageController.ConvertZipToTarGz(fileSystem.FileInfo.New($"{repo}/{packageId}.{version}.zip"), fileSystem.FileInfo.New($"{repo}/{packageId}.{version}.tgz"));
+        CmfPackageController.ConvertTarGzToZip(fileSystem.FileInfo.New($"{repo}/{packageId}.{version}.tgz"), fileSystem.FileInfo.New($"{repo}/{packageId}.{version}.zip"));
+        // var ctrlr = new CmfPackageController(fileSystem.FileInfo.New($"{repo}/{packageId}.{version}.zip"));
+        string newManifestContent = FileSystemUtilities.GetFileContentFromPackage($"{repo}/{packageId}.{version}.zip", "manifest.xml", fileSystem);
+        newManifestContent.Should().Be(manifestContent);
+    }
+}


### PR DESCRIPTION
This PR adds the concept of repository clients to the CLI Core, which allows the CLI and its Core-based plugins to abstract away the repository implementations, allowing us to support an ever-growing roster of repository clients. The initial implementation includes;
- the Local source repository
- Archive repository, basically a folder approach that also works for shares if on Windows
- CIFS repository, a cross platform implementation of CIFS support, less flexible than the Archive repository yet
- NPM repository, allowing us to use NPM as a backing store for our DF packages

Notice that this implementation is not fully disseminated into the CLI yet, and focus on 3 areas:
- Loading package dependencies (e,g, the `ls` command)
- restoring dependencies (via the `build` and `restore` commands)
- publishing packages - this is a new command that allows publishing any packed package into a repository

This PR also includes a feature flag implementation, as these new commands and features are currently blocked by a feature flag (set the `cmf_cli_feature__use_repository_clients` environment variable).