### PR TITLE
chore: remove List method from IRepositoryClient

### DIFF
--- a/core/Interfaces/IRepositoryClient.cs
+++ b/core/Interfaces/IRepositoryClient.cs
@@ -7,7 +7,6 @@ namespace Cmf.CLI.Core.Interfaces;
 public interface IRepositoryClient
 {
     Task<CmfPackageV1> Find(string packageId, string version);
-    Task<CmfPackageV1Collection> List();
     Task Put(CmfPackageV1 package);
     Task<IFileInfo> Get(CmfPackageV1 package, IDirectoryInfo targetDirectory);
     Task<IDirectoryInfo> Extract(CmfPackageV1 package, IDirectoryInfo targetDirectory);

--- a/core/Objects/CIFSClient.cs
+++ b/core/Objects/CIFSClient.cs
@@ -124,6 +124,11 @@ namespace Core.Objects
 
         public Tuple<Uri, Stream> GetFile(string fileName)
         {
+            if (!Exists)
+            {
+                throw new InvalidOperationException("Cannot perform actions in a non-existent shared folder.");
+            }
+
             Tuple<Uri, Stream> fileStream = null;
             var filepath = String.IsNullOrEmpty(_path) ? fileName : $"{_path}/{fileName}";
             var status = _smbFileStore.CreateFile(out object fileHandle, out FileStatus fileStatus, filepath, AccessMask.GENERIC_READ, SMBLibrary.FileAttributes.Normal, ShareAccess.Read | ShareAccess.Write, CreateDisposition.FILE_OPEN, CreateOptions.FILE_NON_DIRECTORY_FILE, null);
@@ -167,6 +172,11 @@ namespace Core.Objects
 
         public void PutFile(string localFilePath, string remoteFilePath)
         {
+            if (!Exists)
+            {
+                throw new InvalidOperationException("Cannot perform actions in a non-existent shared folder.");
+            }
+
             if (!_fileSystem.File.Exists(localFilePath))
             {
                 throw new FileNotFoundException($"The file {localFilePath} does not exist.");

--- a/core/Repository/CIFSRepositoryClient.cs
+++ b/core/Repository/CIFSRepositoryClient.cs
@@ -35,11 +35,6 @@ public class CIFSRepositoryClient : ICIFSRepositoryClient
         return GetFromRepository(dependencyFileName, true);
     }
 
-    public Task<CmfPackageV1Collection> List()
-    {
-        throw new NotSupportedException("Cannot list packages from CIFS share!");
-    }
-
     public async Task Put(CmfPackageV1 package)
     {        
         var tmp = this.fileSystem.DirectoryInfo.New(this.fileSystem.Path.GetTempPath());


### PR DESCRIPTION
List method was removed from IRepositoryClient interface.
Publish command was changed to accommodate new changes.

**Extra:**
Added checks to guarantee a valid connection is active when executing actions on a CIFSClient.