### PR TITLE
fix cmf package from xml missing steps + cmf publish command improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,5 +45,5 @@
     "NPM_CONFIG_MIN_RELEASE_AGE": "3",
     "ZSH_DOTENV_PROMPT": "false"
   },
-  "postCreateCommand": "npm ci && echo \"alias 'cmf=/workspaces/cli/cmf-cli/bin/Debug/cmf'\" >> /home/$USER/.bashrc"
+  "postCreateCommand": "npm ci && echo \"alias 'cmf=/workspaces/cli/cmf-cli/bin/Debug/cmf'\" >> /home/$USER/.zshrc"
 }

--- a/cmf-cli/Commands/publish/PublishCommand.cs
+++ b/cmf-cli/Commands/publish/PublishCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.CommandLine;
 using System.IO.Abstractions;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Cmf.CLI.Core;
@@ -34,12 +35,12 @@ public class PublishCommand : BaseCommand
 
     public override void Configure(Command cmd)
     {
-        var fileArgument = new Argument<IFileInfo>("file")
+        var packagesArgument = new Argument<string[]>("packagePaths")
         {
-            Description = "Package file",
-            CustomParser = argResult => Parse<IFileInfo>(argResult)
+            Description = "Package file(s) (.zip or .tgz) or folder(s) containing package files",
+            Arity = ArgumentArity.OneOrMore
         };
-        cmd.Add(fileArgument);
+        cmd.Add(packagesArgument);
 
         var ciOption = new Option<bool>("--ci")
         {
@@ -52,6 +53,12 @@ public class PublishCommand : BaseCommand
             Description = "Use the first non-CI repository URL from the repositories file"
         };
         cmd.Add(releaseOption);
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Resolve packages and print what would be published without uploading anything"
+        };
+        cmd.Add(dryRunOption);
 
         var repositoryOption = new Option<Uri>("--repository")
         {
@@ -66,36 +73,35 @@ public class PublishCommand : BaseCommand
         // Add the handler
         cmd.SetAction((parseResult, cancellationToken) =>
         {
-            var file = parseResult.GetValue(fileArgument);
+            var packages = parseResult.GetValue(packagesArgument);
             var repository = parseResult.GetValue(repositoryOption);
             var ci = parseResult.GetValue(ciOption);
             var release = parseResult.GetValue(releaseOption);
+            var dryRun = parseResult.GetValue(dryRunOption);
 
-            Execute(file, repository, ci, release);
+            Execute(packages, repository, ci, release, dryRun);
             return Task.FromResult(0);
         });
     }
 
-    public void Execute(IFileInfo file, Uri repository, bool ci, bool release)
+    public void Execute(string packagePath, Uri repository, bool ci, bool release)
+    {
+        Execute([packagePath], repository, ci, release, false);
+    }
+
+    public void Execute(string[] packagePaths, Uri repository, bool ci, bool release)
+    {
+        Execute(packagePaths, repository, ci, release, false);
+    }
+
+    public void Execute(string[] packagePaths, Uri repository, bool ci, bool release, bool dryRun)
     {
         using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
-
-        if (!file.Exists || file.Directory == null)
-        {
-            throw new CliException(
-                $"Could not find package file {file.FullName}, make sure the file exists and is valid");
-        }
-
-        if (file.Extension != ".zip" && file.Extension != ".tgz")
-        {
-            throw new CliException(
-                $"The package needs to be in a zip or gzipped tar file (with .tgz extension). Use the `pack` command to get a valid file to publish.");
-        }
 
         if (ci && release)
         {
             throw new CliException(
-                $"Cannot use both flags `--ci` and `--release` at the same time.");
+                "Cannot use both flags `--ci` and `--release` at the same time.");
         }
 
         if ((ci || release) && repository != null)
@@ -112,7 +118,7 @@ public class PublishCommand : BaseCommand
             if (repository == null)
             {
                 throw new CliException(
-                    $"No CIRepository was defined on the repositories configuration file, cannot use the `--ci` flag.");
+                    "No CIRepository was defined on the repositories configuration file, cannot use the `--ci` flag.");
             }
         }
         else if (release)
@@ -122,34 +128,95 @@ public class PublishCommand : BaseCommand
             if (repository == null)
             {
                 throw new CliException(
-                    $"No Repositories were defined on the repositories configuration file, cannot use the `--release` flag.");
+                    "No Repositories were defined on the repositories configuration file, cannot use the `--release` flag.");
             }
         }
 
         if (repository == null)
         {
             throw new CliException(
-                $"No repository URL to publish to was passed. Try using one of the following options: `--ci`, `--release` or `--repository`.");
+                "No repository URL to publish to was passed. Try using one of the following options: `--ci`, `--release` or `--repository`.");
         }
 
