### PR TITLE
feat: simplify init command to better manage target MES version

### DIFF
--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -178,15 +178,17 @@ namespace Cmf.CLI.Commands
 
             var nugetVersionOption = new Option<string>("--nugetVersion")
             {
-                Description = "NuGet versions to target. This is usually the MES version",
-                Required = true
+                Description = "NuGet versions to target. Defaults to --MESVersion when not specified.",
+                Required = false,
+                DefaultValueFactory = argResult => { try { return argResult.GetValue(baseVersionOption); } catch { return null; } }
             };
             cmd.Add(nugetVersionOption);
 
             var testScenariosNugetVersionOption = new Option<string>("--testScenariosNugetVersion")
             {
-                Description = "Test Scenarios Nuget Version",
-                Required = true
+                Description = "Test Scenarios NuGet version. Defaults to --MESVersion when not specified.",
+                Required = false,
+                DefaultValueFactory = argResult => { try { return argResult.GetValue(baseVersionOption); } catch { return null; } }
             };
             cmd.Add(testScenariosNugetVersionOption);
 
@@ -357,6 +359,9 @@ namespace Cmf.CLI.Commands
         internal void Execute(InitArguments x)
         {
             using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
+
+            Log.Information($"Starting scaffolding for MES Version: {x.BaseVersion}");
+
             var args = new List<string>()
             {
                 // engine options
@@ -496,16 +501,20 @@ namespace Cmf.CLI.Commands
             args.AddRange(new [] {"--DevTasksVersion", x.DevTasksVersion ?? ""});
             args.AddRange(new [] {"--HTMLStarterVersion", x.HTMLStarterVersion ?? ""});
             args.AddRange(new [] {"--yoGeneratorVersion", x.yoGeneratorVersion ?? ""});
-            args.AddRange(new [] {"--ngxSchematicsVersion", x.ngxSchematicsVersion ?? ""});
 
-            if (x.nugetVersion != null)
+            if (string.IsNullOrWhiteSpace(x.ngxSchematicsVersion))
             {
-                args.AddRange(new [] {"--nugetVersion", x.nugetVersion});
+                var mesVer = Version.Parse(x.BaseVersion);
+                x.ngxSchematicsVersion = $"release-{mesVer.Major}{mesVer.Minor}{mesVer.Build}";
             }
-            if (x.testScenariosNugetVersion != null)
-            {
-                args.AddRange(new [] {"--testScenariosNugetVersion", x.testScenariosNugetVersion});
-            }
+
+            Log.Information($"Using ngx-schematics version: {x.ngxSchematicsVersion}");
+
+            args.AddRange(new [] {"--ngxSchematicsVersion", x.ngxSchematicsVersion});
+
+            args.AddRange(new [] {"--nugetVersion", x.nugetVersion});
+            
+            args.AddRange(new [] {"--testScenariosNugetVersion", x.testScenariosNugetVersion});
 
             #region infrastructure
 
@@ -567,10 +576,6 @@ namespace Cmf.CLI.Commands
                 throw new CliException("MES Versions under 10 are no longer supported with the newest version of the CLI. Please use cmf-cli 5.8.0 or lower.");
             }
 
-            if (string.IsNullOrWhiteSpace(x.ngxSchematicsVersion))
-            {
-                throw new CliException("--ngxSchematicsVersion is missing, please specify it.");
-            }
             #endregion
 
             if (x.config != null)

--- a/cmf-cli/Commands/new/HTMLCommand.cs
+++ b/cmf-cli/Commands/new/HTMLCommand.cs
@@ -86,10 +86,6 @@ namespace Cmf.CLI.Commands.New
         public void ExecuteV10(IDirectoryInfo workingDir, string version)
         {
             var ngxSchematicsVersion = ExecutionContext.Instance.ProjectConfig.NGXSchematicsVersion;
-            if (ngxSchematicsVersion == null)
-            {
-                throw new CliException("Seems like the repository scaffolding was run on a previous version of MES. Please re-init for versions 10+.");
-            }
 
             var baseLayer = ExecutionContext.Instance.ProjectConfig.BaseLayer ?? CliConstants.DefaultBaseLayer;
             this.baseWebPackage = baseLayer == BaseLayer.MES
@@ -108,7 +104,7 @@ namespace Cmf.CLI.Commands.New
             var packageName = base.GeneratePackageName(workingDir)!.Value.Item1;
             var packageDir = workingDir.GetDirectories(packageName).First();
 
-            var schematicsVersion = ngxSchematicsVersion.ToString() ?? $"@release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}";
+            var schematicsVersion = !string.IsNullOrEmpty(ngxSchematicsVersion) ? ngxSchematicsVersion : $"release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}";
 
             //After v11 we use Angular default routing
             var routing = mesVersion.Major >= 11 ? "true" : "false";
@@ -147,7 +143,7 @@ namespace Cmf.CLI.Commands.New
                     "add", "--registry", ExecutionContext.Instance.ProjectConfig.NPMRegistry.OriginalString,
                                       "--skip-confirmation", $"@criticalmanufacturing/ngx-schematics@{schematicsVersion}",
                                       "--eslint", "--application", baseLayer.ToString(),
-                                      "--version", $"release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}"
+                                      "--version", schematicsVersion
                 ],
                 WorkingDirectory = packageDir,
                 ForceColorOutput = false

--- a/cmf-cli/Commands/new/HelpCommand.cs
+++ b/cmf-cli/Commands/new/HelpCommand.cs
@@ -99,14 +99,10 @@ namespace Cmf.CLI.Commands.New
         {
             int majorVersion = ExecutionContext.Instance.ProjectConfig.MESVersion.Major;
             var ngxSchematicsVersion = ExecutionContext.Instance.ProjectConfig.NGXSchematicsVersion;
-            if (ngxSchematicsVersion == null)
-            {
-                throw new CliException("Seems like the repository scaffolding was run on a previous version of MES. Please re-init for versions 10+.");
-            }
 
             var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
 
-            this.schematicsVersion = ngxSchematicsVersion.ToString() ?? $"@release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}";
+            this.schematicsVersion = ngxSchematicsVersion ?? $"release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}";
 
             //Switch between v10 and v11 template 
             switch (majorVersion)

--- a/cmf-cli/Commands/new/IoTCommand.cs
+++ b/cmf-cli/Commands/new/IoTCommand.cs
@@ -178,11 +178,6 @@ namespace Cmf.CLI.Commands.New
 
             var ngxSchematicsVersion = ExecutionContext.Instance.ProjectConfig.NGXSchematicsVersion;
 
-            if (ngxSchematicsVersion == null)
-            {
-                throw new CliException("Seems like the repository scaffolding was run on a previous version of MES. Please re-init for versions 10+.");
-            }
-
             IDirectoryInfo htmlPackageDir = fileSystem.DirectoryInfo.New(htmlPackageLocation);
 
             if (!htmlPackageDir.Exists) throw new CliException(string.Format(CliMessages.SomePackagesNotFound, string.Join(", ", htmlPackageLocation)));
@@ -217,7 +212,7 @@ namespace Cmf.CLI.Commands.New
 
             var mesVersion = ExecutionContext.Instance.ProjectConfig.MESVersion;
 
-            var schematicsVersion = ngxSchematicsVersion.ToString() ?? $"@release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}";
+            var schematicsVersion = ngxSchematicsVersion ?? $"release-{mesVersion.Major}{mesVersion.Minor}{mesVersion.Build}";
 
             Log.Debug($"Creating new IoT Workspace {packageName}");
 

--- a/core/Objects/ProjectConfig/ProjectConfigV1.cs
+++ b/core/Objects/ProjectConfig/ProjectConfigV1.cs
@@ -30,7 +30,7 @@ public class ProjectConfigV1
     public SemanticVersion DevTasksVersion { get; set; }
     public Version HTMLStarterVersion { get; set; }
     public SemanticVersion YoGeneratorVersion { get; set; }
-    public SemanticVersion NGXSchematicsVersion { get; set; }
+    public string NGXSchematicsVersion { get; set; }
     public Version NugetVersion { get; set; }
     public Version TestScenariosNugetVersion { get; set; }
     [Newtonsoft.Json.JsonConverter(typeof(BooleanJsonConverter))]

--- a/tests/Specs/Init.cs
+++ b/tests/Specs/Init.cs
@@ -145,12 +145,94 @@ namespace tests.Specs
             TestUtilities.GetParser(cmd).Invoke(Array.Empty<string>(), console);
 
             Assert.Contains("Required argument missing for command: 'x'", console.Error.ToString());
-            foreach (var optionName in new[]
-                 {
-                     "baseVersion", "nugetVersion", "testScenariosNugetVersion"
-                 })
+            Assert.Contains("Option '--baseVersion' is required.", console.Error.ToString());
+            Assert.DoesNotContain("Option '--nugetVersion' is required.", console.Error.ToString());
+            Assert.DoesNotContain("Option '--testScenariosNugetVersion' is required.", console.Error.ToString());
+        }
+
+        [Fact]
+        public void Init_VersionSettingsDefaultToMESVersionWhenNotSpecified()
+        {
+            var tmp = TestUtilities.GetTmpDirectory();
+            var projectName = Convert.ToHexString(Guid.NewGuid().ToByteArray()).Substring(0, 8);
+            var deploymentDir = "\\\\share\\deployment_dir";
+            var mesVersion = "11.1.5";
+
+            var cur = Directory.GetCurrentDirectory();
+            try
             {
-                Assert.Contains($"Option '--{optionName}' is required.", console.Error.ToString());
+                var console = new TestConsole();
+                Directory.SetCurrentDirectory(tmp);
+
+                var initCommand = new InitCommand();
+                var cmd = new Command("x");
+                initCommand.Configure(cmd);
+
+                TestUtilities.GetParser(cmd).Invoke(new[]
+                {
+                    projectName,
+                    "--infra", TestUtilities.GetFixturePath("init", "infrastructure.json"),
+                    "-c", TestUtilities.GetFixturePath("init", "config.json"),
+                    "--MESVersion", mesVersion,
+                    // --nugetVersion, --testScenariosNugetVersion and --ngxSchematicsVersion are intentionally omitted
+                    "--deploymentDir", deploymentDir,
+                }, console);
+
+                console.Error.ToString().Should().BeEmpty("command should succeed when version options are omitted");
+                Assert.True(File.Exists("cmfpackage.json"), "root cmfpackage is missing");
+
+                var projectConfig = File.ReadAllText(Path.Join(tmp, ".project-config.json"));
+                projectConfig.Should().Contain(@"""NugetVersion"": ""11.1.5""", "NugetVersion should default to the MES version");
+                projectConfig.Should().Contain(@"""TestScenariosNugetVersion"": ""11.1.5""", "TestScenariosNugetVersion should default to the MES version");
+                projectConfig.Should().Contain(@"""NGXSchematicsVersion"": ""release-1115""", "NGXSchematicsVersion should default to the MES dist-tag");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(cur);
+                Directory.Delete(tmp, true);
+            }
+        }
+
+        [Fact]
+        public void Init_NgxSchematicsVersionUsesProvidedValueOverDefault()
+        {
+            var tmp = TestUtilities.GetTmpDirectory();
+            var projectName = Convert.ToHexString(Guid.NewGuid().ToByteArray()).Substring(0, 8);
+            var deploymentDir = "\\\\share\\deployment_dir";
+            var mesVersion = "11.1.5";
+            var customSchematicsVersion = "my-custom-schematics-tag";
+
+            var cur = Directory.GetCurrentDirectory();
+            try
+            {
+                var console = new TestConsole();
+                Directory.SetCurrentDirectory(tmp);
+
+                var initCommand = new InitCommand();
+                var cmd = new Command("x");
+                initCommand.Configure(cmd);
+
+                TestUtilities.GetParser(cmd).Invoke(new[]
+                {
+                    projectName,
+                    "--infra", TestUtilities.GetFixturePath("init", "infrastructure.json"),
+                    "-c", TestUtilities.GetFixturePath("init", "config.json"),
+                    "--MESVersion", mesVersion,
+                    "--ngxSchematicsVersion", customSchematicsVersion,
+                    "--deploymentDir", deploymentDir,
+                }, console);
+
+                console.Error.ToString().Should().BeEmpty("command should succeed with explicit --ngxSchematicsVersion");
+                Assert.True(File.Exists("cmfpackage.json"), "root cmfpackage is missing");
+
+                File.ReadAllText(Path.Join(tmp, ".project-config.json"))
+                    .Should().Contain($@"""NGXSchematicsVersion"": ""{customSchematicsVersion}""",
+                        "NGXSchematicsVersion should use the provided value, not the MES dist-tag");
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(cur);
+                Directory.Delete(tmp, true);
             }
         }
 
@@ -226,7 +308,7 @@ namespace tests.Specs
                     "--deploymentDir", deploymentDir,
                 }, console);
 
-                Assert.Contains("--ngxSchematicsVersion is missing, please specify it.", console.Error.ToString());
+                // ngxSchematicsVersion is now auto-resolved from npm when omitted
                 console.Error.ToString().Should().NotContain("DevTasksVersion is required");
                 console.Error.ToString().Should().NotContain("HTMLStarterVersion is required");
                 console.Error.ToString().Should().NotContain("yoGeneratorVersion is required");


### PR DESCRIPTION
# **What was done**

In init command nugetVersion, testScenariosNuget and ngxSchematicsVersion are not required at launch. 
They all use the version from MESVersion flag except the last one that also checks the config file if not mentioned in the command line.

Also worth mentioning, in ProjectConfigV1.cs changed NGXSchematicsVersion  from SemanticVersion to string to allow tags like release-1115. HTMLCommand.cs, HelpCommand.cs, IoTCommand.cs got the @ prefix removed because the string was being built as "ngx-schematics@@release-1115".

# **Validation checklist**

Please ensure the following conditions are met in order for this PR to be merged:
* [ ] Code validation (careful with side-effects)
* [ ] Integration test run provided
* [ ] Main WorkItem is linked
* [ ] Target branch version is correct
