### PR TITLE
feat: Support GUI localization in customization projects

### DIFF
--- a/cmf-cli/Commands/build/html/ExtractI18nCommand.cs
+++ b/cmf-cli/Commands/build/html/ExtractI18nCommand.cs
@@ -1,0 +1,99 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Abstractions;
+using Cmf.CLI.Builders;
+using Cmf.CLI.Constants;
+using Cmf.CLI.Core;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.Xml.Linq;
+using System.Linq;
+
+namespace Cmf.CLI.Commands.html;
+
+/// <summary>
+/// Extract HTML i18n messages
+/// </summary>
+[CmfCommand("extract-i18n", Id = "build_html_extract_i18n", ParentId = "build_html")]
+public class ExtractI18nCommand : BaseCommand
+{
+    public override void Configure(Command cmd)
+    {
+        var packageRoot = FileSystemUtilities.GetPackageRoot(this.fileSystem);
+        var packagePath = ".";
+        if (packageRoot != null)
+        {
+            packagePath = this.fileSystem.Path.GetRelativePath(this.fileSystem.Directory.GetCurrentDirectory(), packageRoot.FullName);
+        }
+        var arg = new Argument<IDirectoryInfo>(
+            name: "packagePath",
+            parse: (argResult) => Parse<IDirectoryInfo>(argResult, packagePath),
+            isDefault: true)
+        {
+            Description = "Package Path"
+        };
+
+        cmd.AddArgument(arg);
+        cmd.Handler = CommandHandler.Create(this.Execute);
+    }
+
+    /// <summary>
+    /// Executes this instance.
+    /// </summary>
+    public void Execute(IDirectoryInfo packagePath)
+    {
+        var cmfPackageFile = this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(packagePath.FullName, CliConstants.CmfPackageFileName));
+        if (!cmfPackageFile.Exists)
+        {
+            throw new CliException($"Cannot find a package at {cmfPackageFile.FullName}");
+        }
+
+        var cmfPackage = CmfPackage.Load(cmfPackageFile, true, this.fileSystem);
+
+        var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
+        var packageDirectory = cmfPackage.GetFileInfo().Directory;
+        Debug.Assert(projectRoot != null, "Invalid repository! Run this command inside a project repository.");
+
+        new NgCommand()
+        {
+            DisplayName = $"ng extract-i18n",
+            Command = "extract-i18n",
+            Args = new[] { "--format", "xlf" },
+            WorkingDirectory = packageDirectory
+        }.Exec()?.Wait();
+
+        RemoveInheritedMessages(packageDirectory);
+    }
+
+    /// <summary>
+    /// The extract-i18n command scans the whole bundle, meaning that it generates a file containing messages from the project, but also
+    /// from its dependencies. To make it easier to maintain the translations, this command will erase the messages that do not belong to this project.
+    /// </summary>
+    private void RemoveInheritedMessages(IDirectoryInfo packageDirectory)
+    {
+        Log.Debug("Removing inherited messages from messages.xlf");
+
+        string messagesFilePath = this.fileSystem.Path.Join(packageDirectory.FullName, "messages.xlf");
+
+        if (!this.fileSystem.Path.Exists(messagesFilePath))
+        {
+            throw new CliException($"Cannot find the messages.xlf file on {messagesFilePath}");
+        }
+
+        var messagesXlf = XDocument.Load(messagesFilePath);
+        var transUnits = messagesXlf.Root?.Descendants(messagesXlf.Root.Name.Namespace + "trans-unit");
+
+        // Erase elements that reference files that do not exist in this project
+        transUnits.Where(unit =>
+        {
+            string sourceFile = unit.Descendants(messagesXlf.Root.Name.Namespace + "context").FirstOrDefault(element => element.Attribute("context-type").Value.Equals("sourcefile"))?.Value;
+
+            return !this.fileSystem.Path.Exists(this.fileSystem.Path.Join(packageDirectory.FullName, sourceFile));
+        }).Remove();
+
+        messagesXlf.Save(messagesFilePath);
+    }
+}

--- a/cmf-cli/Commands/build/html/ExtractI18nCommand.cs
+++ b/cmf-cli/Commands/build/html/ExtractI18nCommand.cs
@@ -11,6 +11,7 @@ using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 using System.Xml.Linq;
 using System.Linq;
+using System;
 
 namespace Cmf.CLI.Commands.html;
 