-        // If it passes the above checks the only possible client for the requested file 
-        // is a ArchiveRepositoryClient with only a single Package
-        var client = ExecutionContext.ServiceProvider?.GetService<IRepositoryLocator>()
-            .GetRepositoryClient(new Uri(file.FullName), file.FileSystem) as ArchiveRepositoryClient;
-        if (client == null)
+        var repositoryLocator = ExecutionContext.ServiceProvider?.GetService<IRepositoryLocator>();
+        var packagesToPublish = new List<CmfPackageV1>();
+
+        foreach (var packagePath in packagePaths)
         {
-            throw new CliException($"Could not determine repository type for {file.FullName}!");
+            var directory = fileSystem.DirectoryInfo.New(packagePath);
+            var fileInfo = fileSystem.FileInfo.New(packagePath);
+
+            if (fileInfo.Exists)
+            {
+                if (fileInfo.Extension != ".zip" && fileInfo.Extension != ".tgz")
+                {
+                    throw new CliException(
+                        "The package needs to be in a zip or gzipped tar file (with .tgz extension). Use the `pack` command to get a valid file to publish.");
+                }
+
+                var fileClient = repositoryLocator?.GetRepositoryClient(new Uri(fileInfo.FullName), fileInfo.FileSystem) as ArchiveRepositoryClient;
+                if (fileClient == null)
+                {
+                    throw new CliException($"Could not determine repository type for {fileInfo.FullName}!");
+                }
+
+                Log.Debug($"Got client {fileClient.GetType().Name} for package file {fileInfo.FullName}");
+                packagesToPublish.Add(fileClient.List().GetAwaiter().GetResult().Single());
+                continue;
+            }
+
+            if (!directory.Exists)
+            {
+                throw new CliException(
+                    $"Could not find package file or directory at {packagePath}, make sure the path exists and is valid");
+            }
+
+            var directoryClient = new ArchiveRepositoryClient(directory.FullName, directory.FileSystem);
+            Log.Debug($"Got client {directoryClient.GetType().Name} for package directory {directory.FullName}");
+            var folderPackages = directoryClient.List().GetAwaiter().GetResult();
+
+            if (!folderPackages.Any())
+            {
+                Log.Information($"No packages found in folder {directory.FullName}. Skipping...");
+                continue;
+            }
+
+            Log.Information($"Found {folderPackages.Count} package(s) in folder {directory.FullName}.");
+            packagesToPublish.AddRange(folderPackages);
         }
-        Log.Debug($"Got client {client.GetType().Name} for package file {file.FullName}");
-        var repoClient = ExecutionContext.ServiceProvider?.GetService<IRepositoryLocator>()
-            .GetRepositoryClient(repository, file.FileSystem);
-        if (repoClient == null)
+        
+        if (!packagesToPublish.Any())
         {
-            throw new CliException($"Could not determine repository type for {repository.AbsoluteUri}!");
+            Log.Information($"No packages found to publish.");
         }
-        Log.Debug($"Got client {repoClient.GetType().Name} for repository URL {repository.AbsoluteUri}");
-        Log.Debug($"Publishing package with target repository client...");
-        repoClient.Put(client.List().Result.Single()).GetAwaiter().GetResult();
-        Log.Debug("Publish completed!");
+        else
+        {
+            var repoClient = repositoryLocator?.GetRepositoryClient(repository, fileSystem);
+            if (repoClient == null)
+            {
+                throw new CliException($"Could not determine repository type for {repository.AbsoluteUri}!");
+            }
+            Log.Debug($"Got client {repoClient.GetType().Name} for repository URL {repository.AbsoluteUri}");
+
+            foreach (var package in packagesToPublish)
+            {
+                var action = dryRun ? "Would publish" : "Publishing";
+                Log.Information($"{action} {package.PackageDotRef}...");
+
+                if (!dryRun)
+                {
+                    repoClient.Put(package).GetAwaiter().GetResult();
+                }
+            }
+
+            if (dryRun)
+            {
+                Log.Information($"Dry run completed. {packagesToPublish.Count} package(s) would be published.");
+            }
+            else
+            {
+                Log.Information($"Completed publishing {packagesToPublish.Count} package(s)!");
+            }
+        }
     }
 }

--- a/core/Enums/StepType.cs
+++ b/core/Enums/StepType.cs
@@ -96,6 +96,33 @@
         CleanupS3InstallationFolder = 20,
 
         CreateAppUser = 21,
-        UpdateConfiguration = 22
+        
+        UpdateConfiguration = 22,
+        
+        DatabaseAccount = 23,
+
+        ClickHouseAccount = 24,
+
+        RunClickhouseMigration = 25,
+
+        CreateSystemUsers = 26,
+
+        InstallIfDbDoesntExist = 27,
+
+        ProductLicense = 28,
+
+        DeleteQueue = 29,
+
+        DeleteStorageEntries = 30,
+
+        DeleteKafkaTopics = 31,
+
+        DeleteSqlReports = 32,
+
+        ProductConfiguration = 33,
+
+        SignEntityTypes = 35,
+
+        EnqueueXmla = 36
     }
 }

