### PR TITLE
Development proper project naming

### DIFF
--- a/cmf-cli/Commands/init/InitCommand.cs
+++ b/cmf-cli/Commands/init/InitCommand.cs
@@ -1,10 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.Threading.Tasks;
 using System.CommandLine.Parsing;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using Cmf.CLI.Constants;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Attributes;
@@ -90,7 +91,16 @@ namespace Cmf.CLI.Commands
         {
             var projectNameArgument = new Argument<string>("projectName")
             {
-                CustomParser = argResult => ParseArgument<string>(argResult)
+                CustomParser = argResult =>
+                {
+                    var value = ParseArgument<string>(argResult);
+                    if (value != null && !Regex.IsMatch(value, @"^[A-Za-z0-9][A-Za-z0-9_-]*$"))
+                    {
+                        argResult.AddError($"'{value}' is not a valid project name. " +
+                            "Project names must contain only lowercase/uppercase letters, digits, hyphens (-), and underscores (_) as well as start with a letter or digit.");
+                    }
+                    return value;
+                }
             };
             cmd.Add(projectNameArgument);
 

--- a/tests/Specs/Init.cs
+++ b/tests/Specs/Init.cs
@@ -134,6 +134,20 @@ namespace tests.Specs
         }
 
         [Fact]
+        public void Init_Fail_InvalidProjectName_WithDot()
+        {
+            var console = new TestConsole();
+
+            var initCommand = new InitCommand();
+            var cmd = new Command("x");
+            initCommand.Configure(cmd);
+
+            TestUtilities.GetParser(cmd).Invoke(new[] { "My.Project" }, console);
+
+            Assert.Contains("'My.Project' is not a valid project name.", console.Error.ToString());
+        }
+
+        [Fact]
         public void Init_Fail_MissingMandatoryArgumentsAndOptions()
         {
             var console = new TestConsole();


### PR DESCRIPTION
# **What was done**

This bug originated here: 
https://github.com/criticalmanufacturing/cli/issues/742#issue-4469480239

A regex was applied to check if the project name follows the rule: Project name must contain only lowercase/uppercase letters, digits, hyphens (-), and underscores (_).

# **Validation checklist**

Please ensure the following conditions are met in order for this PR to be merged:
* [ ] Code validation (careful with side-effects)
* [ ] Integration test run provided
* [ ] Main WorkItem is linked
* [ ] Target branch version is correct
