### PR TITLE
chore: add docker pull to CM devcontainer to always have the latest image

### DIFF
--- a/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
+++ b/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
@@ -62,5 +62,6 @@
     },
     "forwardPorts": [
         80
-    ]
+    ],
+    "initializeCommand": "docker pull criticalmanufacturing.io/criticalmanufacturing/devcontainer:<%= $CLI_PARAM_MESVersion-Major %>"
 }


### PR DESCRIPTION
While previously using "--pull=always" seemed to work, now, when testing it does not work as it attempts to pull the vscode-<name>-<uuid> generated by vscode.
`[2025-07-01T15:33:54.962Z] docker: Error response from daemon: pull access denied for vsc-devops-0a98b29c1c20aa3a721f0e6c62f60ce5a841748f5ff1aae7ad580fee5f68bdc7-uid, repository does not exist or may require 'docker login': denied: requested access to the resource is denied`

There are also issues on GitHub referring to this behavior: https://github.com/microsoft/vscode-remote-release/issues/7104
The workaround is to manually call "docker pull <image>" on the initializeCommand hook.