### PR TITLE
Implement put method on CIFSRepositoryClient

### DIFF
--- a/cmf-cli/Commands/publish/PublishCommand.cs
+++ b/cmf-cli/Commands/publish/PublishCommand.cs
@@ -28,7 +28,18 @@ public class PublishCommand : BaseCommand
         
         cmd.AddOption(new Option<Uri>(
             aliases: new string[] { "--repository" },
-            description: "Repository the package should be published to"));
+            description: "Repository the package should be published to",
+            parseArgument: result =>
+            {
+                var value = result.Tokens[0].Value;
+                if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+                {
+                    result.ErrorMessage = "The repository must be a valid absolute URI.";
+                    return null;
+                }
+                return uri;
+            }
+        ));
 
         cmd.IsHidden =
             !(ExecutionContext.ServiceProvider?.GetService<IFeaturesService>()?.UseRepositoryClients ?? false);

--- a/core/Repository/Credentials/CIFSRepositoryCredentials.cs
+++ b/core/Repository/Credentials/CIFSRepositoryCredentials.cs
@@ -19,7 +19,7 @@ namespace Cmf.CLI.Core.Repository.Credentials
 
         public PropertyRequirement KeyPropertyRequirement => PropertyRequirement.Ignored;
 
-        public PropertyRequirement DomainPropertyRequirement => PropertyRequirement.Mandatory;
+        public PropertyRequirement DomainPropertyRequirement => PropertyRequirement.Optional;
 
         public void ValidateCredentials(IList<ICredential> credentials)
         { }

--- a/tests/Specs/Publish.cs
+++ b/tests/Specs/Publish.cs
@@ -1,0 +1,45 @@
+using System;
+using Xunit;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.IO.Abstractions;
+using Moq;
+using Cmf.CLI.Commands;
+using System.CommandLine.NamingConventionBinder;
+using System.CommandLine.IO;
+
+namespace tests.Specs;
+
+public class Publish
+{
+    [Theory]
+    [InlineData("testhost", @"\\testhost\files\share")]
+    [InlineData("example.com", "https://example.com/repository")]
+    [InlineData("", "/local/path/to/repository")]
+    public void Repository_Arg_ParsedCorrectly(string expectedHost, string inputRepository)
+    {
+        string inputFile = "/test/testPackage.zip";
+
+        var publishCommand = new PublishCommand();
+        var cmd = new Command("publish");
+        publishCommand.Configure(cmd);
+
+        IFileInfo _file = null;
+        Uri _repository = null;
+        cmd.Handler = CommandHandler.Create<IFileInfo, Uri>((
+            file, repository) => {
+                _file = file;
+                _repository = repository;
+            }
+        );
+
+        var console = new TestConsole();
+        cmd.Invoke(new[] {
+            inputFile, "--repository", inputRepository
+        }, console);
+
+        Assert.Equal(inputFile, _file.FullName);
+        Assert.Equal(inputRepository, _repository.OriginalString);
+        Assert.Equal(expectedHost, _repository.Host);
+    }
+}


### PR DESCRIPTION
Can now publish package to a CIFS share.
Added tests to CIFSClient and also to assert publish command parses repository input correctly as an absolute Uri.