### PR TITLE
fix: devcontainer able to run cmf login sync at launch

### DIFF
--- a/cmf-cli/Commands/login/LoginCommand.cs
+++ b/cmf-cli/Commands/login/LoginCommand.cs
@@ -46,7 +46,7 @@ namespace Cmf.CLI.Commands
         public override void Configure(Command cmd)
         {
             cmd.AddArgument(new Argument<RepositoryCredentialsType?>(
-                name: "repositoryType", description: "Type of repository for login (values: portal, docker, npm, nuget, cifs)"
+                name: "repositoryType", description: "Type of repository for login"
             ) { Arity = ArgumentArity.ZeroOrOne });
             cmd.AddArgument(new Argument<string>(
                 name: "repository", description: "URL of repository for login"

--- a/cmf-cli/Commands/login/LoginCommand.cs
+++ b/cmf-cli/Commands/login/LoginCommand.cs
@@ -170,7 +170,7 @@ namespace Cmf.CLI.Commands
 
                     if (password == null)
                     {
-                        password = Prompt("Username", noPrompt);
+                        password = Prompt("Password", noPrompt);
                     }
 
                     GenericUtilities.ValidatePropertyRequirement($"Option \"domain\"", domain, repositoryCredentials.DomainPropertyRequirement);

--- a/cmf-cli/Commands/login/LoginCommand.cs
+++ b/cmf-cli/Commands/login/LoginCommand.cs
@@ -118,6 +118,10 @@ namespace Cmf.CLI.Commands
             {
                 repository = CmfAuthConstants.PortalRepository;
             }
+            else if (string.IsNullOrEmpty(repository))
+            {
+                throw new CliException($"Missing mandatory {repositoryType} repository URL.");
+            }
 
             // We find the repository type implementation for the repo type
             var repositoryCredentials = authStore.GetRepositoryType(repositoryType.Value);

--- a/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
+++ b/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
@@ -8,10 +8,10 @@
         "ghcr.io/criticalmanufacturing/cli/install:1": {
             "version": "<%= $CLI_PARAM_CLIVersion-MajorRange %>"
         },
-        "ghcr.io/criticalmanufacturing/portal-sdk/install:1": {}
+        "ghcr.io/criticalmanufacturing/portal-sdk/install:1": {},
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {}
     },
     "mounts": [
-        "source=/var/run/docker.sock,target=/var/run/docker.sock,type=bind,consistency=cached",
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/.cmf-auth.json,target=/home/vscode/.cmf-auth.json,type=bind,consistency=cached"
     ],
     "containerEnv": {

--- a/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
+++ b/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
@@ -33,12 +33,34 @@
             "settings": {
                 // Store credentials inside the devcontainer itself,
                 // To avoid relying on the user having a functioning local docker installation
-                "dev.containers.dockerCredentialHelper": false
+                "dev.containers.dockerCredentialHelper": false,
+                // The command "cmf login sync" needs to run when the devcontainer starts,
+                // but since it relies on xdg-open working a URL on the host, it cannot be
+                // defined in postStartCommand or anything similar
+                // See https://github.com/microsoft/vscode-remote-release/issues/9935
+                "tasks": {
+                    "version": "2.0.0",
+                    "tasks": [
+                        {
+                            "label": "cmf login",
+                            "type": "shell",
+                            "hide": false,
+                            "command": "cmf login sync",
+                            "runOptions": {
+                                "runOn": "folderOpen"
+                            },
+                            "options": {
+                                "statusbar": {
+                                    "label": "$(key) cmf login"
+                                }
+                            }
+                        }
+                    ]
+                }
             }
         }
     },
     "forwardPorts": [
         80
-    ],
-    "postStartCommand": "cmf login sync"
+    ]
 }

