### PR TITLE
fix(business): fix application version csproj template to include licensed app name

### DIFF
--- a/cmf-cli/Commands/assemble/AssembleCommand.cs
+++ b/cmf-cli/Commands/assemble/AssembleCommand.cs
@@ -3,7 +3,6 @@ using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
-using Cmf.CLI.Core.Objects.CmfApp;
 using Cmf.CLI.Utilities;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -332,10 +331,8 @@ namespace Cmf.CLI.Commands
         /// <param name="cmfPackage">The current cmf package.</param>
         internal void HandleAppPkg(IDirectoryInfo outputDir, CmfPackage cmfPackage)
         {
-            IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
-            IFileInfo cmfAppFile = fileSystem.FileInfo.New(fileSystem.Path.Join(projectRoot.FullName, CliConstants.CmfAppFileName));
-            var appData = JsonConvert.DeserializeObject<AppData>(cmfAppFile.ReadToString());
-
+            var appData = ExecutionContext.Instance.AppData ??
+                 throw new CliException("Could not retrieve repository AppData.");
             string appPackageName = $"{appData.id}@{cmfPackage.Version}";
             string appPackageFullName = $"{appPackageName}.zip";
             string appPkgDestinationFile = $"{outputDir.FullName}/{appPackageFullName}";

--- a/cmf-cli/Commands/new/BusinessCommand.cs
+++ b/cmf-cli/Commands/new/BusinessCommand.cs
@@ -80,15 +80,16 @@ namespace Cmf.CLI.Commands.New
                 includeMESNugets = baseLayer == BaseLayer.MES;
                 Log.Debug($"Project is targeting base layer {baseLayer}, so scaffolding {(includeMESNugets ? "with" : "without")} MES nugets.");
 
-                bool isProjectApp = ExecutionContext.Instance.ProjectConfig.RepositoryType == RepositoryType.App;
-                
                 args.AddRange(new []{ "--targetFramework",  mesVersion.Major >= 11 ? "net8.0" : "net6.0" });
 
-                if (isProjectApp)
+                if (ExecutionContext.Instance.ProjectConfig.RepositoryType == RepositoryType.App)
                 {
+                    var appData = ExecutionContext.Instance.AppData ??
+                        throw new CliException("Could not retrieve repository AppData.");
                     args.AddRange(new[]
                     {
-                        "--app", isProjectApp.ToString(),
+                        "--app", "true",
+                        "--licensedAppName", appData.licensedApplication,
                         "--fileVersion", $"{mesVersion}.0",
                         "--assemblyVersion", $"{mesVersion.Major}.{mesVersion.Minor}.0.0",
                         "--addApplicationVersionAssembly", AddApplicationVersionAssembly.ToString()

--- a/cmf-cli/Commands/new/HTMLCommand.cs
+++ b/cmf-cli/Commands/new/HTMLCommand.cs
@@ -11,7 +11,6 @@ using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
-using Cmf.CLI.Core.Objects.CmfApp;
 using Cmf.CLI.Services;
 using Cmf.CLI.Utilities;
 using Microsoft.Extensions.DependencyInjection;
@@ -380,17 +379,8 @@ $@"{{
 
             if (ExecutionContext.Instance.ProjectConfig.RepositoryType == RepositoryType.App)
             {
-
-                IDirectoryInfo projectRoot = FileSystemUtilities.GetProjectRoot(fileSystem);
-
-                IFileInfo cmfAppFile = fileSystem.FileInfo.New(fileSystem.Path.Join(projectRoot.FullName, CliConstants.CmfAppFileName));
-                if (!cmfAppFile.Exists)
-                {
-                    throw new CliException($"{CliConstants.CmfAppFileName} not found!");
-                }
-
-                var appFileContent = cmfAppFile.ReadToString();
-                var appData = JsonConvert.DeserializeObject<AppData>(appFileContent);
+                var appData = ExecutionContext.Instance.AppData ??
+                    throw new CliException("Could not retrieve repository AppData.");
                 var appName = appData.id;
 
                 var servePathArgument = $" --allowed-hosts host.docker.internal --serve-path /apps/{appName}/";

--- a/cmf-cli/Constants/CliConstants.cs
+++ b/cmf-cli/Constants/CliConstants.cs
@@ -49,11 +49,6 @@ namespace Cmf.CLI.Constants
         public const string CmfPackageFileName = "cmfpackage.json";
 
         /// <summary>
-        /// The CMF app file name
-        /// </summary>
-        public const string CmfAppFileName = "cmfapp.json";
-
-        /// <summary>
         /// The assets folder
         /// </summary>
         public const string AssetsFolder = "assets";

--- a/cmf-cli/Handlers/PackageType/RootPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/RootPackageTypeHandler.cs
@@ -4,12 +4,12 @@ using System.Linq;
 using System.Xml.Linq;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
+using Cmf.CLI.Core.Constants;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Core.Objects.CmfApp;
 using Cmf.CLI.Core.Utilities;
 using Cmf.CLI.Utilities;
-using Newtonsoft.Json;
 
 
 namespace Cmf.CLI.Handlers
@@ -59,17 +59,8 @@ namespace Cmf.CLI.Handlers
         /// <exception cref="CliException"></exception>
         internal virtual void GenerateAppFiles(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir)
         {
-            IFileInfo cmfAppFile = fileSystem.FileInfo.New(CliConstants.CmfAppFileName);
-            if (!cmfAppFile.Exists)
-            {
-                Log.Debug($"{CliConstants.CmfAppFileName} not found! No need to generate app manifest");
-                return;
-            }
-
-            string appFileContent = cmfAppFile.ReadToString();
-
-            var appData = JsonConvert.DeserializeObject<AppData>(appFileContent);
-
+            var appData = ExecutionContext.Instance.AppData ??
+                throw new CliException("Could not retrieve repository AppData.");
             Log.Debug("Generating App manifest");
 
             // Get Template
@@ -181,7 +172,7 @@ namespace Cmf.CLI.Handlers
             }
             else if (!AppIconUtilities.IsIconValid(appData.icon))
             {
-                throw new CliException(string.Format(CoreMessages.InvalidValue, CliConstants.CmfAppFileName));
+                throw new CliException(string.Format(CoreMessages.InvalidValue, CoreConstants.CmfAppFileName));
             }
 
             string iconSource = appData.icon;

--- a/cmf-cli/resources/template_feed/business/from900/.template.config/template.json
+++ b/cmf-cli/resources/template_feed/business/from900/.template.config/template.json
@@ -71,6 +71,12 @@
       "defaultValue": "False",
       "description": "Indicates that repository type is app if true"
     },
+    "licensedAppName": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "<%= $CLI_PARAM_LicensedAppName %>",
+      "fileRename": "%LicensedAppName%"
+    },
     "fileVersion": {
       "type": "parameter",
       "datatype": "string",

--- a/cmf-cli/resources/template_feed/business/from900/Business.Package/ApplicationVersion/Version.csproj
+++ b/cmf-cli/resources/template_feed/business/from900/Business.Package/ApplicationVersion/Version.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<TargetFramework><%= $CLI_PARAM_TargetFramework %></TargetFramework>
 		<AssemblyTitle>ApplicationVersion</AssemblyTitle>
-		<Product><%= $CLI_PARAM_Tenant %></Product>
+		<Product><%= $CLI_PARAM_LicensedAppName %></Product>
 		<AssemblyName>Cmf.<%= $CLI_PARAM_idSegment %>.ApplicationVersion</AssemblyName>
 		<RootNamespace>Cmf.<%= $CLI_PARAM_idSegment %>.ApplicationVersion</RootNamespace>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -17,7 +17,5 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Cmf.Foundation.ApplicationVersion" Version="<%= $CLI_PARAM_MESVersion %>" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
-		<PackageReference Include="System.Composition.AttributedModel" Version="7.0.0" />
 	</ItemGroup>
 </Project>

--- a/cmf-cli/resources/template_feed/business/from900/Business.Package/Business.sln
+++ b/cmf-cli/resources/template_feed/business/from900/Business.Package/Business.sln
@@ -16,7 +16,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cmf.Custom.<%= $CLI_PARAM_i
 	EndProjectSection
 EndProject
 #if (app)
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Version", "ApplicationVersion\Version.csproj", "{2F05799E-8030-4B25-98B7-2BACF606E7B1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Version", "ApplicationVersion\Version.csproj", "{7A42A73B-81C3-442C-880B-090B85FC8635}"
 EndProject
 #endif
 Global
@@ -37,6 +37,12 @@ Global
 		{4F4342A5-3D64-4D54-B83B-368F768E2A95}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F4342A5-3D64-4D54-B83B-368F768E2A95}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F4342A5-3D64-4D54-B83B-368F768E2A95}.Release|Any CPU.Build.0 = Release|Any CPU
+		#if (app)
+		{7A42A73B-81C3-442C-880B-090B85FC8635}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7A42A73B-81C3-442C-880B-090B85FC8635}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7A42A73B-81C3-442C-880B-090B85FC8635}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7A42A73B-81C3-442C-880B-090B85FC8635}.Release|Any CPU.Build.0 = Release|Any CPU
+		#endif
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/core/Objects/ExecutionContext.cs
+++ b/core/Objects/ExecutionContext.cs
@@ -1,14 +1,12 @@
 using Cmf.CLI.Core.Interfaces;
