### PR TITLE
fix: load derived credentials for internal repo operations

### DIFF
--- a/core/Repository/Credentials/PortalRepositoryCredentials.cs
+++ b/core/Repository/Credentials/PortalRepositoryCredentials.cs
@@ -113,7 +113,7 @@ namespace Cmf.CLI.Core.Repository.Credentials
                 if (cred.Repository == CmfAuthConstants.PortalRepository)
                 {
                     string[] cmfDomainListWithExtras = [..CmfDomainList, ..Environment.GetEnvironmentVariable("cmf_cli_derived_credentials_domain_list")?.Split(',') ?? []];
-                    Uri[] repositoriesToCheck = [ExecutionContext.Instance?.RepositoriesConfig?.CIRepository, ..ExecutionContext.Instance?.RepositoriesConfig?.Repositories];
+                    Uri[] repositoriesToCheck = [ExecutionContext.Instance?.RepositoriesConfig?.CIRepository, ..ExecutionContext.Instance?.RepositoriesConfig?.Repositories ?? []];
                     var derivedUrls = repositoriesToCheck.ToList().Where(url =>
                         cmfDomainListWithExtras.Contains(url?.Host)
                     );

--- a/core/Services/RepositoryAuthStore.cs
+++ b/core/Services/RepositoryAuthStore.cs
@@ -333,6 +333,7 @@ namespace Cmf.CLI.Core.Services
             if (_cachedAuthFile == null)
             {
                 _cachedAuthFile = await Load();
+                AddDerivedCredentials(_cachedAuthFile);
             }
 
             return _cachedAuthFile;


### PR DESCRIPTION
When we run `cmf login` or `cmf login sync`, we are automatically authenticating against the CM's Customer Portal, and also on all official CM repositories (Docker, NPM, NuGet, etc....).

The way this is implemented, since the credentials for all repositories are the same as the credentials for the Customer Portal, is by storing on the `.cmf-auth.json` file only the portal credentials.

The repository credentials are then derived from these in real time. We had a bug however, that we were not deriving them in memory when they were needed to be used by the internal NPM client used by the CLI to download packages, etc...