### PR TITLE
chore(init-tests): set up remote WebDriver configs

### DIFF
--- a/cmf-cli/resources/template_feed/test/Tests.Package/local.runsettings
+++ b/cmf-cli/resources/template_feed/test/Tests.Package/local.runsettings
@@ -34,7 +34,8 @@
 		<Parameter name="browser" value="chrome" />
 		<Parameter name="debug" value="false" />
 		<Parameter name="headless" value="false" /> <!-- on devcontainer use headless as `true` -->
-
+		<Parameter name="useRemoteWebDriver" value="false" />
+		<Parameter name="remoteWebDriverUrl" value="" />
 		<!-- Security Portal Authentication -->
 		<Parameter name="authenticateViaSecurityPortalToken" value="true" />
 		<Parameter name="securityPortalClientId" value="MES" />


### PR DESCRIPTION
This Pull Request adds the necessary configurations with default values to the initial scaffolding of the Cmf.Custom.Tests package, enabling the execution of tests using a remote WebDriver.

```xml
<Parameter name="useRemoteWebDriver" value="false" />
<Parameter name="remoteWebDriverUrl" value="" />
```