--- a/core/Repository/Credentials/NuGetRepositoryCredentials.cs
+++ b/core/Repository/Credentials/NuGetRepositoryCredentials.cs
@@ -185,10 +185,12 @@ namespace Cmf.CLI.Core.Repository.Credentials
         protected IFileInfo GetConfigFile()
         {
             // NuGet stores the per-user NuGet.config file on the AppData directory
-            //      in Linux, it is stored in "~/.config", which is the path returned for ApplicationData in Linux too. Consistency, yay
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            //      in Linux, it is stored in "~/.nuget" instead, Consistency? Nay :(
+            var home = OperatingSystem.IsWindows()
+                ? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+                : _fileSystem.Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget");
 
-            // The official Microsoft documentation has references to both `NuGet.config` and `nuget.config` explicitly in some parts of their documentation.
+            // The official Microsoft documentation has references to both `NuGet.Config` and `nuget.config` explicitly in some parts of their documentation.
             // Because of that, and since Linux is case sensitive, we do our best effort to support both. In case none exists on the filesystem yet, the last one
             // we looked for (in this case, NuGet.config) will be used
             var nugetConfig = _fileSystem.FileInfo.New(_fileSystem.Path.Join(home, "NuGet", "nuget.config"));

--- a/docs/src/03-explore/commands/login.md
+++ b/docs/src/03-explore/commands/login.md
@@ -139,7 +139,7 @@ The credentials are stored on the auth file, with the following structure:
 }
 ```
 
-By default, the `.cmf-auth.json` is located inside the `$HOME` folder of the user running the command. It is however, possible to change the location used the the `cmf` tool by setting an environment variable:
+By default, the `.cmf-auth.json` is located inside the `$HOME` folder of the user running the command. It is however, possible to change the location used the `cmf` tool by setting an environment variable:
 ```env
 cmf_cli_authfile=/custom/path/to/.cmf-auth.json
 ```

--- a/docs/src/03-explore/commands/login_sync.md
+++ b/docs/src/03-explore/commands/login_sync.md
@@ -44,6 +44,6 @@ Repository Type | Method      | Details
 --------------- | ----------- | --------
 **Portal**      | File        | `{ApplicationData}/cmfportal/cmfportaltoken`
 **NPM**         | File        | `{Home}/.npmrc`
-**NuGet**       | File        | `{ApplicationData}/NuGet/NuGet.config`
+**NuGet**       | File        | **Windows** `{ApplicationData}/NuGet/NuGet.config`<br />**Linux** `{HOME}/.nuget/NuGet/NuGet.config`
 **Docker**      | Command     | `docker login <repoUrl> -u <username> -p <password>`
 **CIFS**        | N/A         | _CIFS authentication is only used internally by the cmf cli itself and thus needs no synchronization_

--- a/tests/Specs/RepositoryCredentials.cs
+++ b/tests/Specs/RepositoryCredentials.cs
@@ -29,9 +29,14 @@ namespace tests.Specs;
 
 public class RepositoryCredentials
 {
+    // Sadly, the path depends on the Operating System, so depending on where we are running the tests, we should expect the file on different places
+    private static string NuGetParentFolder = OperatingSystem.IsWindows()
+        ? Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)
+        : Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget");
+
     public static string MockCmfAuthFilePath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cmf-auth.json");
     public static string MockNPMConfigFilePath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".npmrc");
-    public static string MockNuGetConfigFilePath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "NuGet", "NuGet.Config");
+    public static string MockNuGetConfigFilePath = Path.Join(NuGetParentFolder, "NuGet", "NuGet.Config");
     public static string MockPortalTokenFilePath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData, Environment.SpecialFolderOption.Create), "cmfportal", "cmfportaltoken");
 
     public const string mockCmfAuthJson =


### PR DESCRIPTION
We were running the command `cmf login sync` on the `"postStartCommand"`. This did not work however, because the `$BROWSER` environment variable is not yet defined at that stage (the reason being that the variable is defined by VS Code, while the `"postStartCommand"` and similar commands are managed by the `devcontainer` tooling before VS Code takes over).
See https://github.com/microsoft/vscode-remote-release/issues/9935

One of the solutions suggested there was to define a task instead, that is defined with:
```
"runOptions": {
    "runOn": "folderOpen"
},
```

Tested this and it works like this.