### PR TITLE
Update k6 version to v2

### DIFF
--- a/cmf-cli/resources/template_feed/test/Tests.Package/%Org%.%Product%.Tests.Performance/package.json
+++ b/cmf-cli/resources/template_feed/test/Tests.Package/%Org%.%Product%.Tests.Performance/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@types/k6": "^1.4.0",
+    "@types/k6": "^2.0.0",
     "cmf-k6": "file:<%= $CLI_PARAM_output %>/Libs/LBOs/K6/cmf_k6/cmf-k6-0.0.1.tgz"
   },
   "scripts": {


### PR DESCRIPTION
# **What was done**

This pull request updates the `@types/k6` dependency in the `package.json` for the performance test template to the latest major version.