-using Cmf.CLI.Core.Repository.Credentials;
 using Cmf.CLI.Utilities;
 using Core.Objects;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.TemplateEngine.Utils;
-using System;
 using System.Collections.Generic;
 using System.IO.Abstractions;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Cmf.CLI.Core.Objects.CmfApp;
 
 namespace Cmf.CLI.Core.Objects
 {
@@ -39,6 +37,11 @@ namespace Cmf.CLI.Core.Objects
         /// the current repository's project config
         /// </summary>
         public ProjectConfig ProjectConfig { get; private set; }
+        
+        /// <summary>
+        /// The current repository app data (only applicable for repositories of type App)
+        /// </summary>
+        public AppData AppData { get; } 
 
         /// <summary>
         /// Get the current (executing) version of the CLI
@@ -46,7 +49,7 @@ namespace Cmf.CLI.Core.Objects
         public static string CurrentVersion => (ServiceProvider.GetService<IVersionService>()!.CurrentVersion) ?? "dev";
 
         /// <summary>
-        /// Get or set the latest vetsion of the CLI. Use this if the CLI checks for new versions
+        /// Get or set the latest version of the CLI. Use this if the CLI checks for new versions
         /// </summary>
         public static string LatestVersion { get; set; }
 
@@ -93,6 +96,7 @@ namespace Cmf.CLI.Core.Objects
             // private constructor, can only obtain instance via the Instance property
             this.fileSystem = fileSystem;
             this.RepositoriesConfig = FileSystemUtilities.ReadRepositoriesConfig(fileSystem);
+            this.AppData = FileSystemUtilities.ReadAppData(fileSystem);
             if (ServiceProvider != null)
             {
                 IProjectConfigService pcs = ServiceProvider.GetService<IProjectConfigService>();

--- a/core/Utilities/FileSystemUtilities.cs
+++ b/core/Utilities/FileSystemUtilities.cs
@@ -12,6 +12,7 @@ using Cmf.CLI.Core;
 using Cmf.CLI.Core.Constants;
 using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
+using Cmf.CLI.Core.Objects.CmfApp;
 
 namespace Cmf.CLI.Utilities
 {
@@ -357,6 +358,36 @@ namespace Cmf.CLI.Utilities
             }
 
             return repoConfig;
+        }
+
+        /// <summary>
+        /// Reads the AppData from the repository. 
+        /// </summary>
+        /// <param name="fileSystem"></param>
+        /// <returns></returns>
+        public static AppData ReadAppData(IFileSystem fileSystem)
+        {
+            IDirectoryInfo projectRoot = GetProjectRoot(fileSystem);
+
+            if (projectRoot == null)
+            {
+                Log.Debug("Running outside a repository.");
+                return null;
+            }
+            
+            IFileInfo cmfAppFile = fileSystem.FileInfo.New(
+                fileSystem.Path.Join(projectRoot.FullName, CoreConstants.CmfAppFileName));
+
+            if (!cmfAppFile.Exists)
+            {
+                Log.Debug($"{CoreConstants.CmfAppFileName} not found.");
+                return null;
+            }
+            
+            var appFileContent = cmfAppFile.ReadToString();
+            var appData = JsonConvert.DeserializeObject<AppData>(appFileContent);
+
+            return appData;
         }
 
         /// <summary>

--- a/tests/Fixtures/app/cmfapp.json
+++ b/tests/Fixtures/app/cmfapp.json
@@ -1,0 +1,8 @@
+{
+  "id": "APP_ID",
+  "name": "APP_NAME",
+  "author": "APP_AUTHOR",
+  "description": "APP_DESCRIPTION",
+  "licensedApplication": "LICENSED_APP_NAME",
+  "icon": "assets/icon.png"
+}

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -69,13 +69,15 @@ namespace tests.Specs
                 extraArguments: appContext ? new[] { "--addApplicationVersionAssembly" } : null,
                 extraAsserts: args =>
                 {
-                    var (pkgVersion, dir) = args;
                     Assert.True(File.Exists($"Cmf.Custom.Business/Cmf.Custom.Common/tenantConstants.cs"), "Constants file is missing or has wrong name");
                     Assert.True(File.Exists($"Cmf.Custom.Business/Cmf.Custom.Common/Cmf.Custom.tenant.Common.csproj"), "Common project file is missing or has wrong name");
                 
                     if (appContext)
                     {
-                        Assert.True(File.Exists($"Cmf.Custom.Business/ApplicationVersion/Version.csproj"), "Version file is missing or has wrong name");
+                        Assert.True(File.Exists("Cmf.Custom.Business/ApplicationVersion/Version.csproj"), "Version file is missing or has wrong name");
+                        
+                        var versionCsproj = File.ReadAllText("Cmf.Custom.Business/ApplicationVersion/Version.csproj");
+                        versionCsproj.Should().Contain("<Product>LICENSED_APP_NAME</Product>");
                     }
                     else
                     {
@@ -931,6 +933,11 @@ namespace tests.Specs
                     .Replace("backup_share", MockUnixSupport.Path(@"y:\backup_share").Replace(@"\", @"\\"))
                     .Replace("temp_folder", MockUnixSupport.Path(@"z:\temp_folder").Replace(@"\", @"\\"))
                 );
+            }
+
+            if (repositoryType == RepositoryType.App)
+            {
+                TestUtilities.CopyFixture("app", new DirectoryInfo(dir));
             }
         }
     }

--- a/tests/Specs/Pack.cs
+++ b/tests/Specs/Pack.cs
@@ -25,6 +25,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Xml.Linq;
+using Cmf.CLI.Core.Constants;
 using tests.Objects;
 using Xunit;
 
@@ -531,11 +532,11 @@ namespace tests.Specs
 
                 DirectoryInfo curDir = new(System.IO.Directory.GetCurrentDirectory());
 
-                Assert.True(File.Exists($"{dir}/{CliConstants.CmfAppFileName}"), $"Root {CliConstants.CmfAppFileName} is missing");
+                Assert.True(File.Exists($"{dir}/{CoreConstants.CmfAppFileName}"), $"Root {CoreConstants.CmfAppFileName} is missing");
 
                 Assert.False(Directory.Exists($"{dir}/Package"), "Package folder exists");
 
-                Assert.False(File.Exists($"{featureDir}/{CliConstants.CmfAppFileName}"), $"Feature {CliConstants.CmfAppFileName} exists");
+                Assert.False(File.Exists($"{featureDir}/{CoreConstants.CmfAppFileName}"), $"Feature {CoreConstants.CmfAppFileName} exists");
 
                 Assert.True(Directory.Exists($"{featureDir}/Package"), "Package folder is missing");
 


### PR DESCRIPTION
This pull request updates the application version `.csproj` template to be correctly included in the resulting solution and also to include the correct licensed application name instead of the tenant name. This change affects only Business packages created in a repository of type App.

Side changes:
- A AppData property was created in the ExecutionContext to avoid repeated code across the codebase
- Unit Tests were updated to include cmfapp.json file