### PR TITLE
fix: skip folder entries when converting zip to tgz

### DIFF
--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -1495,6 +1495,15 @@ public class CmfPackageController
                 foreach (ZipArchiveEntry zipEntry in zipArchive.Entries)
                 {
                     var entryName = zipEntry.FullName;
+
+                    // The ZIP spec does not have a specific flag for determining if an entry is a file or folder
+                    // Taking as an example the SharpZipLib, the way they validate that is by checking he last character
+                    // of the full name, and validating if it is a path separator
+                    if (entryName.EndsWith("\\") || entryName.EndsWith("/"))
+                    {
+                        continue;
+                    }
+
                     // Open the entry stream from the Zip archive
                     using (Stream zipEntryStream = zipEntry.Open())
                     {


### PR DESCRIPTION
I found a bug when converting `.zip` packages created with, for example, Windows Explorer, to `.tgz`. If the `.zip` has any folders inside, like so:
<img width="976" height="248" alt="imagem" src="https://github.com/user-attachments/assets/67351375-6c01-45e1-8b6f-0a3aff2f74e9" />

Our code is creating the folders as files, resulting in invalid `.tgz` archives.
<img width="766" height="250" alt="imagem" src="https://github.com/user-attachments/assets/ee62af70-c21b-4a8c-9e57-ec4f2e9ddfb9" />

Although this issue **does not happen when packages are generated with our `cmf pack`** (the way packages are supposed to be generated), this change makes package conversion more resilient and avoids potential future issues.