### PR TITLE
fix: added TypeScript LBOs tgz to gitignore

### DIFF
--- a/cmf-cli/resources/template_feed/init/.gitignore
+++ b/cmf-cli/resources/template_feed/init/.gitignore
@@ -266,6 +266,7 @@ Business/packages/
 Tests/packages/
 
 /Libs/HTML5/*
+/Libs/LBOs/**/*.tgz
 
 Package/
 Dependencies/


### PR DESCRIPTION
Following the change to the lbo generator where a *.tgz is created, we need to add it to the gitinore to not pollute the repositories.