--- a/core/Objects/NPMClient.cs
+++ b/core/Objects/NPMClient.cs
@@ -317,7 +317,14 @@ namespace Cmf.CLI.Core.Objects
             try
             {
                 var httpClient = this.client;
-                httpClient.Timeout = TimeSpan.FromMinutes(5);
+
+                // Fix for publishng multiple packages using the same NPMClient instance
+                // HTTPClient throws exception if you attempt to change its settings after the first request, hence this check
+                int timeoutMinutes = 5;
+                if (httpClient.Timeout != TimeSpan.FromMinutes(timeoutMinutes))
+                {
+                    httpClient.Timeout = TimeSpan.FromMinutes(timeoutMinutes);
+                }
                 var response = await httpClient.PutAsync($"{this.baseUrl}/{name}", content);
                 if (!response.IsSuccessStatusCode)
                 {

--- a/core/Objects/Step.cs
+++ b/core/Objects/Step.cs
@@ -189,6 +189,91 @@ namespace Cmf.CLI.Core.Objects
         /// </summary>
         public string TargetFile { get; set; }
 
+        /// <summary>
+        /// Gets or sets the user key for ClickHouse account steps.
+        /// </summary>
+        public string UserKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the quota for ClickHouse account steps.
+        /// </summary>
+        public string Quota { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID for integration entries or generic steps.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use machine name for database account steps.
+        /// </summary>
+        public bool? UseMachineName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the account name for database account steps.
+        /// </summary>
+        public string Account { get; set; }
+
+        /// <summary>
+        /// Gets or sets the on initialize handler for generic steps.
+        /// </summary>
+        public string OnInitialize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the on prepare handler for generic steps.
+        /// </summary>
+        public string OnPrepare { get; set; }
+
+        /// <summary>
+        /// Gets or sets the script handler for generic steps.
+        /// </summary>
+        public string ScriptHandler { get; set; }
+
+        /// <summary>
+        /// Gets or sets the patch ID.
+        /// </summary>
+        public string PatchId { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to replace tokens.
+        /// </summary>
+        public bool? ReplaceTokens { get; set; }
+
+        /// <summary>
+        /// Gets or sets the source packages for install steps.
+        /// </summary>
+        public string SourcePackages { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target database name for install steps.
+        /// </summary>
+        public string TargetDb { get; set; }
+
+        /// <summary>
+        /// Gets or sets the condition path for ClickHouse SQL steps.
+        /// </summary>
+        public string ConditionPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the patch description.
+        /// </summary>
+        public string PatchDescription { get; set; }
+
+        /// <summary>
+        /// Gets or sets the database type for SQL steps.
+        /// </summary>
+        public string DatabaseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration path for update configuration steps.
+        /// </summary>
+        public string ConfigPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the value for update configuration steps.
+        /// </summary>
+        public string Value { get; set; }
+
         #endregion
 
         #region Constructors
@@ -211,7 +296,7 @@ namespace Cmf.CLI.Core.Objects
             : this(type, title, onExecute, contentPath, file, tagFile, targetDatabase, messageType, relativePath, filePath, null, null, null)
         { }
         
-        public Step(StepType? type, string title, string onExecute, string contentPath, string file, bool? tagFile, string targetDatabase, MessageType? messageType, string relativePath, string filePath, string oldSystemName, string targetDirectory, string targetFile)
+    public Step(StepType? type, string title, string onExecute, string contentPath, string file, bool? tagFile, string targetDatabase, MessageType? messageType, string relativePath, string filePath, string oldSystemName, string targetDirectory, string targetFile)
         {
             Type = type ?? throw new ArgumentNullException(nameof(type));
             Title = title;
@@ -271,7 +356,24 @@ namespace Cmf.CLI.Core.Objects
                    FilePath == other.FilePath &&
                    OldSystemName == other.OldSystemName &&
                    TargetDirectory == other.TargetDirectory &&
-                   TargetFile == other.TargetFile;
+                   TargetFile == other.TargetFile &&
+                   UserKey == other.UserKey &&
+                   Quota == other.Quota &&
+                   Id == other.Id &&
+                   UseMachineName == other.UseMachineName &&
+                   Account == other.Account &&
+                   OnInitialize.IgnoreCaseEquals(other.OnInitialize) &&
+                   OnPrepare.IgnoreCaseEquals(other.OnPrepare) &&
+                   ScriptHandler.IgnoreCaseEquals(other.ScriptHandler) &&
+                   PatchId == other.PatchId &&
+                   ReplaceTokens == other.ReplaceTokens &&
+                   SourcePackages == other.SourcePackages &&
+                   TargetDb == other.TargetDb &&
+                   ConditionPath == other.ConditionPath &&
+                   PatchDescription == other.PatchDescription &&
+                   DatabaseType == other.DatabaseType &&
+                   ConfigPath == other.ConfigPath &&
+                   Value == other.Value;
         }
 
         #endregion

--- a/core/Services/CmfPackageController.cs
+++ b/core/Services/CmfPackageController.cs
@@ -39,10 +39,40 @@ public class CmfPackageController
         "title",
         "onExecute",
         "contentPath",
+        "content",
+        "file",
+        "file",
         "tagFile",
         "targetDatabase",
+        "messageType",
         "filePath",
-        "oldSystemName"
+        "oldSystemName",
+        "targetDirectory",
+        "targetFile",
+        "runInMaster",
+        "targetAll",
+        "deeBasePath",
+        "importXMLObjectPath",
+        "automationWorkflowFileBasePath",
+        "createInCollection",
+        "targetPlatform",
+        "userKey",
+        "quota",
+        "id",
+        "useMachineName",
+        "account",
+        "onInitialize",
+        "onPrepare",
+        "scriptHandler",
+        "patchId",
+        "replaceTokens",
+        "sourcePackages",
+        "targetDb",
+        "conditionPath",
+        "patchDescription",
+        "databaseType",
+        "configPath",
+        "value"
     ];
     
     public CmfPackageController(CmfPackageV1 package, IFileSystem fileSystem)
@@ -370,27 +400,46 @@ public class CmfPackageController
                 {
                     LogUnknownAttributes(element, KnownStepAttributes);
                     
-                    Step step = new Step(
-                        type: Enum.Parse(typeof(StepType), element.Attribute("type")?.Value) is StepType
-                            ? (StepType)Enum.Parse(typeof(StepType), element.Attribute("type")?.Value)
-                            : StepType.Generic,
-                        title: element.Attribute("title")?.Value,
-                        onExecute: element.Attribute("onExecute")?.Value,
-                        contentPath: element.Attribute("contentPath")?.Value,
-                        file: null,
-                        tagFile: element.Attribute("tagFile")?.Value != null ? bool.Parse(element.Attribute("tagFile")?.Value) : null,
-                        targetDatabase: element.Attribute("targetDatabase")?.Value,
-                        messageType: element.Attribute("messageType") != null && Enum.TryParse(element.Attribute("messageType").Value, out MessageType messageType) ? messageType : null,
-                        relativePath: null,
-                        filePath: element.Attribute("filePath")?.Value,
-                        oldSystemName: element.Attribute("oldSystemName")?.Value,
-                        targetDirectory: element.Attribute("targetDirectory")?.Value,
-                        targetFile: element.Attribute("targetFile")?.Value
-                    );
-
-                    step.DeeBasePath = element.Attribute("deeBasePath")?.Value;
-                    step.ImportXMLObjectPath = element.Attribute("importXMLObjectPath")?.Value;
-                    step.AutomationWorkflowFileBasePath = element.Attribute("automationWorkflowFileBasePath")?.Value;
+                    Step step = new Step {
+                        Type = Enum.TryParse<StepType>(element.Attribute("type")?.Value, out var parsedStepType) ? parsedStepType : StepType.Generic,
+                        Title = element.Attribute("title")?.Value,
+                        OnExecute = element.Attribute("onExecute")?.Value,
+                        ContentPath = element.Attribute("contentPath")?.Value,
+                        Content = element.Attribute("content")?.Value,
+                        File = element.Attribute("file")?.Value,
+                        TagFile = bool.TryParse(element.Attribute("tagFile")?.Value, out bool tagFile) ? tagFile : null,
+                        TargetDatabase = element.Attribute("targetDatabase")?.Value,
+                        MessageType = Enum.TryParse(element.Attribute("messageType")?.Value, out MessageType messageType) ? messageType : null,
+                        RelativePath = null,
+                        FilePath = element.Attribute("filePath")?.Value,
+                        OldSystemName = element.Attribute("oldSystemName")?.Value,
+                        TargetDirectory = element.Attribute("targetDirectory")?.Value,
+                        TargetFile = element.Attribute("targetFile")?.Value,
+                        RunInMaster = bool.TryParse(element.Attribute("runInMaster")?.Value, out bool runInMaster) ? runInMaster : null,
+                        TargetAll = bool.TryParse(element.Attribute("targetAll")?.Value, out bool targetAll) ? targetAll : null,
+                        DeeBasePath = element.Attribute("deeBasePath")?.Value,
+                        ImportXMLObjectPath = element.Attribute("importXMLObjectPath")?.Value,
+                        AutomationWorkflowFileBasePath = element.Attribute("automationWorkflowFileBasePath")?.Value,
+                        CreateInCollection = bool.TryParse(element.Attribute("createInCollection")?.Value, out bool createInCollection) ? createInCollection : null,
+                        TargetPlatform = Enum.TryParse(element.Attribute("targetPlatform")?.Value, out MasterDataTargetPlatformType targetPlatform) ? targetPlatform : null,
+                        UserKey = element.Attribute("userKey")?.Value,
+                        Quota = element.Attribute("quota")?.Value,
+                        Id = element.Attribute("id")?.Value,
+                        UseMachineName = bool.TryParse(element.Attribute("useMachineName")?.Value, out bool useMachineName) ? useMachineName : null,
+                        Account = element.Attribute("account")?.Value,
+                        OnInitialize = element.Attribute("onInitialize")?.Value,
+                        OnPrepare = element.Attribute("onPrepare")?.Value,
+                        ScriptHandler = element.Attribute("scriptHandler")?.Value,
+                        PatchId = element.Attribute("patchId")?.Value,
+                        ReplaceTokens = bool.TryParse(element.Attribute("replaceTokens")?.Value, out bool replaceTokens) ? replaceTokens : null,
+                        SourcePackages = element.Attribute("sourcePackages")?.Value,
+                        TargetDb = element.Attribute("targetDb")?.Value,
+                        ConditionPath = element.Attribute("conditionPath")?.Value,
+                        PatchDescription = element.Attribute("patchDescription")?.Value,
+                        DatabaseType = element.Attribute("databaseType")?.Value,
+                        ConfigPath = element.Attribute("configPath")?.Value,
+                        Value = element.Attribute("value")?.Value,
+                    };
 
                 // // Create an XmlSerializer for the Person type
                 // XmlSerializer serializer = new XmlSerializer(typeof(Step));

--- a/tests/Specs/CmfPackageController_FromXml.cs
+++ b/tests/Specs/CmfPackageController_FromXml.cs
@@ -70,7 +70,76 @@ public class CmfPackageController_FromXml
         pkg.Steps.Single().ImportXMLObjectPath.Should().Be("./xml");
     }
 
-      [Fact]
+    [Theory]
+    [InlineData("DeployFiles", StepType.DeployFiles)]
+    [InlineData("RunSql", StepType.RunSql)]
+    [InlineData("MasterData", StepType.MasterData)]
+    [InlineData("EnqueueXmla", StepType.EnqueueXmla)]
+    [InlineData("DatabaseAccount", StepType.DatabaseAccount)]
+    public void FromXml_ShouldParseStepType_WhenTypeAttributeIsKnown(string typeValue, StepType expectedType)
+    {
+        var xml = XDocument.Parse(
+            $"""
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="{typeValue}" contentPath="*" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().Type.Should().Be(expectedType);
+    }
+
+    [Theory]
+    [InlineData("UnknownType")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void FromXml_ShouldFallbackToGenericStepType_WhenTypeAttributeIsUnknownOrMissing(string typeValue)
+    {
+        var typeAttr = typeValue != null ? $"type=\"{typeValue}\"" : "";
+        var xml = XDocument.Parse(
+            $"""
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step {typeAttr} contentPath="*" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().Type.Should().Be(StepType.Generic);
+    }
+
+    [Fact]
+    public void FromXml_ShouldFallbackToGenericStepType_WhenTypeAttributeIsMissing()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step contentPath="*" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().Type.Should().Be(StepType.Generic);
+    }
+
+    [Fact]
       public void FromXml_ShouldParseIsToForceInstall_FromManifestElement()
       {
         var xml = XDocument.Parse(
@@ -88,4 +157,241 @@ public class CmfPackageController_FromXml
 
         pkg.IsToForceInstall.Should().BeTrue();
       }
+
+    [Fact]
+    public void FromXml_ShouldParseFileAttribute_ForTransformFileStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="TransformFile" file="./config/app.config" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().File.Should().Be("./config/app.config");
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseContentAttribute_ForAutomationSyncStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="AutomationBusinessScenariosSync" content="./scenarios" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().Content.Should().Be("./scenarios");
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseUserKeyAndQuota_ForClickHouseAccountStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="ClickHouseAccount" userKey="myUser" quota="1000" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().UserKey.Should().Be("myUser");
+        pkg.Steps.Single().Quota.Should().Be("1000");
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseIdAndMessageType_ForCreateIntegrationEntriesStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="CreateIntegrationEntries" id="entry1" messageType="ImportObject" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().Id.Should().Be("entry1");
+        pkg.Steps.Single().MessageType.Should().Be(MessageType.ImportObject);
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseUseMachineNameAndAccount_ForDatabaseAccountStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="DatabaseAccount" useMachineName="true" account="sa" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().UseMachineName.Should().BeTrue();
+        pkg.Steps.Single().Account.Should().Be("sa");
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseGenericStepHandlersAndPatchAttributes()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="Generic" id="step1" onInitialize="InitHandler" onPrepare="PrepHandler" scriptHandler="ScriptH" patchId="p001" replaceTokens="true" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        var step = pkg.Steps.Single();
+        step.Id.Should().Be("step1");
+        step.OnInitialize.Should().Be("InitHandler");
+        step.OnPrepare.Should().Be("PrepHandler");
+        step.ScriptHandler.Should().Be("ScriptH");
+        step.PatchId.Should().Be("p001");
+        step.ReplaceTokens.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseInstallIfDbDoesntExistAttributes()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="InstallIfDbDoesntExist" sourcePackages="pkg1,pkg2" targetDb="myDb" replaceTokens="false" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        var step = pkg.Steps.Single();
+        step.SourcePackages.Should().Be("pkg1,pkg2");
+        step.TargetDb.Should().Be("myDb");
+        step.ReplaceTokens.Should().BeFalse();
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseCreateInCollection_ForMasterDataStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="MasterData" contentPath="*.xlsx" createInCollection="true" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().CreateInCollection.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseRunClickhouseSqlAttributes()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="RunClickhouseSql" conditionPath="./cond.sql" patchId="p001" patchDescription="init patch" replaceTokens="true" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        var step = pkg.Steps.Single();
+        step.ConditionPath.Should().Be("./cond.sql");
+        step.PatchId.Should().Be("p001");
+        step.PatchDescription.Should().Be("init patch");
+        step.ReplaceTokens.Should().BeTrue();
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseDatabaseType_ForRunSqlStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="RunSql" databaseType="Online" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().DatabaseType.Should().Be("Online");
+    }
+
+    [Fact]
+    public void FromXml_ShouldParseConfigPathAndValue_ForUpdateConfigurationStep()
+    {
+        var xml = XDocument.Parse(
+            """
+            <deploymentPackage>
+              <packageId>Cmf.Custom.Data</packageId>
+              <version>1.0.0</version>
+              <steps>
+                <step type="UpdateConfiguration" configPath="./appsettings.json" value="newValue" />
+              </steps>
+            </deploymentPackage>
+            """);
+
+        var pkg = CmfPackageController.FromXml(xml);
+
+        pkg.Steps.Should().ContainSingle();
+        pkg.Steps.Single().ConfigPath.Should().Be("./appsettings.json");
+        pkg.Steps.Single().Value.Should().Be("newValue");
+    }
 }

--- a/tests/Specs/Publish.cs
+++ b/tests/Specs/Publish.cs
@@ -5,6 +5,8 @@ using System.IO.Abstractions;
 using Moq;
 using Cmf.CLI.Commands;
 using System.Threading.Tasks;
+using Cmf.CLI.Core;
+using Cmf.CLI.Utilities;
 using System.Collections.Generic;
 using System.Formats.Tar;
 using System.IO.Abstractions.TestingHelpers;
@@ -17,6 +19,7 @@ using Cmf.CLI.Core.Interfaces;
 using Cmf.CLI.Core.Repository;
 using Cmf.CLI.Core.Services;
 using Cmf.CLI.Core.Repository.Credentials;
+using Spectre.Console;
 using FluentAssertions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -34,31 +37,32 @@ public class Publish
     public void Repository_Arg_ParsedCorrectly(string expectedHost, string inputRepository)
     {
         string inputFile = "/test/testPackage.zip";
+        string inputFolder = "/test/packages";
 
         var publishCommand = new PublishCommand();
         var cmd = new Command("publish");
         publishCommand.Configure(cmd);
 
-        var fileArg = cmd.Arguments.FirstOrDefault(a => a.Name == "file") as Argument<IFileInfo>;
+        var packagesArg = cmd.Arguments.FirstOrDefault(a => a.Name == "packagePaths") as Argument<string[]>;
         var repositoryOpt = cmd.Options.OfType<Option<Uri>>().FirstOrDefault();
 
-        IFileInfo _file = null;
+        string[] _packages = null;
         Uri _repository = null;
 
         cmd.SetAction((parseResult, cancellationToken) =>
         {
-            _file = parseResult.GetValue(fileArg);
+            _packages = parseResult.GetValue(packagesArg);
             _repository = parseResult.GetValue(repositoryOpt);
             return Task.FromResult(0);
         });
 
         var console = new TestConsole();
         var parseResult = cmd.Parse(new[] {
-            inputFile, "--repository", inputRepository
+            inputFile, inputFolder, "--repository", inputRepository
         });
         parseResult.Invoke(console);
 
-        Assert.Equal(inputFile, _file.FullName);
+        _packages.Should().Equal(inputFile, inputFolder);
         Assert.Equal(inputRepository, _repository.OriginalString);
         Assert.Equal(expectedHost, _repository.Host);
     }
@@ -120,7 +124,7 @@ public class Publish
 
         // Act
         var publishCommand = new PublishCommand(fileSystem);
-        publishCommand.Execute(fileSystem.FileInfo.New(archivePath), repositoryUrl, false, false);
+        publishCommand.Execute(archivePath, repositoryUrl, false, false);
 
         // Assert
         npmClient.Verify(x => x.PublishPackage(It.IsAny<IFileInfo>()), Times.Once);
@@ -218,7 +222,7 @@ public class Publish
 
         // Act
         var publishCommand = new PublishCommand(fileSystem);
-        publishCommand.Execute(fileSystem.FileInfo.New(archivePath), repository: null, ci: true, release: false);
+        publishCommand.Execute(archivePath, repository: null, ci: true, release: false);
 
         // Assert
         repositoryLocator.Verify(x => x.GetRepositoryClient(repositoryUrl, It.IsAny<IFileSystem>()), Times.Once);
@@ -280,9 +284,290 @@ public class Publish
 
         // Act
         var publishCommand = new PublishCommand(fileSystem);
-        var exception = publishCommand.Invoking(x => x.Execute(fileSystem.FileInfo.New(archivePath), repositoryUrl, false, false));
+        var exception = publishCommand.Invoking(x => x.Execute(archivePath, repositoryUrl, false, false));
 
         // Assert
         exception.Should().Throw<Exception>().WithMessage("*Invalid manifest file: one of the following keywords must be present*");
+    }
+
+    [Fact]
+    public void DryRunArgument_DoesNotPublishPackages()
+    {
+        // Arrange
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+        var archivePath = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Packages\Cmf.Custom.Tests.1.1.0.zip");
+        var archiveData = CreatePackageArchiveData("1.1.0");
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { archivePath, new MockFileData(archiveData) },
+        }, MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test"));
+
+        var remoteClientMock = new Mock<IRepositoryClient>();
+
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .SetupSequence(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns(new ArchiveRepositoryClient(archivePath, fileSystem))
+            .Returns(remoteClientMock.Object);
+
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        var publishCommand = new PublishCommand(fileSystem);
+        var cmd = new Command("publish");
+        publishCommand.Configure(cmd);
+
+        var console = new TestConsole();
+
+        // Act
+        var result = cmd.Parse(new[]
+        {
+            archivePath,
+            "--repository", repositoryUrl.AbsoluteUri,
+            "--dry-run"
+        }).Invoke(console);
+
+        // Assert
+        result.Should().Be(0);
+        remoteClientMock.Verify(x => x.Put(It.IsAny<CmfPackageV1>()), Times.Never);
+        repositoryLocator.Verify(x => x.GetRepositoryClient(repositoryUrl, It.IsAny<IFileSystem>()), Times.Once);
+    }
+
+    [Fact]
+    public void PublishFromDirectory()
+    {
+        // Arrange
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+        var packageDir = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Package");
+        var topLevelArchive1 = MockUnixSupport.Path(packageDir + @"\Cmf.Custom.Tests.1.1.0.zip");
+        var topLevelArchive2 = MockUnixSupport.Path(packageDir + @"\Cmf.Custom.Tests.2.0.0.zip");
+        var nestedArchive = MockUnixSupport.Path(packageDir + @"\subfolder\Cmf.Custom.Tests.3.0.0.zip");
+        var archiveData1 = CreatePackageArchiveData("1.1.0");
+        var archiveData2 = CreatePackageArchiveData("2.0.0");
+        var archiveData3 = CreatePackageArchiveData("3.0.0");
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { topLevelArchive1, new MockFileData(archiveData1) },
+            { topLevelArchive2, new MockFileData(archiveData2) },
+            { nestedArchive, new MockFileData(archiveData3) },
+        }, packageDir);
+
+        var publishedFilesCount = 0;
+        
+        var npmClient = new Mock<INPMClientEx>();
+        npmClient.Setup(x => x.PublishPackage(It.IsAny<IFileInfo>()))
+            .Callback(() => publishedFilesCount++);
+        
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .Setup(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns((Uri uri, IFileSystem fs) =>
+            {
+                if (uri.IsFile)
+                {
+                    return new ArchiveRepositoryClient(uri.LocalPath, fs);
+                }
+                return new NPMRepositoryClient(repositoryUrl.AbsoluteUri, fs, npmClient.Object);
+            });
+        
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        // Act
+        var publishCommand = new PublishCommand(fileSystem);
+        publishCommand.Execute(packageDir, repositoryUrl, false, false);
+
+        // Assert
+        npmClient.Verify(x => x.PublishPackage(It.IsAny<IFileInfo>()), Times.Exactly(2));
+        publishedFilesCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void PublishMultipleFilesAndDirectories()
+    {
+        // Arrange
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+        var packageDir = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Package");
+        var directArchive = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Packages\Cmf.Custom.Tests.0.9.0.zip");
+        var folderArchive = MockUnixSupport.Path(packageDir + @"\Cmf.Custom.Tests.1.1.0.zip");
+        var directArchiveData = CreatePackageArchiveData("0.9.0");
+        var folderArchiveData = CreatePackageArchiveData("1.1.0");
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { directArchive, new MockFileData(directArchiveData) },
+            { folderArchive, new MockFileData(folderArchiveData) },
+        }, MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test"));
+
+        var publishedFilesCount = 0;
+
+        var npmClient = new Mock<INPMClientEx>();
+        npmClient.Setup(x => x.PublishPackage(It.IsAny<IFileInfo>()))
+            .Callback(() => publishedFilesCount++);
+
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .Setup(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns((Uri uri, IFileSystem fs) =>
+            {
+                if (uri.IsFile)
+                {
+                    return new ArchiveRepositoryClient(uri.LocalPath, fs);
+                }
+                return new NPMRepositoryClient(repositoryUrl.AbsoluteUri, fs, npmClient.Object);
+            });
+
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        // Act
+        var publishCommand = new PublishCommand(fileSystem);
+        publishCommand.Execute([directArchive, packageDir], repositoryUrl, false, false);
+
+        // Assert
+        npmClient.Verify(x => x.PublishPackage(It.IsAny<IFileInfo>()), Times.Exactly(2));
+        publishedFilesCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void PublishFailsWithoutPublishingAnythingWhenAnyInputPathDoesNotExist()
+    {
+        // Arrange
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+        var existingArchive = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Packages\Cmf.Custom.Tests.1.1.0.zip");
+        var missingArchive = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Packages\Missing.zip");
+        var archiveData = CreatePackageArchiveData("1.1.0");
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            { existingArchive, new MockFileData(archiveData) },
+        }, MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test"));
+
+        var npmClient = new Mock<INPMClientEx>();
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .Setup(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns((Uri uri, IFileSystem fs) =>
+            {
+                if (uri.IsFile)
+                {
+                    return new ArchiveRepositoryClient(uri.LocalPath, fs);
+                }
+
+                return new NPMRepositoryClient(repositoryUrl.AbsoluteUri, fs, npmClient.Object);
+            });
+
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        var publishCommand = new PublishCommand(fileSystem);
+
+        // Act
+        var exception = publishCommand.Invoking(x =>
+            x.Execute([existingArchive, missingArchive], repositoryUrl, false, false));
+
+        // Assert
+        exception.Should().Throw<CliException>()
+            .WithMessage($"*Could not find package file or directory at {missingArchive}*");
+        npmClient.Verify(x => x.PublishPackage(It.IsAny<IFileInfo>()), Times.Never);
+    }
+
+    [Fact]
+    public void PublishSkipsEmptyFolderAndLogsMessage()
+    {
+        // Arrange
+        var repositoryUrl = new Uri("https://fake.criticalmanufacturing.io");
+        var emptyFolder = MockUnixSupport.Path(@"C:\repo\Cmf.Custom.Test\Empty");
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>(), emptyFolder);
+        var npmClient = new Mock<INPMClientEx>();
+        var repositoryLocator = new Mock<IRepositoryLocator>();
+        repositoryLocator
+            .Setup(m => m.GetRepositoryClient(It.IsAny<Uri>(), It.IsAny<IFileSystem>()))
+            .Returns((Uri uri, IFileSystem fs) =>
+            {
+                if (uri.IsFile)
+                {
+                    return new ArchiveRepositoryClient(uri.LocalPath, fs);
+                }
+
+                return new NPMRepositoryClient(repositoryUrl.AbsoluteUri, fs, npmClient.Object);
+            });
+
+        var writer = new StringWriter();
+        Log.AnsiConsole = AnsiConsole.Create(new AnsiConsoleSettings
+        {
+            Ansi = AnsiSupport.Yes,
+            ColorSystem = (ColorSystemSupport)ColorSystem.NoColors,
+            Out = new AnsiConsoleOutput(writer),
+            Interactive = InteractionSupport.No,
+            Enrichment = new ProfileEnrichment
+            {
+                UseDefaultEnrichers = false,
+            },
+        });
+
+        ExecutionContext.ServiceProvider = (new ServiceCollection())
+            .AddSingleton<IFileSystem>(fileSystem)
+            .AddSingleton<IVersionService, MockVersionService>()
+            .AddSingleton<IRepositoryAuthStore>(RepositoryAuthStore.FromEnvironmentConfig(fileSystem))
+            .AddSingleton<IRepositoryLocator>(repositoryLocator.Object)
+            .AddSingleton<IRepositoryCredentials, NPMRepositoryCredentials>()
+            .BuildServiceProvider();
+        ExecutionContext.Initialize(fileSystem);
+
+        var publishCommand = new PublishCommand(fileSystem);
+
+        // Act
+        publishCommand.Execute(emptyFolder, repositoryUrl, false, false);
+
+        // Assert
+        writer.ToString().Should().Contain($"No packages found in folder {emptyFolder}. Skipping.");
+        npmClient.Verify(x => x.PublishPackage(It.IsAny<IFileInfo>()), Times.Never);
+    }
+
+    private static byte[] CreatePackageArchiveData(string version)
+    {
+        using var zipStream = new MemoryStream();
+        using (var zipArchive = new ZipArchive(zipStream, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using var entryStream = zipArchive.CreateEntry("package.json").Open();
+            entryStream.Write(Encoding.UTF8.GetBytes($$"""
+            {
+                "name": "Cmf.Custom.Tests",
+                "version": "{{version}}",
+                "description": "Custom Tests Package",
+                "author": "Critical Manufacturing",
+                "keywords": ["cmf-tests-package"]
+            }
+            """));
+        }
+
+        return zipStream.ToArray();
     }
 }


### PR DESCRIPTION
# What was done
- `publish` command can now accept multiple arguments and also folder paths. For folder paths it will search the immediate packages inside the folder (just the first level) and publish them one by one. For the file arguments the logic remains the same. Previous usage remains the same.
- Added missing attribute steps when converting Envmanager packages to .tgz format.