### PR TITLE
fix: modified assemble command to add the app icon

### DIFF
--- a/cmf-cli/Commands/assemble/AssembleCommand.cs
+++ b/cmf-cli/Commands/assemble/AssembleCommand.cs
@@ -185,7 +185,7 @@ namespace Cmf.CLI.Commands
 
         #endregion
 
-        #region Private Methods
+        #region Private Methods & Internal Methods
 
         /// <summary>
         /// Assemble Packages of Type Test
@@ -330,7 +330,7 @@ namespace Cmf.CLI.Commands
         /// </summary>
         /// <param name="outputDir">The package output directory.</param>
         /// <param name="cmfPackage">The current cmf package.</param>
-        private void HandleAppPkg(IDirectoryInfo outputDir, CmfPackage cmfPackage)
+        internal void HandleAppPkg(IDirectoryInfo outputDir, CmfPackage cmfPackage)
         {
             IFileInfo cmfAppFile = fileSystem.FileInfo.New(CliConstants.CmfAppFileName);
             var appData = JsonConvert.DeserializeObject<AppData>(cmfAppFile.ReadToString());

--- a/cmf-cli/Commands/assemble/AssembleCommand.cs
+++ b/cmf-cli/Commands/assemble/AssembleCommand.cs
@@ -332,7 +332,8 @@ namespace Cmf.CLI.Commands
         /// <param name="cmfPackage">The current cmf package.</param>
         internal void HandleAppPkg(IDirectoryInfo outputDir, CmfPackage cmfPackage)
         {
-            IFileInfo cmfAppFile = fileSystem.FileInfo.New(CliConstants.CmfAppFileName);
+            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
+            IFileInfo cmfAppFile = fileSystem.FileInfo.New(fileSystem.Path.Join(projectRoot.FullName, CliConstants.CmfAppFileName));
             var appData = JsonConvert.DeserializeObject<AppData>(cmfAppFile.ReadToString());
 
             string appPackageName = $"{appData.id}@{cmfPackage.Version}";


### PR DESCRIPTION
This PR modifies the assemble command to generate a package containing the app files.
One of these files is the app icon, which is important when installing an app.
This package was already generated when running the "pack" command but was not generated by the "assemble" command.