### PR TITLE
fix: cmf build of test pkgs ignoring user-level nuget configs

### DIFF
--- a/cmf-cli/Handlers/PackageType/TestPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/TestPackageTypeHandler.cs
@@ -54,7 +54,6 @@ namespace Cmf.CLI.Handlers
                     Command = "restore",
                     DisplayName = "NuGet restore",
                     Solution = this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(cmfPackage.GetFileInfo().Directory.FullName, "Tests.sln")),
-                    NuGetConfig = this.fileSystem.FileInfo.New(this.fileSystem.Path.Join(FileSystemUtilities.GetProjectRoot(this.fileSystem, throwException: true).FullName, "NuGet.Config")),
                     WorkingDirectory = cmfPackage.GetFileInfo().Directory
                 },
                 new DotnetCommand()


### PR DESCRIPTION
For some reason, the `cmf build` for test packages is forcing the `dotnet restore` to run only with the `NuGet.config` file on the root of the project.
https://github.com/criticalmanufacturing/cli/blob/1277020adcc2c7b489f6bedbee5f938c8b0e5647/cmf-cli/Handlers/PackageType/TestPackageTypeHandler.cs#L52-L59

This behavior is different from the one for building the business packages, for example:
https://github.com/criticalmanufacturing/cli/blob/9739fd13d5b7f2b79d1ee03943b9225137fa3f3e/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs#L57-L63

This is a problem because it prevents the `dotnet restore` command from resolving the **user-level config files** located in places like the home directory, and which are sometimes needed because they may contain credentials to private NuGet repositories needed to restore the solution.