### PR TITLE
Update the `new html` command to work with version 12.0

### DIFF
--- a/cmf-cli/Utilities/CommandUtilities.cs
+++ b/cmf-cli/Utilities/CommandUtilities.cs
@@ -1,0 +1,16 @@
+
+using Cmf.CLI.Core.Objects;
+
+namespace Cmf.CLI.Utilities;
+
+public class CommandUtilities
+{
+    public static void ThrowIfNoProjectConfig(ExecutionContext context)
+    {
+        if (context.ProjectConfig == null)
+        {
+            throw new CliException(@"No project config found. Please make sure you're executing this command inside a valid CMF repository.
+You can init a repository with 'cmf init'.");
+        }
+    }
+}

--- a/cmf-cli/services/DependencyVersionService.cs
+++ b/cmf-cli/services/DependencyVersionService.cs
@@ -4,7 +4,7 @@ namespace Cmf.CLI.Services;
 
 public record AngularDeps
 {
-    public string CLI { get; init; }
+    public Version CLI { get; init; }
     public string Zone { get; init; }
     public string Typescript { get; init; }
     public string ESLint { get; init; }
@@ -16,10 +16,33 @@ public record AngularDeps
 /// </summary>
 public interface IDependencyVersionService
 {
-    string DotNetSdk(Version version);
-    string Node(Version version);
-    string AngularCLI(Version version);
-    AngularDeps Angular(Version version);
+    /// <summary>
+    /// Returns the expected .NET SDK version for the given product version
+    /// </summary>
+    /// <param name="productVersion">The product version to use</param>
+    /// <returns>String representing the .NET SDK version</returns>
+    string DotNetSdk(Version productVersion);
+    
+    /// <summary>
+    /// Returns the expected Node.js version for the given product version
+    /// </summary>
+    /// <param name="productVersion">The product version to use</param>
+    /// <returns>String representing the Node.js version</returns>
+    string Node(Version productVersion);
+
+    /// <summary>
+    /// Returns the expected Angular CLI major version for the given product version
+    /// </summary>
+    /// <param name="productVersion">The product version to use</param>
+    /// <returns>String representing the Angular CLI major version</returns>
+    string AngularCLI(Version productVersion);
+
+    /// <summary>
+    /// Returns the expected Angular dependencies for the given product version
+    /// </summary>
+    /// <param name="productVersion">The product version to use</param>
+    /// <returns>AngularDeps representing the Angular dependencies</returns>
+    AngularDeps Angular(Version productVersion);
 }
 
 /// <summary>
@@ -35,34 +58,52 @@ public class DependencyVersionService : IDependencyVersionService
     public const string NODE12 = "12.20.2";
     public const string NG15 = "15.2.1";
     public const string NG17 = "17.2.1";
+    public const string NG21 = "21.1.0";
     public const string NG15_ZONE = "0.12.0";
     public const string NG17_ZONE = "0.14.3";
+    public const string NG21_ZONE = "0.16.0";
     public const string NG15_TSESLINT = "5.44.0";
     public const string NG17_TSESLINT = "6.10.0";
+    public const string NG21_TSESLINT = "8.52.0";
     public const string NG15_ESLINT = "8.28.0";
     public const string NG17_ESLINT = "8.53.0";
+    public const string NG21_ESLINT = "9.39.2";
     public const string NG15_TS = "4.8.4";
     public const string NG17_TS = "5.3.3";
+    public const string NG21_TS = "5.9.3";
 
-    public string DotNetSdk(Version version) => version.Major > 10 ? NET8SDK : version.Major > 8 ? NET6SDK : NET3SDK;
-    public string Node(Version version) => version.Major > 10 ? NODE20 : version.Major > 9 ? NODE18 : NODE12;
+    public string DotNetSdk(Version productVersion) => productVersion.Major > 10 ? NET8SDK : productVersion.Major > 8 ? NET6SDK : NET3SDK;
+    public string Node(Version productVersion) => productVersion.Major > 10 ? NODE20 : productVersion.Major > 9 ? NODE18 : NODE12;
 
-    public AngularDeps Angular(Version version) => version.Major > 10
-        ? new AngularDeps()
+    public AngularDeps Angular(Version productVersion) =>
+        productVersion.Major switch
         {
-            CLI = NG17,
-            Zone = NG17_ZONE,
-            Typescript = NG17_TS,
-            ESLint = NG17_ESLINT,
-            TSESLint = NG17_TSESLINT
-        }
-        : new AngularDeps()
-        {
-            CLI = NG15,
-            Zone = NG15_ZONE,
-            Typescript = NG15_TS,
-            ESLint = NG15_ESLINT,
-            TSESLint = NG15_TSESLINT
+            <= 10 => new AngularDeps()
+            {
+                CLI = Version.Parse(NG15),
+                Zone = NG15_ZONE,
+                Typescript = NG15_TS,
+                ESLint = NG15_ESLINT,
+                TSESLint = NG15_TSESLINT
+            },
+            11 => new AngularDeps()
+            {
+                CLI = Version.Parse(NG17),
+                Zone = NG17_ZONE,
+                Typescript = NG17_TS,
+                ESLint = NG17_ESLINT,
+                TSESLint = NG17_TSESLINT
+            },
+            12 => new AngularDeps()
+            {
+                CLI = Version.Parse(NG21),
+                Zone = NG21_ZONE,
+                Typescript = NG21_TS,
+                ESLint = NG21_ESLINT,
+                TSESLint = NG21_TSESLINT
+            },
+            _ => throw new NotSupportedException($"No Angular dependencies defined for MES version {productVersion}")
         };
-    public string AngularCLI(Version version) => Version.Parse(this.Angular(version).CLI).Major.ToString();
+
+    public string AngularCLI(Version productVersion) => this.Angular(productVersion).CLI.Major.ToString();
 }


### PR DESCRIPTION
Update the new html command to work with MES version 12.0:
- Updated the Angular CLI version
- Updated the ngx-schematics version (check this [PR](https://github.com/criticalmanufacturing/ngx-schematics/pull/42) for more details)
- Fixed uncaught null reference exception by checking if the project config file is present (if not present we display a message suggesting that `cmf init` is run)