### PR TITLE
chore(init): replace DooD with DinD devcontainer feature

### DIFF
--- a/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
+++ b/cmf-cli/resources/template_feed/init/.devcontainer/devcontainer.json
@@ -1,18 +1,13 @@
 {
     "image": "criticalmanufacturing.io/criticalmanufacturing/devcontainer:<%= $CLI_PARAM_MESVersion-Major %>",
-    "runArgs": [
-        "--network",
-        "host"
-    ],
+    "runArgs": [],
     "features": {
         "ghcr.io/criticalmanufacturing/cli/install:1": {
             "version": "<%= $CLI_PARAM_CLIVersion-MajorRange %>"
         },
         "ghcr.io/criticalmanufacturing/portal-sdk/install:1": {},
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
-            // Bug in buildx originally tracked here: https://github.com/docker/buildx/issues/3328
-            // Until the devcontainer feature is updated to include the fix for this issue, we need to pin to an earlier version
-            "mobyBuildxVersion": "0.25.0"
+        "ghcr.io/devcontainers/features/docker-in-docker": {
+            "dockerDefaultAddressPool":"base=10.250.0.0/16,size=24"
         },
         "ghcr.io/kreemer/features/chrometesting": {}
     },
@@ -67,6 +62,6 @@
     },
     "forwardPorts": [
         80
-    ],
+    ],  
     "initializeCommand": "docker pull criticalmanufacturing.io/criticalmanufacturing/devcontainer:<%= $CLI_PARAM_MESVersion-Major %>"
 }


### PR DESCRIPTION
* Replace DooD with DinD.
* Remove the network host usage.
* Add subnetwork for DinD to avoid collisions
* No version of docker, as latest (29.1) already has API version:      1.51 (minimum version 1.24)