### PR TITLE
fix(core): re-calculate derived credentials after loading repository URLs

### DIFF
--- a/core/Interfaces/IRepositoryAuthStore.cs
+++ b/core/Interfaces/IRepositoryAuthStore.cs
@@ -34,6 +34,12 @@ namespace Cmf.CLI.Core.Interfaces
         /// <returns></returns>
         Task<CmfAuthFile> GetOrLoad();
 
+        /// <summary>
+        /// Resets the auth file cached in memory, forcing the next call to <see cref="GetOrLoad"/>
+        /// to re-load the credentials from disk.
+        /// </summary>
+        void Unload();
+
         Task<CmfAuthFile> Save(IList<ICredential> credentials, bool sync = true);
     }
 }

--- a/core/Objects/ExecutionContext.cs
+++ b/core/Objects/ExecutionContext.cs
@@ -96,6 +96,11 @@ namespace Cmf.CLI.Core.Objects
             // private constructor, can only obtain instance via the Instance property
             this.fileSystem = fileSystem;
             this.RepositoriesConfig = FileSystemUtilities.ReadRepositoriesConfig(fileSystem);
+
+            // Make sure the cached credentials are reset, to recalculate the derived credentials
+            var authStore = ServiceProvider?.GetService<IRepositoryAuthStore>();
+            authStore?.Unload();
+
             this.AppData = FileSystemUtilities.ReadAppData(fileSystem);
             if (ServiceProvider != null)
             {

--- a/core/Services/RepositoryAuthStore.cs
+++ b/core/Services/RepositoryAuthStore.cs
@@ -338,6 +338,12 @@ namespace Cmf.CLI.Core.Services
 
             return _cachedAuthFile;
         }
+        
+        /// <inheritdoc/>
+        public void Unload()
+        {
+            _cachedAuthFile = null;
+        }
 
         public async Task<CmfAuthFile> Save(IList<ICredential> credentials, bool sync = true)
         {
@@ -366,7 +372,7 @@ namespace Cmf.CLI.Core.Services
                 authFile.Repositories = credentialsByRepo
                     .ToDictionary(group => group.Key.RepositoryType, group => new CmfAuthFileRepositoryType { Credentials = group.Value });
                 AddDerivedCredentials(authFile);
-                
+
                 foreach (var (repoType, repoCredentials) in authFile.Repositories)
                 {
                     await GetRepositoryType(repoType).SyncCredentials(repoCredentials.Credentials);


### PR DESCRIPTION
When running commands that required access to derived credentials (like trying to do `cmf publish` on a `cm-collaborationhub.io` repo), the derived credentials were not being taken into account.

That is because repository clients (like the NPM client) relied on the `IRepositoryAuthStore.GetOrLoad()` method to retrieve the list of credentials, and this method caches said list in memory. This is fine, as long as the list of credentials is first loaded **after** the list of repository URLs (usually read from the `repositories.json` file) is loaded (since the derived credentials are generated based on those repositories).

It just so happens that the code that does the version check (to see if there is a newer version available) uses the same class (`NPMClient`) as the repository clients, and does that at the very beginning of the application (before the `repositories.json` has been loaded). This meant that the credentials file was being cached without some of the derived credentials that it should have.