### PR TITLE
chore: add npm shrinkwrap to prepare script and include npm-shrinkwra…

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -3,7 +3,7 @@
   "version": "5.10.1",
   "description": "Critical Manufacturing command line client",
   "bin": {
-    "cmf": "./run.js"
+    "cmf": "run.js"
   },
   "scripts": {
     "prepare": "npm shrinkwrap",
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/criticalmanufacturing/cli#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/criticalmanufacturing/cli.git"
+    "url": "git+https://github.com/criticalmanufacturing/cli.git"
   },
   "files": [
     "dist",

--- a/npm/package.json
+++ b/npm/package.json
@@ -6,6 +6,7 @@
     "cmf": "./run.js"
   },
   "scripts": {
+    "prepare": "npm shrinkwrap",
     "postinstall": "node postinstall.js install",
     "preuninstall": "node postinstall.js uninstall",
     "test": "jest",
@@ -29,7 +30,8 @@
     "dist",
     "postinstall.js",
     "run.js",
-    "utils.js"
+    "utils.js",
+    "npm-shrinkwrap.json"
   ],
   "dependencies": {
     "adm-zip": "^0.5.12",


### PR DESCRIPTION
# **What was done**

- Generates shrinkwrap when publishing/packing to be included in the npm package.
- Fix npm warnings regarding package.json.

# **Validation checklist**

Test running npm pack:
```
> @criticalmanufacturing/cli@5.10.1 prepare
> npm shrinkwrap

npm warn shrinkwrap Converting lock file (npm-shrinkwrap.json) from v1 -> v3
npm notice package-lock.json has been renamed to npm-shrinkwrap.json and updated to version 3
npm notice
npm notice 📦  @criticalmanufacturing/cli@5.10.1
npm notice Tarball Contents
npm notice 454B README.md
npm notice 151.4kB npm-shrinkwrap.json
npm notice 1.5kB package.json
npm notice 7.1kB postinstall.js
npm notice 817B run.js
npm notice 2.9kB utils.js
npm notice Tarball Details
npm notice name: @criticalmanufacturing/cli
npm notice version: 5.10.1
npm notice filename: criticalmanufacturing-cli-5.10.1.tgz
npm notice package size: 46.1 kB
npm notice unpacked size: 164.2 kB
npm notice shasum: 62be416687c383dd4bbeab83703e1cf8e93a7164
npm notice integrity: sha512-CHUvFnfGybvqa[...]WAwGafALWYAJg==
npm notice total files: 6
npm notice
criticalmanufacturing-cli-5.10.1.tgz
```

Test running npm publish (before fix, after fix no warnings are shown):
```

> @criticalmanufacturing/cli@5.10.1 prepare
> npm shrinkwrap

npm notice npm-shrinkwrap.json up to date
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "bin[cmf]" script name run.js was invalid and removed
npm warn publish "repository.url" was normalized to "git+https://github.com/criticalmanufacturing/cli.git"
npm notice
npm notice 📦  @criticalmanufacturing/cli@5.10.1
npm notice Tarball Contents
npm notice 454B README.md
npm notice 151.4kB npm-shrinkwrap.json
npm notice 1.5kB package.json
npm notice 7.1kB postinstall.js
npm notice 817B run.js
npm notice 2.9kB utils.js
npm notice Tarball Details
npm notice name: @criticalmanufacturing/cli
npm notice version: 5.10.1
npm notice filename: criticalmanufacturing-cli-5.10.1.tgz
npm notice package size: 46.1 kB
npm notice unpacked size: 164.2 kB
npm notice shasum: 62be416687c383dd4bbeab83703e1cf8e93a7164
npm notice integrity: sha512-CHUvFnfGybvqa[...]WAwGafALWYAJg==
npm notice total files: 6
npm notice
npm warn This command requires you to be logged in to https://registry.npmjs.org/ (dry-run)
npm error You cannot publish over the previously published versions: 5.10.1.
npm error A complete log of this run can be found in: /root/.npm/_logs/2026-04-15T14_43_03_477Z-debug-0.log
```

