### PR TITLE
fix: make scaffolded related packages property cross-platform

### DIFF
--- a/cmf-cli/Commands/new/DataCommand.cs
+++ b/cmf-cli/Commands/new/DataCommand.cs
@@ -130,7 +130,7 @@ namespace Cmf.CLI.Commands.New
 
                     dataPackage.RelatedPackages = new()
                     {
-                        new RelatedPackage() { Path = fileSystem.Path.GetRelativePath(dataPackage.GetFileInfo().Directory.FullName, businessPackage.FullName), PreBuild = true, PrePack = false }
+                        new RelatedPackage() { Path = fileSystem.Path.GetRelativePath(dataPackage.GetFileInfo().Directory.FullName, businessPackage.FullName).Replace("\\", "/"), PreBuild = true, PrePack = false }
                     };
 
                     dataPackage.SaveCmfPackage();

--- a/cmf-cli/Commands/new/IoTCommand.cs
+++ b/cmf-cli/Commands/new/IoTCommand.cs
@@ -277,7 +277,7 @@ namespace Cmf.CLI.Commands.New
             // After building the IoT Package we must ensure to also build the HTML Package
             iotCustomPackage.RelatedPackages = new()
             {
-                new RelatedPackage() { Path = fileSystem.Path.GetRelativePath(iotCustomPackageWorkDir.FullName, htmlPackageDir.FullName), PostBuild = true, PostPack = true }
+                new RelatedPackage() { Path = fileSystem.Path.GetRelativePath(iotCustomPackageWorkDir.FullName, htmlPackageDir.FullName).Replace("\\", "/"), PostBuild = true, PostPack = true }
             };
 
             iotCustomPackage.SaveCmfPackage();


### PR DESCRIPTION
If a package is scaffolded on a windows machine, it should still build correctly on linux machines later on. However, for Data and IoT packages, we are storing the related packages path hardcoded with the Path Separator of the operating system where the package was created (which on windows is `\`). This won't work if we later try to build on linux.

We can however force the paths to always be split up by the `/`, because that is supported on all OSs (including windows), so it will build successfully everywhere, regardless of where the package was generated.