### PR TITLE
fix: skip root package entry when converting tgz to zip

### DIFF
--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -1575,6 +1575,14 @@ public class CmfPackageController
             // Check for the "package" folder and strip it out
             string packageFolderName = "package/";
 
+            // If the tar file has an entry just for the "package/" folder, we simply skip that entry,
+            // because the folder itself will never be a part of the converted zip, only the files/sub-folders
+            // inside of it
+            if (entry.Name == packageFolderName)
+            {
+                continue;
+            }
+
             // Iterate through the files in the TAR archive
             // If the file is in the "package" folder, strip it
             var entryName = entry.Name.StartsWith(packageFolderName) ? entry.Name.Substring(packageFolderName.Length) : entry.Name;


### PR DESCRIPTION
If the tgz file downloaded by the NPM Repository Client has an entry for the `package/` folder, since we are removing that portion of the name, it ends up being just an empty string `""`.
<img width="990" height="141" alt="imagem" src="https://github.com/user-attachments/assets/7e409e58-5be5-4620-a511-ac1f72a34f89" />
Which ends up causing the error below, when converting the package to a `.zip` file:
<img width="1634" height="263" alt="imagem" src="https://github.com/user-attachments/assets/5542e7b3-9975-4106-b86b-e3db4d6c965a" />

Not all files trigger this, some tar archives do not have a specific entry for this folder. It seems like it's mostly manually generated `.tgz` files that do (by using the `tar` shell command, for example), but it is still safer to validate since it is a logical bug to be able to create an entry with an empty name `""` anyways.