### PR TITLE
Fixed cmf new test local runsettings for apps

### DIFF
--- a/cmf-cli/Commands/new/TestCommand.cs
+++ b/cmf-cli/Commands/new/TestCommand.cs
@@ -4,6 +4,7 @@ using System.CommandLine;
 using System.CommandLine.NamingConventionBinder;
 using System.IO.Abstractions;
 using System.Text.Json;
+using Cmf.CLI.Constants;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
@@ -52,6 +53,7 @@ namespace Cmf.CLI.Commands.New
         {
             var packageName = "Cmf.Custom.Tests";
             var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
+            var repoType = ExecutionContext.Instance.ProjectConfig.RepositoryType ?? CliConstants.DefaultRepositoryType;
             var projectConfig = ExecutionContext.Instance.ProjectConfig;
             var tenant = projectConfig.Tenant;
             var args = new List<string>()
@@ -66,6 +68,7 @@ namespace Cmf.CLI.Commands.New
                 "--Tenant", tenant
             };
 
+            var projectName = projectConfig.ProjectName;
             var restPort = projectConfig.RESTPort;
             var mesVersion = projectConfig.MESVersion;
             var htmlPort = projectConfig.HTMLPort;
@@ -74,6 +77,8 @@ namespace Cmf.CLI.Commands.New
             var isSslEnabled = projectConfig.IsSslEnabled;
             args.AddRange(new[]
             {
+                "--projectName", projectName,
+                "--repositoryType", repoType.ToString(),
                 "--vmHostname", vmHostname,
                 "--RESTPort", restPort.ToString(),
                 "--testScenariosNugetVersion", testScenariosNugetVersion.ToString(),

--- a/cmf-cli/resources/template_feed/test/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/test/.template.config/template.json
@@ -26,12 +26,27 @@
       "displayName": "Package Name",
       "replaces": "<%= $CLI_PARAM_CustomPackageName %>"
     },
+    "projectName": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "The name of our project",
+      "displayName": "Project Name",
+      "replaces": "<%= $CLI_PARAM_ProjectName %>"
+    },
     "packageVersion": {
       "type": "parameter",
       "datatype": "string",
       "description": "The custom package version",
       "displayName": "Package Version",
       "replaces": "<%= $CLI_PARAM_CustomPackageVersion %>"
+    },
+    "repositoryType": {
+      "type": "parameter",
+      "datatype": "string",
+      "description": "The type of repository to scaffold",
+      "displayName": "Repository Type",
+      "replaces": "<%= $CLI_PARAM_RepositoryType %>",
+      "fileRename": "%repositoryType%"
     },
     "Tenant": {
       "type": "parameter",

--- a/cmf-cli/resources/template_feed/test/Tests.Package/local.runsettings
+++ b/cmf-cli/resources/template_feed/test/Tests.Package/local.runsettings
@@ -1,57 +1,69 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <RunSettings>
-  <!-- Configurations that affect the Test Framework -->
-  <RunConfiguration>
-    <!--0 = As many processes as possible, limited by number of cores on machine, 1 = Sequential (1 process), 2-> Given number of processes up to limit by number of cores on machine-->
-    <MaxCpuCount>1</MaxCpuCount>
-  </RunConfiguration>
-  
-    <!-- Parameters used by tests at runtime -->
-  <TestRunParameters>
-    <Parameter name="applicationName" value="AutomaticTests" />
-    <Parameter name="websiteAdress" value="localhost" />
-    <Parameter name="websitePort" value="7000" />
-    <Parameter name="websiteUseSSL" value="false" />
-    <Parameter name="hostAdress" value="localhost" />
-    <Parameter name="hostPort" value="<%= $CLI_PARAM_RESTPort %>" />
-    <Parameter name="clientTenantName" value="<%= $CLI_PARAM_Tenant %>" />
-    <Parameter name="culture" value="en-US"/>
-    <Parameter name="userRole" value="Administrators"/>
-    <Parameter name="userName" value="TestUserAccountHere" />
-    <Parameter name="password" value="TestUserPasswordHere" />
-    <Parameter name="auxiliaryUserName" value="TestUserAccountHere" />
-    <Parameter name="auxiliaryUserPassword" value="TestUserPasswordHere" />
-    <Parameter name="skipLogin" value="true" />
-    <Parameter name="hostUseSSL" value="false" />
-    <Parameter name="securityToken" value="4n5g84uLK347" />
-    <Parameter name="useLoadBalancer" value="false" />
-    <Parameter name="requestTimeout" value="00:10:00" />
-    <Parameter name="reuseWebDriver" value="true" />
-    <Parameter name="browser" value="chrome" />
-	<Parameter name="debug" value="false" />
-    <!-- Connect IoT -->
-    <Parameter name="mode" value="Local" />
-    <Parameter name="filePathRemote" value="./RunSettings/local.runsettings" />
-    <Parameter name="filePathLocal" value="../../local.runsettings" />
-    <!-- test output -->
-    <Parameter name="screenshotPath" value="\\<%= $CLI_PARAM_vmHostname %>\Deployment\TestArtifacts" />
-    <Parameter name="logsPath" value="\\<%= $CLI_PARAM_vmHostname %>\Deployment\TestArtifacts" />
-    <Parameter name="documentationScreenshotPath" value="\\<%= $CLI_PARAM_vmHostname %>\Deployment\TestArtifacts\Documentation" />
-  </TestRunParameters>
+	<!-- Configurations that affect the Test Framework -->
+	<RunConfiguration>
+		<!--0 = As many processes as possible, limited by number of cores on machine, 1 = Sequential (1 process), 2-> Given number of processes up to limit by number of cores on machine-->
+		<MaxCpuCount>1</MaxCpuCount>
+	</RunConfiguration>
 
-  <!-- MSTest adapter -->
-  <MSTest>
-    <KeepExecutorAliveAfterLegacyRun>true</KeepExecutorAliveAfterLegacyRun>
-    <MapInconclusiveToFailed>true</MapInconclusiveToFailed>
-    <CaptureTraceOutput>true</CaptureTraceOutput>
-    <DeleteDeploymentDirectoryAfterTestRunIsComplete>false</DeleteDeploymentDirectoryAfterTestRunIsComplete>
-    <DeploymentEnabled>false</DeploymentEnabled>
-    <InProcMode>false</InProcMode>
-  </MSTest>
+	<!-- Parameters used by tests at runtime -->
+	<TestRunParameters>
+		<Parameter name="applicationName" value="AutomaticTests" />
+		<Parameter name="websiteAdress" value="localhost" />
+		<Parameter name="websitePort" value="80" />
+		<Parameter name="websiteUseSSL" value="false" />
+		//#if (repositoryType == "App")
+		<Parameter name="hostAdress" value="localhost/apps/<%= $CLI_PARAM_ProjectName %>/"/>
+		//#else
+		<Parameter name="hostAdress" value="localhost"/>
+		//#endif
+		<Parameter name="hostPort" value="80" />
+		<Parameter name="clientTenantName" value="<%= $CLI_PARAM_Tenant %>" />
+		<Parameter name="culture" value="en-US"/>
+		<Parameter name="userRole" value="Administrators"/>
+		<Parameter name="userName" value="TestUserAccountHere" />
+		<Parameter name="password" value="TestUserPasswordHere" />
+		<Parameter name="auxiliaryUserName" value="TestUserAccountHere" />
+		<Parameter name="auxiliaryUserPassword" value="TestUserPasswordHere" />
+		<Parameter name="skipLogin" value="true" />
+		<Parameter name="hostUseSSL" value="false" />
+		<Parameter name="securityToken" value="4n5g84uLK347" />
+		<Parameter name="useLoadBalancer" value="false" />
+		<Parameter name="requestTimeout" value="00:10:00" />
+		<Parameter name="reuseWebDriver" value="true" />
+		<Parameter name="browser" value="chrome" />
+		<Parameter name="debug" value="false" />
 
-  
-  <!-- Connect IoT -->
-  <!-- <connectIotAutomaticTests>
+		<!-- Security Portal Authentication -->
+		<Parameter name="authenticateViaSecurityPortalToken" value="true" />
+		<Parameter name="securityPortalClientId" value="MES" />
+		<Parameter name="securityPortalBaseAddress" value="http://localhost/SecurityPortal/tenant" />
+		<!-- Generate PAT from the Local Environment -->
+		<Parameter name="securityPortalAccessToken" value="" />
+
+		<!-- Connect IoT -->
+		<Parameter name="mode" value="Local" />
+		<Parameter name="filePathRemote" value="./RunSettings/local.runsettings" />
+		<Parameter name="filePathLocal" value="../../local.runsettings" />
+		<!-- test output -->
+		<Parameter name="screenshotPath" value="\\<%= $CLI_PARAM_vmHostname %>\Deployment\TestArtifacts" />
+		<Parameter name="logsPath" value="\\<%= $CLI_PARAM_vmHostname %>\Deployment\TestArtifacts" />
+		<Parameter name="documentationScreenshotPath" value="\\<%= $CLI_PARAM_vmHostname %>\Deployment\TestArtifacts\Documentation" />
+	</TestRunParameters>
+
+	<!-- MSTest adapter -->
+	<MSTest>
+		<KeepExecutorAliveAfterLegacyRun>true</KeepExecutorAliveAfterLegacyRun>
+		<MapInconclusiveToFailed>true</MapInconclusiveToFailed>
+		<CaptureTraceOutput>true</CaptureTraceOutput>
+		<DeleteDeploymentDirectoryAfterTestRunIsComplete>false</DeleteDeploymentDirectoryAfterTestRunIsComplete>
+		<DeploymentEnabled>false</DeploymentEnabled>
+		<InProcMode>false</InProcMode>
+	</MSTest>
+
+
+	<!-- Connect IoT -->
+	<!-- <connectIotAutomaticTests>
     <Global
       dataDir="%TestsPath%\Cmf.Custom.Tests.IoT\bin\Debug\"
       configLocation="%ConfigLocation%"
@@ -67,5 +79,5 @@
       </Cluster>
     </Equipments>
   </connectIotAutomaticTests> -->
-  
+
 </RunSettings>


### PR DESCRIPTION
This PR corrects the generated `runsettings` file produced by the `cmf-new-test` scaffold command when used in an app-type repository.