### PR TITLE
feat: add devcontainer definition to init template

### DIFF
--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -249,7 +249,8 @@ namespace Cmf.CLI.Commands
                 "--customPackageName", x.rootPackageName,
                 "--projectName", x.projectName,
                 "--repositoryType", x.repositoryType.ToString(),
-                "--baseLayer", x.repositoryType == RepositoryType.App ? BaseLayer.Core.ToString() : BaseLayer.MES.ToString()
+                "--baseLayer", x.repositoryType == RepositoryType.App ? BaseLayer.Core.ToString() : BaseLayer.MES.ToString(),
+                "--CLIVersion", ExecutionContext.CurrentVersion
             };
 
             if (x.repositoryType == RepositoryType.App)

--- a/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
+++ b/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+    "image": "criticalmanufacturing.io/criticalmanufacturing/devcontainer:<%= $CLI_PARAM_MESVersion-Major %>",
+    "runArgs": [
+        "--network",
+        "host"
+    ],
+    "features": {
+        "ghcr.io/criticalmanufacturing/cli/install:1": {
+            "version": "<%= $CLI_PARAM_CLIVersion-MajorRange %>"
+        },
+        "ghcr.io/criticalmanufacturing/portal-sdk/install:1": {}
+    },
+    "mounts": [
+        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.cmf-auth.json,target=/home/vscode/.cmf-auth.json,type=bind,consistency=cached",
+        "source=${localEnv:XDG_CONFIG_HOME}${localEnv:APPDATA}/cmfportal/cmfportaltoken,target=/home/vscode/.config/cmfportal/cmfportaltoken,type=bind,consistency=cached"
+    ],
+    "containerEnv": {
+        "DOCKER_REGISTRY": "docker.io",
+        "CM_DOCKER_REGISTRY": "criticalmanufacturing.io"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "formulahendry.docker-explorer",
+                "ms-azuretools.vscode-docker",
+                "ms-dotnettools.csdevkit@1.9.55",
+                "ms-dotnettools.csharp@2.39.29",
+                "ms-dotnettools.vscode-dotnet-runtime",
+                "ms-dotnettools.vscodeintellicode-csharp",
+                "FullStackSpider.visual-nuget",
+                "actboy168.tasks"
+            ]
+        }
+    },
+    "forwardPorts": [
+        80
+    ],
+    "postStartCommand": "cmf login sync"
+}

--- a/cmf-cli/resources/template_feed/init/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/init/.template.config/template.json
@@ -162,6 +162,25 @@
       "replaces": "<%= $CLI_PARAM_MESVersion-Feature %>",
       "valueTransform": "versionToFeature"
     },
+    "MESVersion-Major": {
+      "type": "derived",
+      "datatype": "string",
+      "valueSource": "MESVersion",
+      "replaces": "<%= $CLI_PARAM_MESVersion-Major %>",
+      "valueTransform": "versionToMajor"
+    },
+    "CLIVersion": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "<%= $CLI_PARAM_CLIVersion %>"
+    },
+    "CLIVersion-MajorRange": {
+      "type": "derived",
+      "datatype": "string",
+      "valueSource": "CLIVersion",
+      "replaces": "<%= $CLI_PARAM_CLIVersion-MajorRange %>",
+      "valueTransform": "versionToMajorRange"
+    },
     "DevTasksVersion": {
       "type": "parameter",
       "datatype": "string",
@@ -523,6 +542,16 @@
     }
   },
   "forms": {
+    "versionToMajor": {
+      "identifier": "replace",
+      "pattern": "(\\d+)\\.(\\d+)\\.(\\d+)",
+      "replacement": "$1"
+    },
+    "versionToMajorRange": {
+      "identifier": "replace",
+      "pattern": "(\\d+)\\.(\\d+)\\.(\\d+).*",
+      "replacement": "$1.x.x"
+    },
     "versionToFeature": {
       "identifier": "replace",
       "pattern": "(\\d+)\\.(\\d+)\\.(\\d+)",
@@ -544,6 +573,12 @@
             "app_deployment_manifest.xml",
             "assets/**",
             "assets/"
+          ]
+        },
+        {
+          "condition": "MESVersion-Major < 10",
+          "exclude": [
+            ".devcontainer/*"
           ]
         }
       ]


### PR DESCRIPTION
When scaffolding a new project with `cmf init`, we want to include the default devcontainer definition. 

Since the devcontainer image is only available for MES v10 and above, we omit the generation of the file for any MES versions below that.

The devcontainer installs two separate features, one of them to install this this cli inside the container. We always pass the version of the cli to install inside the devcontainer, to match by default, the version of the cli that was used to scaffold the project. However, the version of the cli is also relevant when using CI/CD pipelines. Special care should be taken to make sure that the version of the cli the pipeline uses, and the version of the cli used by the devcontainer match.