### PR TITLE
feat: login sync renew portal token

### DIFF
--- a/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
+++ b/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
@@ -29,7 +29,12 @@
                 "ms-dotnettools.vscodeintellicode-csharp",
                 "FullStackSpider.visual-nuget",
                 "actboy168.tasks"
-            ]
+            ],
+            "settings": {
+                // Store credentials inside the devcontainer itself,
+                // To avoid relying on the user having a functioning local docker installation
+                "dev.containers.dockerCredentialHelper": false
+            }
         }
     },
     "forwardPorts": [

--- a/core/Interfaces/IRepositoryAuthStore.cs
+++ b/core/Interfaces/IRepositoryAuthStore.cs
@@ -9,7 +9,7 @@ namespace Cmf.CLI.Core.Interfaces
     {
         IRepositoryCredentials GetRepositoryType(RepositoryCredentialsType repositoryType);
 
-        IRepositoryCredentials GetRepositoryType<T>() where T : IRepositoryCredentials;
+        T GetRepositoryType<T>() where T : IRepositoryCredentials;
 
         ICredential GetEnvironmentCredentialsFor(RepositoryCredentialsType repositoryType, string repository);
 
@@ -34,6 +34,6 @@ namespace Cmf.CLI.Core.Interfaces
         /// <returns></returns>
         Task<CmfAuthFile> GetOrLoad();
 
-        Task Save(IList<ICredential> credentials, bool sync = true);
+        Task<CmfAuthFile> Save(IList<ICredential> credentials, bool sync = true);
     }
 }

--- a/core/Repository/Credentials/IPortalRepositoryCredentials.cs
+++ b/core/Repository/Credentials/IPortalRepositoryCredentials.cs
@@ -1,0 +1,10 @@
+﻿using Cmf.CLI.Core.Objects;
+using System.Threading.Tasks;
+
+namespace Cmf.CLI.Core.Repository.Credentials
+{
+    public interface IPortalRepositoryCredentials : IRepositoryCredentials
+    {
+        public Task<ICredential> TryRenewToken(CmfAuthFile authFile);
+    }
+}


### PR DESCRIPTION
Developed in sequence of #515, depends on that before merging this one.

The goal here, still in line with using our devcontainer image to develop MES customization projects, is to always run the following command when launching the devcontainer: `cmf login sync`

This command previously only synced the credentials stored inside `~/.cmf-auth.json` to the various tools (nuget, npm, docker, etc..) inside the devcontainer. However, there were two situations where the user would have to manually run `cmf login` before launching the devcontainer:

- The very first time, since no credentials were stored yet
- When the CM Portal token expired (usually after 30 days of the last login)

With this change, every time `sync` runs, the existence of the token (and also its expiration date) are automatically checked, and if needed, the token renewal is performed in the background.

There was also an environment flag added to the tool, `cmf_cli_disable_portal_token_renew` which can be used if for some reason the user wants to disable this automatic renewal of the access tokens (although in 99% of the cases this will and should not be needed).