### PR TITLE
fix: pin mermaid version in help package

### DIFF
--- a/cmf-cli/resources/template_feed/help/from1000/Help.Package/package.json
+++ b/cmf-cli/resources/template_feed/help/from1000/Help.Package/package.json
@@ -42,7 +42,7 @@
     "lunr": "^2.3.9",
     "marked": "^4.1.1",
     "marked-katex": "^0.3.8",
-    "mermaid": "^9.1.3",
+    "mermaid": "9.1.3",
     "prismjs": "1.29.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.4.0",

--- a/cmf-cli/resources/template_feed/help/from1100/Help.Package/package.json
+++ b/cmf-cli/resources/template_feed/help/from1100/Help.Package/package.json
@@ -27,7 +27,7 @@
     "mermaid": "9.1.3"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^<%= $CLI_PARAM_ngVersion %>", 
+    "@angular-devkit/build-angular": "^<%= $CLI_PARAM_ngVersion %>",
     "@angular-eslint/schematics": "<%= $CLI_PARAM_ngVersion %>",
     "@angular/compiler-cli": "^<%= $CLI_PARAM_ngVersion %>",
     "@criticalmanufacturing/ngx-schematics": "<%= $CLI_PARAM_NGXSchematicsVersion %>",


### PR DESCRIPTION
# **What was done**

Since the error is:
```
 ./node_modules/mermaid/dist/mindmap-definition-44684416.js:4:0-56 - Error: Module not found: Error: "./dist/cytoscape.umd.js" is not exported under the 
conditions ["es2020","es2015","import","module","webpack","production","browser"] from package 
/home/runner/work/cli/cli/scaffolding-validation/Cmf.Custom.Help/node_modules/cytoscape (see exports field in 
/home/runner/work/cli/cli/scaffolding-validation/Cmf.Custom.Help/node_modules/cytoscape/package.json)

```
The package mermaid was pinned in the help package. 

# **Validation checklist**

Please ensure the following conditions are met in order for this PR to be merged:
* [ ] Code validation (careful with side-effects)
* [ ] Integration test run provided
* [ ] Main WorkItem is linked
* [ ] Target branch version is correct
