### PR TITLE
feat: pack tests generates a package.json to allow publishing to NPM

### DIFF
--- a/cmf-cli/Commands/publish/PublishCommand.cs
+++ b/cmf-cli/Commands/publish/PublishCommand.cs
@@ -17,6 +17,21 @@ namespace Cmf.CLI.Commands;
 [CmfCommand("publish", Id = "publish", Description = "Publishes a local package to the specified repository")]
 public class PublishCommand : BaseCommand
 {
+    #region Constructors
+
+    /// <summary>
+    /// Publish Command
+    /// </summary>
+    public PublishCommand() : base() { }
+
+    /// <summary>
+    /// Publish Command
+    /// </summary>
+    /// <param name="fileSystem"></param>
+    public PublishCommand(IFileSystem fileSystem) : base(fileSystem) { }
+
+    #endregion
+
     public override void Configure(Command cmd)
     {
         cmd.AddArgument(new Argument<IFileInfo>(
@@ -26,7 +41,7 @@ public class PublishCommand : BaseCommand
         {
             Description = "Package file"
         });
-        
+
         cmd.AddOption(new Option<Uri>(
             aliases: new string[] { "--repository" },
             description: "Repository the package should be published to",
@@ -44,7 +59,7 @@ public class PublishCommand : BaseCommand
 
         cmd.IsHidden =
             !(ExecutionContext.ServiceProvider?.GetService<IFeaturesService>()?.UseRepositoryClients ?? false);
-        
+
         // Add the handler
         cmd.Handler = CommandHandler.Create<IFileInfo, Uri>(Execute);
     }

--- a/cmf-cli/resources/templateFiles/Tests/package.json
+++ b/cmf-cli/resources/templateFiles/Tests/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "",
+  "version": "",
+  "description": "",
+  "author": "Critical Manufacturing",
+  "keywords": ["cmf-tests-package"]
+}

--- a/tests/Specs/Publish.cs
+++ b/tests/Specs/Publish.cs
@@ -7,6 +7,22 @@ using Moq;
 using Cmf.CLI.Commands;
 using System.CommandLine.NamingConventionBinder;
 using System.CommandLine.IO;
+using System.Collections.Generic;
+using System.Formats.Tar;
+using System.IO.Abstractions.TestingHelpers;
+using Cmf.CLI.Core.Objects;
+using System.IO.Compression;
+using System.IO;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Core.Repository;
+using Cmf.CLI.Core.Services;
+using Cmf.CLI.Core.Repository.Credentials;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using tests.Mocks;
 
 namespace tests.Specs;
 
@@ -27,10 +43,11 @@ public class Publish
         IFileInfo _file = null;
         Uri _repository = null;
         cmd.Handler = CommandHandler.Create<IFileInfo, Uri>((
-            file, repository) => {
-                _file = file;
-                _repository = repository;
-            }
+            file, repository) =>
+        {
+            _file = file;
+            _repository = repository;
+        }
         );
 
         var console = new TestConsole();
@@ -41,5 +58,166 @@ public class Publish
         Assert.Equal(inputFile, _file.FullName);
         Assert.Equal(inputRepository, _repository.OriginalString);
         Assert.Equal(expectedHost, _repository.Host);
+    }
+
+    [Fact]
+    public void NonDeploymentFrameworkPackage()
+    {
+        // Arrange
+        using var zipStream = new MemoryStream();
+        using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using (var entryStream = zipArchive.CreateEntry("package.json").Open())
+            {
+                entryStream.Write(Encoding.UTF8.GetBytes("""
+                {
+                    "name": "Cmf.Custom.Tests",
+                    "version": "1.1.0",
+                    "description": "Custom Tests Package",
+                    "author": "Critical Manufacturing",
+                    "keywords": ["cmf-tests-package"]
+                }
+                """));
+            }
+        }
+        zipStream.Position = 0;
+
+        var archivePath = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Packages\Cmf.Custom.Test.zip");
+        var archiveData = zipStream.ToArray();
+
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { archivePath, new MockFileData(archiveData) },
+        }, MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test"));
+
+        IFileInfo publishedFileInfo = null;
+        
+        // Set up a Mock NPM Client that saves the last file info that was published to it
+        // Later we can validate that it was only called once, and that means this is the only file that was uploaded
+        var npmClient = new Mock<INPMClientEx>();
+        npmClient.Setup(x => x.PublishPackage(It.IsAny<IFileInfo>()))
+            .Callback((IFileInfo fileInfo) => publishedFileInfo = fileInfo);
+        
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .SetupSequence(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns(new ArchiveRepositoryClient(archivePath, fileSystem))
+            .Returns(new NPMRepositoryClient(repositoryUrl.AbsoluteUri, fileSystem, npmClient.Object));
+        
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        // Act
+        var publishCommand = new PublishCommand(fileSystem);
+        publishCommand.Execute(fileSystem.FileInfo.New(archivePath), repositoryUrl);
+
+        // Assert
+        npmClient.Verify(x => x.PublishPackage(It.IsAny<IFileInfo>()), Times.Once);
+        publishedFileInfo.Should().NotBeNull();
+        publishedFileInfo.Exists.Should().BeTrue();
+        publishedFileInfo.Extension.Should().Be(".tgz");
+        
+        // Extract the "package.json" file from the .tgz that was "uploaded" to the mock NPM client
+        using GZipStream gzipStream = new GZipStream(publishedFileInfo.OpenRead(), CompressionMode.Decompress);
+        using TarReader tarReader = new(gzipStream);
+        JObject json = null;
+        while (tarReader.GetNextEntry() is { } entry)
+        {
+            // Check if this is the file you're looking for
+            if ((entry.Name == "package/package.json") && entry.EntryType == TarEntryType.V7RegularFile)
+            {
+                if (entry.DataStream != null)
+                {
+                    // Read the content of the file inside the TAR
+                    using var reader = new StreamReader(entry.DataStream);
+                    var contents = reader.ReadToEnd();
+                    json = JsonConvert.DeserializeObject<JObject>(contents);
+                }
+
+                break;
+            }
+        }
+        
+        // Make sure the file package.json exists
+        Assert.NotNull(json);
+        
+        Assert.True(json.ContainsKey("name"));
+        Assert.Equal("Cmf.Custom.Tests", json["name"]!.Value<string>());
+
+        Assert.True(json.ContainsKey("version"));
+        Assert.Equal("1.1.0", json["version"]!.Value<string>());
+        
+        Assert.False(json.ContainsKey("deployment"));
+    }
+    
+    
+    [Fact]
+    public void NonDeploymentFrameworkPackage_MissingKeyword()
+    {
+        // Arrange
+        using var zipStream = new MemoryStream();
+        using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using (var entryStream = zipArchive.CreateEntry("package.json").Open())
+            {
+                entryStream.Write(Encoding.UTF8.GetBytes("""
+                {
+                    "name": "Cmf.Custom.Tests",
+                    "version": "1.1.0",
+                    "description": "Custom Tests Package",
+                    "author": "Critical Manufacturing"
+                }
+                """));
+            }
+        }
+        zipStream.Position = 0;
+
+        var archivePath = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Packages\Cmf.Custom.Test.zip");
+        var archiveData = zipStream.ToArray();
+
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { archivePath, new MockFileData(archiveData) },
+        }, MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test"));
+
+        IFileInfo publishedFileInfo = null;
+        
+        // Set up a Mock NPM Client that saves the last file info that was published to it
+        // Later we can validate that it was only called once, and that means this is the only file that was uploaded
+        var npmClient = new Mock<INPMClientEx>();
+        npmClient.Setup(x => x.PublishPackage(It.IsAny<IFileInfo>()))
+            .Callback((IFileInfo fileInfo) => publishedFileInfo = fileInfo);
+        
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .SetupSequence(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns(new ArchiveRepositoryClient(archivePath, fileSystem))
+            .Returns(new NPMRepositoryClient(repositoryUrl.AbsoluteUri, fileSystem, npmClient.Object));
+        
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        // Act
+        var publishCommand = new PublishCommand(fileSystem);
+        var exception = publishCommand.Invoking(x => x.Execute(fileSystem.FileInfo.New(archivePath), repositoryUrl));
+
+        // Assert
+        exception.Should().Throw<Exception>().WithMessage("*Invalid manifest file: one of the following keywords must be present*");
     }
 }


### PR DESCRIPTION
Now that MES will support grabbing packages Deployment Framework from NPM feeds, and the CLI is able to publish Deplyment Framework packages into NPM feeds, we had one problem: test packages are "special" in that they are not Deployment Framework packages (they do not have a manifest file, and they are not installed into an MES system).

Nevertheless, for consistency and to keep the architecture of things simple, we want to be able to publish these packages to NPM as well. For that, the purpose of this PR is to, when packaging a test package, generate a `package.json` file into the resulting archive, so that it can be uploaded to NPM via a regular `cmf pusblish` command execution.