@@ -20,6 +21,11 @@ namespace Cmf.CLI.Commands.html;
 [CmfCommand("extract-i18n", Id = "build_html_extract-i18n", ParentId = "build_html")]
 public class ExtractI18nCommand : BaseCommand
 {
+    /// <summary>
+    /// The minimum MES Version that supports this command
+    /// </summary>
+    private readonly Version MIN_MES_VERSION = new Version(11, 2, 0);
+
     public override void Configure(Command cmd)
     {
         var packageRoot = FileSystemUtilities.GetPackageRoot(this.fileSystem);
@@ -45,6 +51,11 @@ public class ExtractI18nCommand : BaseCommand
     /// </summary>
     public void Execute(IDirectoryInfo packagePath)
     {
+        if (ExecutionContext.Instance.ProjectConfig.MESVersion < MIN_MES_VERSION)
+        {
+            throw new CliException(string.Format(CliMessages.InvalidVersionForCommand, MIN_MES_VERSION.ToString()));
+        }
+
         var cmfPackageFile = this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(packagePath.FullName, CliConstants.CmfPackageFileName));
         if (!cmfPackageFile.Exists)
         {

--- a/cmf-cli/Commands/build/html/ExtractI18nCommand.cs
+++ b/cmf-cli/Commands/build/html/ExtractI18nCommand.cs
@@ -17,7 +17,7 @@ namespace Cmf.CLI.Commands.html;
 /// <summary>
 /// Extract HTML i18n messages
 /// </summary>
-[CmfCommand("extract-i18n", Id = "build_html_extract_i18n", ParentId = "build_html")]
+[CmfCommand("extract-i18n", Id = "build_html_extract-i18n", ParentId = "build_html")]
 public class ExtractI18nCommand : BaseCommand
 {
     public override void Configure(Command cmd)

--- a/cmf-cli/Commands/build/html/LocalizeCommand.cs
+++ b/cmf-cli/Commands/build/html/LocalizeCommand.cs
@@ -8,6 +8,7 @@ using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 using System.Linq;
+using System;
 
 namespace Cmf.CLI.Commands.html;
 
@@ -17,6 +18,11 @@ namespace Cmf.CLI.Commands.html;
 [CmfCommand("localize", Id = "build_html_localize", ParentId = "build_html")]
 public class LocalizeCommand : BaseCommand
 {
+    /// <summary>
+    /// The minimum MES Version that supports this command
+    /// </summary>
+    private readonly Version MIN_MES_VERSION = new Version(11, 2, 0);
+
     public override void Configure(Command cmd)
     {
         var packageRoot = FileSystemUtilities.GetPackageRoot(this.fileSystem);
@@ -42,6 +48,11 @@ public class LocalizeCommand : BaseCommand
     /// </summary>
     public void Execute(IDirectoryInfo packagePath)
     {
+        if (ExecutionContext.Instance.ProjectConfig.MESVersion < MIN_MES_VERSION)
+        {
+            throw new CliException(string.Format(CliMessages.InvalidVersionForCommand, MIN_MES_VERSION.ToString()));
+        }
+
         var cmfPackageFile = this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(packagePath.FullName, CliConstants.CmfPackageFileName));
         if (!cmfPackageFile.Exists)
         {

--- a/cmf-cli/Commands/build/html/LocalizeCommand.cs
+++ b/cmf-cli/Commands/build/html/LocalizeCommand.cs
@@ -1,0 +1,88 @@
+using System.CommandLine;
+using System.CommandLine.NamingConventionBinder;
+using System.Diagnostics;
+using System.IO.Abstractions;
+using Cmf.CLI.Builders;
+using Cmf.CLI.Constants;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Utilities;
+using System.Linq;
+
+namespace Cmf.CLI.Commands.html;
+
+/// <summary>
+/// Generates messages files in .json format containing UI localized messages
+/// </summary>
+[CmfCommand("localize", Id = "build_html_localize", ParentId = "build_html")]
+public class LocalizeCommand : BaseCommand
+{
+    public override void Configure(Command cmd)
+    {
+        var packageRoot = FileSystemUtilities.GetPackageRoot(this.fileSystem);
+        var packagePath = ".";
+        if (packageRoot != null)
+        {
+            packagePath = this.fileSystem.Path.GetRelativePath(this.fileSystem.Directory.GetCurrentDirectory(), packageRoot.FullName);
+        }
+        var arg = new Argument<IDirectoryInfo>(
+            name: "packagePath",
+            parse: (argResult) => Parse<IDirectoryInfo>(argResult, packagePath),
+            isDefault: true)
+        {
+            Description = "Package Path"
+        };
+
+        cmd.AddArgument(arg);
+        cmd.Handler = CommandHandler.Create(this.Execute);
+    }
+
+    /// <summary>
+    /// Executes this instance.
+    /// </summary>
+    public void Execute(IDirectoryInfo packagePath)
+    {
+        var cmfPackageFile = this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(packagePath.FullName, CliConstants.CmfPackageFileName));
+        if (!cmfPackageFile.Exists)
+        {
+            throw new CliException($"Cannot find a package at {cmfPackageFile.FullName}");
+        }
+
+        var cmfPackage = CmfPackage.Load(cmfPackageFile, true, this.fileSystem);
+
+        var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
+        var packageDirectory = cmfPackage.GetFileInfo().Directory;
+        Debug.Assert(projectRoot != null, "Invalid repository! Run this command inside a project repository.");
+
+        if (cmfPackage.BaseLocalizationFiles?.Any() != true)
+        {
+            throw new CliException($"Please define the baseLocalizationFiles setting.");
+        }
+
+        foreach (string localizationFolder in cmfPackage.BaseLocalizationFiles)
+        {
+            if (!this.fileSystem.Path.Exists(localizationFolder))
+            {
+                throw new CliException($"Could not find {localizationFolder}.");
+            }
+        }
+
+        new NgCommand()
+        {
+            DisplayName = $"ng extract-i18n",
+            Command = "extract-i18n",
+            Args = new[] { "--format", "json", "--output-path", "./src/assets/i18n" },
+            WorkingDirectory = packageDirectory
+        }.Exec()?.Wait();
+
+        // localize
+        new NPXCommand()
+        {
+            DisplayName = $"ui-i18n localize",
+            Command = "ui-i18n",
+            Args = new[] { "localize", "./src/assets/i18n/messages.json", "--destination", "./src/assets/i18n", "--translations", string.Join(" ", cmfPackage.BaseLocalizationFiles), "translations" },
+            WorkingDirectory = packageDirectory,
+            ForceColorOutput = false
+        }.Exec()?.Wait();
+    }
+}

--- a/core/Objects/CmfPackage.cs
+++ b/core/Objects/CmfPackage.cs
@@ -280,6 +280,12 @@ namespace Cmf.CLI.Core.Objects
         public string DependenciesDirectory { get; set; }
 
         /// <summary>
+        /// A list of folders containing .xlf files that include messages used by this project.
+        /// </summary>
+        [JsonProperty(Order = 24)]
+        public List<string> BaseLocalizationFiles { get; private set; }
+
+        /// <summary>
         /// Loaded SharedFolder when loading from cifs
         /// </summary>
         [JsonIgnore]
@@ -313,7 +319,7 @@ namespace Cmf.CLI.Core.Objects
         public CmfPackage(string name, string packageId, string version, string description, PackageType packageType,
                           string targetDirectory, string targetLayer, bool? isInstallable, bool? isUniqueInstall, string keywords,
                           bool? isToSetDefaultSteps, DependencyCollection dependencies, List<Step> steps,
-                          List<ContentToPack> contentToPack, List<string> xmlInjection, bool? waitForIntegrationEntries, DependencyCollection testPackages = null) : this()
+                          List<ContentToPack> contentToPack, List<string> xmlInjection, bool? waitForIntegrationEntries, List<string> baseLocalizationFiles, DependencyCollection testPackages = null) : this()
         {
             Name = name;
             PackageId = packageId ?? throw new ArgumentNullException(nameof(packageId));
@@ -332,6 +338,7 @@ namespace Cmf.CLI.Core.Objects
             XmlInjection = xmlInjection;
             WaitForIntegrationEntries = waitForIntegrationEntries;
             TestPackages = testPackages;
+            BaseLocalizationFiles = baseLocalizationFiles;
         }
 
         /// <summary>
@@ -429,6 +436,7 @@ namespace Cmf.CLI.Core.Objects
                    EqualityComparer<DependencyCollection>.Default.Equals(Dependencies, other.Dependencies) &&
                    EqualityComparer<List<Step>>.Default.Equals(Steps, other.Steps) &&
                    EqualityComparer<List<ContentToPack>>.Default.Equals(ContentToPack, other.ContentToPack) &&
+                   BaseLocalizationFiles.Equals(other.BaseLocalizationFiles) &&
                    EqualityComparer<IFileInfo>.Default.Equals(GetFileInfo(), other.GetFileInfo());
         }
 
@@ -778,7 +786,7 @@ namespace Cmf.CLI.Core.Objects
                 {
                     var file = share.GetFile(_dependencyFileName);
                     if(file != null)
-                    {                   
+                    {
                         if(fromManifest)
                         {
                             using (ZipArchive zip = new(file.Item2, ZipArchiveMode.Read))
@@ -790,7 +798,7 @@ namespace Cmf.CLI.Core.Objects
                                     using var reader = new StreamReader(stream);
                                     cmfPackage = FromManifest(reader.ReadToEnd(), setDefaultValues: true);
                                     if (cmfPackage != null)
-                                    {   
+                                    {
                                         cmfPackage.Uri = file.Item1;
                                         cmfPackage.SharedFolder = share;
                                         break;
@@ -808,7 +816,7 @@ namespace Cmf.CLI.Core.Objects
                 }
             }
 
-            return cmfPackage;          
+            return cmfPackage;
         }
 
         /// <summary>
@@ -881,6 +889,7 @@ namespace Cmf.CLI.Core.Objects
                 null,
                 null,
                 waitForIntegrationEntries: false,
+                null,
                 testPackages
                 );
 


### PR DESCRIPTION
This PR adds 2 commands to support the solution described in the loop to support GUI localization in custumization projects.

The first command is named `extract-i18n`:
* It calls the `ng extract-i18n` command which will generate a `.xlf` file containing all the localized messages (product + project)
* It has a simple post-processing step which removes the product messages. The goal is to have a file containing only messages from the project so that it is easier to have it in version control.
* The project is then expected to maintain their own translation files, also in `.xlf` format.

The second command is named `localize`:
* It calls the `ng extract-i18n` command again, which will generate a `json` file containing all the localized messages (product + project)
* Then, it calls the `ui-i18n localize` command, which will merge the translation files from the project with the translation files from the base product, or any other intermediate projects that it extends. Finally it converts them to `.json`, which is the format that the GUI reads when it is bootstrapping.
