### PR TITLE
feat(html): modify index.html and ng serve arguments for apps

### DIFF
--- a/cmf-cli/Commands/new/HTMLCommand.cs
+++ b/cmf-cli/Commands/new/HTMLCommand.cs
@@ -386,7 +386,7 @@ $@"{{
                 IFileInfo cmfAppFile = fileSystem.FileInfo.New(fileSystem.Path.Join(projectRoot.FullName, CliConstants.CmfAppFileName));
                 if (!cmfAppFile.Exists)
                 {
-                    throw new Exception($"{CliConstants.CmfAppFileName} not found!");
+                    throw new CliException($"{CliConstants.CmfAppFileName} not found!");
                 }
 
                 var appFileContent = cmfAppFile.ReadToString();


### PR DESCRIPTION
This PR updates the ng serve arguments to include serve path and update index.html to have the correct name and baseHref.