### PR TITLE
feat: include old-system-name in step and log unknown step attributes

### DIFF
--- a/core/Objects/Step.cs
+++ b/core/Objects/Step.cs
@@ -87,6 +87,15 @@ namespace Cmf.CLI.Core.Objects
         /// </value>
         [JsonProperty(Order = 9)]
         public string TargetDatabase { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the old system name.
+        /// </summary>
+        /// <value>
+        /// The old system name.
+        /// </value>
+        [JsonProperty(Order = 11)]
+        public string OldSystemName { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the message.
@@ -188,6 +197,10 @@ namespace Cmf.CLI.Core.Objects
         /// <param name="filePath">The file path.</param>
         /// <exception cref="ArgumentNullException">type</exception>
         public Step(StepType? type, string title, string onExecute, string contentPath, string file, bool? tagFile, string targetDatabase, MessageType? messageType, string relativePath, string filePath)
+            : this(type, title, onExecute, contentPath, file, tagFile, targetDatabase, messageType, relativePath, filePath, null)
+        { }
+        
+        public Step(StepType? type, string title, string onExecute, string contentPath, string file, bool? tagFile, string targetDatabase, MessageType? messageType, string relativePath, string filePath, string oldSystemName)
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             Title = title;
@@ -199,6 +212,7 @@ namespace Cmf.CLI.Core.Objects
             MessageType = messageType;
             RelativePath = relativePath;
             FilePath = filePath;
+            OldSystemName = oldSystemName;
         }
 
         /// <summary>
@@ -241,7 +255,8 @@ namespace Cmf.CLI.Core.Objects
                    TargetDatabase == other.TargetDatabase &&
                    MessageType == other.MessageType &&
                    RelativePath == other.RelativePath &&
-                   FilePath == other.FilePath;
+                   FilePath == other.FilePath &&
+                   OldSystemName == other.OldSystemName;
         }
 
         #endregion

--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -32,6 +32,18 @@ public class CmfPackageController
     private IFileSystem fileSystem;
 
     public CmfPackageV1 CmfPackage => this.package; 
+
+    public static readonly IReadOnlyList<string> KnownStepAttributes =
+    [
+        "type",
+        "title",
+        "onExecute",
+        "contentPath",
+        "tagFile",
+        "targetDatabase",
+        "filePath",
+        "oldSystemName"
+    ];
     
     public CmfPackageController(CmfPackageV1 package, IFileSystem fileSystem)
     {
@@ -234,6 +246,17 @@ public class CmfPackageController
     }
     
     
+    private static void LogUnknownAttributes(XElement element, IEnumerable<string> knownAttributes = null)
+    {
+        knownAttributes ??= [];
+        var allAttributes = element.Attributes().Select(a => a.Name.LocalName);
+
+        var unknownAttributes = allAttributes.Except(knownAttributes).ToList();
+        if (unknownAttributes.Count > 0)
+        {
+            Log.Debug($"Step (type: {element.Attribute("type")?.Value}) has unknown attributes. Attributes: {string.Join(", ", unknownAttributes)}");
+        }
+    }
     
     private static CmfPackageV1 FromXmlManifest(string manifest, bool setDefaultValues = false)
     {
@@ -344,6 +367,8 @@ public class CmfPackageController
             {
                 foreach (var element in stepsElements)
                 {
+                    LogUnknownAttributes(element, KnownStepAttributes);
+                    
                     Step step = new Step(
                         type: Enum.Parse(typeof(StepType), element.Attribute("type")?.Value) is StepType
                             ? (StepType)Enum.Parse(typeof(StepType), element.Attribute("type")?.Value)


### PR DESCRIPTION
The issue was found on clickhouse backup packages downloaded from envmanager as zip and published as tgz by cli.
When they were published to NPM repository, the cli would convert the zip into the tgz and generate a `package.json` based on the `manifest.xml`, but one attribute `oldSystemName` was not being considered.

The publish was not considering the old-system-name.
Also, added a log including all unknown attributes:

Sample output (note: unknownAttr was mine for testing purposes):

```
  Using @criticalmanufacturing/cli version 5.7.0+db6b4b28b49492302927a18d501285f8bdf38a94 while 5.7.0 is available. Please update.
  Got client ArchiveRepositoryClient for package file /workspaces/cli/repo/CollabHub-Vandewiele-001.Cmf.ClickHouse.FullBackup.Online.zip
  Got client NPMRepositoryClient for repository URL https://cm-collaborationhub.io/api/npm/2409250000050000002/dev
  Publishing package with target repository client...
  Spinning up a controller for a CmfPackage file info: /workspaces/cli/repo/CollabHub-Vandewiele-001.Cmf.ClickHouse.FullBackup.Online.zip
  File is a DF package in ZIP format
  Step (type: RunClickhouseSql) has unknown attributes. Attributes: replaceTokens
  Step (type: ReconstructClickhouseKafkaTables) has unknown attributes. Attributes: unknownAttr
  Downloading package CollabHub-Vandewiele-001.Cmf.ClickHouse.FullBackup.Online@11.2.1-54 to /tmp/...
  Done!
  Package at /workspaces/cli/repo/CollabHub-Vandewiele-001.Cmf.ClickHouse.FullBackup.Online.zip is in Zip format, converting to tgz at 
/workspaces/cli/repo/CollabHub-Vandewiele-001.Cmf.ClickHouse.FullBackup.Online.tgz...
  Step (type: RunClickhouseSql) has unknown attributes. Attributes: replaceTokens
  Step (type: ReconstructClickhouseKafkaTables) has unknown attributes. Attributes: unknownAttr
  Done!
  Publishing via NPMClient...
  Spinning up a controller for a CmfPackage file info: /workspaces/cli/repo/CollabHub-Vandewiele-001.Cmf.ClickHouse.FullBackup.Online.tgz
  This constructor can only be invoked from RepositoryClients!
  File is a DF package in TAR.GZ format
  Step (type: RunClickhouseSql) has unknown attributes. Attributes: replaceTokens
  Step (type: ReconstructClickhouseKafkaTables) has unknown attributes. Attributes: unknownAttr
  Trying to publish collabhub-vandewiele-001.cmf.clickhouse.fullbackup.online to https://cm-collaborationhub.io/api/npm/2409250000050000002/dev
  Load package content (streaming mode disabled)...
  Package content with hash sha512-4NvKVIFZSMBmN2afk0ZWMZ3j3fYk7Tx1bsWwVKT/4plPRfH3sWIUBN7F/DNfXZs2ajuDORKeTkyk1uUgs/FcBQ== and checksum a677f9d147d9b9acacbbe342a10878e181e44de3
  PUTing package to https://cm-collaborationhub.io/api/npm/2409250000050000002/dev...
  Publishing via NPMClient completed!
  Publish completed!
  ```