### PR TITLE
fix: publishing clickhouse backup packages

### DIFF
--- a/core/Enums/StepType.cs
+++ b/core/Enums/StepType.cs
@@ -84,7 +84,15 @@
         /// Sync Automation Business Scenarios libraries
         /// </summary>
         AutomationBusinessScenariosSync = 15,
+
+        RestoreDatabaseFromBackup = 16,
+
+        UploadToS3 = 17,
+
+        RunClickhouseSql = 18,
+
+        ReconstructClickhouseKafkaTables = 19,
         
-        RestoreDatabaseFromBackup = 16
+        CleanupS3InstallationFolder = 20,
     }
 }

--- a/core/Objects/NPMClient.cs
+++ b/core/Objects/NPMClient.cs
@@ -237,6 +237,8 @@ namespace Cmf.CLI.Core.Objects
 
             if (!versions.ContainsKey(version))
             {
+                Log.Debug($"Could not get package {packageName}@{version} from {this.baseUrl}: no matching version found.");
+
                 return null;
             }
             

--- a/core/Repository/NPMRepositoryClient.cs
+++ b/core/Repository/NPMRepositoryClient.cs
@@ -29,11 +29,20 @@ public class NPMRepositoryClient : IRepositoryClient
         try
         {
             var pkg = await client.FetchPackageVersion(packageId.ToLowerInvariant(), version);
-            pkg.Client = this;
+
+            if (pkg != null)
+            {
+                pkg.Client = this;
+            }
+
             return pkg;
         }
-        catch (Exception)
+        catch (Exception ex)
         {
+            // TODO Should we remove this catch? The handling for "not finding" a package seems to
+            //      be done by returning null. Handling any other failures (network, etc...)
+            //      should be done higher in the code, not hidden from the user, maybe?
+            Log.Debug($"Error finding package {packageId}@{version}: {ex.Message}");
             return null;
         }
     }

--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -1575,7 +1575,6 @@ public class CmfPackageController
                 //         jsonManifestStream.Seek(0, SeekOrigin.Begin);
                 //     }
                 // }
-                continue;
             }
             
             

--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -116,53 +116,6 @@ public class CmfPackageController
             using GZipStream gzipStream = new GZipStream(zipToOpen, CompressionMode.Decompress);
             var foundManifest = false;
 
-            #region .NET TarReader
-
-            // Disabled because, on .NET 8, when opening ClickHouse backup archives, this code would throw a 
-            // System.IO.InvalidDataException: Unable to parse number
-            // From a cursory look, seems to be related to https://github.com/dotnet/runtime/pull/101172
-
-            // using TarReader tarReader = new(gzipStream);
-            // while (tarReader.GetNextEntry() is { } entry)
-            // {
-            //     // Check if this is the file you're looking for
-            //     if ((entry.Name == CoreConstants.DeploymentFrameworkManifestFileName || entry.Name == $"package/{CoreConstants.DeploymentFrameworkManifestFileName}") && entry.EntryType == TarEntryType.V7RegularFile)
-            //     {
-            //         foundManifest = true;
-            //         // Read the content of the file inside the TAR
-            //         using var reader = new StreamReader(entry.DataStream);
-
-            //         // TODO: make sure this is ok
-            //         // this.package = CmfPackageController.FromXmlManifest(reader.ReadToEnd(), setDefaultValues: true);
-            //         this.package = CmfPackageController.FromXml(XDocument.Parse(reader.ReadToEnd()));
-            //         break;
-            //     }
-            // }
-
-            // if (!foundManifest)
-            // {
-            //     using Stream zipToOpen2 = file.OpenRead();
-            //     using GZipStream gzipStream2 = new GZipStream(zipToOpen2, CompressionMode.Decompress);
-            //     using TarReader tarReader2 = new(gzipStream2);
-            //     while (tarReader2.GetNextEntry() is { } entry)
-            //     {
-            //         // Check if this is the file you're looking for
-            //         if ((entry.Name == "package.json" || entry.Name == $"package/package.json" )&& entry.EntryType == TarEntryType.V7RegularFile)
-            //         {
-            //             foundManifest = true;
-            //             // Read the content of the file inside the TAR
-            //             using var reader = new StreamReader(entry.DataStream);
-
-            //             // TODO: make sure this is ok
-            //             // this.package = CmfPackageController.FromXmlManifest(reader.ReadToEnd(), setDefaultValues: true);
-            //             this.package = CmfPackageController.FromJson(reader.ReadToEnd());
-            //             break;
-            //         }
-            //     }
-            // }
-
-            #endregion .NET TarReader
-
             using var tarReader = SharpCompress.Readers.Tar.TarReader.Open(gzipStream, new SharpCompress.Readers.ReaderOptions { });
             while (tarReader.MoveToNextEntry())
             {


### PR DESCRIPTION
When trying to publish clickhouse types, the CLI did not support all the needed step types:
<img width="1657" height="202" alt="imagem" src="https://github.com/user-attachments/assets/2ee06bae-819f-4ea8-b173-daa21f4cd62d" />

After adding the missing step types, a new issue popped up when reading the `*.tgz` files. This was strange because these `*.tgz` files were created by the CLI itself, based on the `*.zip` files downloaded from the envmanager. It seems like the issue was using `SharpCompress.Writers.Tar.TarWriter` to create the files, but then using `System.Formats.Tar.TarReader` to read them.
<img width="1474" height="541" alt="imagem" src="https://github.com/user-attachments/assets/05e64df7-e7fa-4f2a-8523-9b54e7155f2c" />

The issue seems to have been fixed in https://github.com/dotnet/runtime/pull/101172, which by the looks of it, has not been backported to .NET 8. So instead, I rewrote the code using `SharpCompress.Readers.Tar.TarReader`.

There are still a lot of places that use `System.Formats.Tar.TarReader`. In an ideal world, I think we should choose one library and use it for all reads and writes, to try and avoid incompatibility issues like this as much as possible.

EDIT: I have also included some small separate commits to fix a different but related issue regarding downloading SQL and ClickHouse backup files, respectively.