### PR TITLE
feat(telemetry): improve telemetry startup time.

### DIFF
--- a/tests/Mocks/MockTelemetryService.cs
+++ b/tests/Mocks/MockTelemetryService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Cmf.CLI.Core.Objects;
 using OpenTelemetry.Trace;
 
@@ -28,4 +29,6 @@ public class MockTelemetryService : ITelemetryService
     public ActivitySource InitializeActivitySource() => null;
 
     public void LogException(Exception exception) { }
+
+    public Task<TracerProvider> InitializeTracerProviderAsync(string serviceName, string version) => null;
 }


### PR DESCRIPTION
**This pull request is an improvement of the slow startup affecting cmf-pipeline and other plugins.** 

- Without any changes we have the best scenario possible sitting at 9 seconds approx (this jumps to 20 in heavy loads). This is considering a scenario where we are using "cmf-pipeline --help". 

   <img width="249" height="90" alt="image" src="https://github.com/user-attachments/assets/d570f2c9-6627-4dc8-8843-4a1ef17f3bb3" />

- Removing versionCheck() (which takes about 3~5 seconds) isn't an option since we want to have warnings about the version in the beggining of our startup, the telemetry was analyzed to understand deeply what was causing so much delay.
- It was concluded that the telemetry tracer provider was stopping the thread from executing other actions and this provider setup would take anywhere from 3 to 6 seconds to start (in heavy cases maybe more) this time would sum up to the already versioncheck which had to be sync.
- The improvement was to make the tracer provider async, allowing the system to execute other actions while provider loaded. Once we reach the end of the configure function, we verify if the provider is ready, if not we wait until finish. This is made purposely to avoid pluggins calling the StartActivity() without having a provider since we would lose valuable telemetry information.
  <img width="150" height="54" alt="image" src="https://github.com/user-attachments/assets/3ebff4c2-5a89-4a5d-9678-4241a4e8dce6" />
  
- It is important to understand that the metric values used for performance can vary a lot depending on network and other factors.
- A unit test was made to simulate the plugin behavior to ensure that not waiting for version check would stop the configure() in a way that only when the provider is ready we can call startActivity safely.





