### PR TITLE
fix: performance tests template variables

### DIFF
--- a/cmf-cli/resources/template_feed/test/Tests.Package/Cmf.Custom.Tests.Performance/k6.env
+++ b/cmf-cli/resources/template_feed/test/Tests.Package/Cmf.Custom.Tests.Performance/k6.env
@@ -1,7 +1,14 @@
-K6_INSECURE_SKIP_TLS_VERIFY=true
+export K6_INSECURE_SKIP_TLS_VERIFY=true
 
 # These variables should be configured to point to the CM MES telemetry endpoint
-K6_OTEL_EXPORTER_PROTOCOL=http/protobuf
-K6_OTEL_HTTP_EXPORTER_INSECURE=true
-K6_OTEL_HTTP_EXPORTER_ENDPOINT=localhost:8082
-K6_OTEL_HTTP_EXPORTER_URL_PATH=/__internal/telemetry/http/v1/metrics
+export K6_OTEL_EXPORTER_PROTOCOL=http/protobuf
+export K6_OTEL_HTTP_EXPORTER_INSECURE=true
+export K6_OTEL_HTTP_EXPORTER_ENDPOINT=localhost
+export K6_OTEL_HTTP_EXPORTER_URL_PATH=/__internal/telemetry/http/v1/metrics
+
+
+# Required for authenticating k6 OpenTelemetry metric exports
+TOKEN=$(sed -n 's/.*"accessToken"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "./cmfLbo_config.json")
+BASE64_CREDENTIALS=$(printf '%s' "user:$TOKEN" | base64 -w 0 | tr -d '\n')
+
+export K6_OTEL_HEADERS="authorization=Basic $BASE64_CREDENTIALS"

--- a/cmf-cli/resources/template_feed/test/Tests.Package/Cmf.Custom.Tests.Performance/package.json
+++ b/cmf-cli/resources/template_feed/test/Tests.Package/Cmf.Custom.Tests.Performance/package.json
@@ -4,8 +4,8 @@
     "cmf-k6": "file:<%= $CLI_PARAM_output %>/Libs/LBOs/K6/cmf_k6/cmf-k6-0.0.1.tgz"
   },
   "scripts": {
-    "start": "set -a && . ./k6.env && set +a && k6 run",
-    "otel": "set -a && . ./k6.env && set +a && k6 run -o opentelemetry",
+    "start": ". ./k6.env && k6 run",
+    "otel": ". ./k6.env && k6 run -o opentelemetry",
     "all": "find Tests/*.ts -maxdepth 1 -type f -exec npm start {} \\;"
   }
 }


### PR DESCRIPTION
# Description
This PR corrects the k6 otel environment variables to allow proper login in the `new test` command.

# Changes
- Changed the environment variables for the `new test` command.