### PR TITLE
fix: html config overrides oob config.json on deploy

### DIFF
--- a/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
@@ -57,7 +57,7 @@ namespace Cmf.CLI.Handlers
                     {
                         new Step(StepType.DeployFiles)
                         {
-                            ContentPath = "**" // TODO: remove assets/config.json from the deployed files, should only apply transform
+                            ContentPath = "**"
                         },
                         new Step(StepType.TaggedFile)
                         {
@@ -69,10 +69,11 @@ namespace Cmf.CLI.Handlers
                             ContentPath = "ngsw.json",
                             TagFile = true
                         },
-                        new Step(StepType.TaggedFile)
+                        new Step(StepType.TransformFile)
                         {
-                            ContentPath = "assets/config.json",
-                            TagFile = true
+                            File = "config.json",
+                            TagFile = true,
+                            RelativePath = "assets",
                         }
                     }
             );
@@ -203,40 +204,44 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        // TODO: enable this when we can transform config.json
-        // public override void Pack(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir)
-        // {
-        //     var filesToPack = GetContentToPack(packageOutputDir);
-        //     if (CmfPackage.ContentToPack.HasAny() && !filesToPack.HasAny())
-        //     {
-        //         throw new CliException(string.Format(CoreMessages.ContentToPackNotFound, CmfPackage.PackageId, CmfPackage.Version));
-        //     }
-        //
-        //     if (filesToPack != null)
-        //     {
-        //         FilesToPack.AddRange(filesToPack);
-        //
-        //         FilesToPack.ForEach(fileToPack =>
-        //         {
-        //             Log.Debug($"Packing '{fileToPack.Source.FullName} to {fileToPack.Target.FullName} by contentToPack rule (Action: {fileToPack.ContentToPack.Action.ToString()}, Source: {fileToPack.ContentToPack.Source}, Target: {fileToPack.ContentToPack.Target})");
-        //             IDirectoryInfo _targetFolder = this.fileSystem.DirectoryInfo.New(fileToPack.Target.Directory.FullName);
-        //             if (!_targetFolder.Exists)
-        //             {
-        //                 _targetFolder.Create();
-        //             }
-        //         });
-        //     }
-        //
-        //     // TODO: replace this with an ignore entry in the ContentToPack of the template cmfpackage.json
-        //     FilesToPack = FilesToPack.Where(ftp => !ftp.Source.FullName.EndsWith($"assets{this.fileSystem.Path.DirectorySeparatorChar}config.json")).ToList();
-        //     GeneratePresentationConfigFile(packageOutputDir);
-        //
-        //     GenerateDeploymentFrameworkManifest(packageOutputDir);
-        //
-        //     FinalArchive(packageOutputDir, outputDir);
-        //
-        //     Log.Information($"{outputDir.FullName}/{CmfPackage.ZipPackageName} created");
-        //     
-        // }
+        /// <summary>
+        /// Gets the content to pack, excluding the assets/config.json file (generated in build).
+        /// This file cannot be included since it would replace the config.json running in container.
+        /// </summary>
+        internal override List<FileToPack> GetContentToPack(IDirectoryInfo packageOutputDir)
+        {
+            var filesToPack = base.GetContentToPack(packageOutputDir);
+
+            string configRelativePath = $"assets{this.fileSystem.Path.DirectorySeparatorChar}config.json";
+            return filesToPack.Where(ftp => !ftp.Target.FullName.EndsWith(configRelativePath)).ToList();
+        }
+
+        /// <summary>
+        /// This function will pack the html package. It will also generate the config.json file in the root of the zip.
+        /// </summary>
+        public override void Pack(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir, bool dryRun = false)
+        {
+            if (!dryRun)
+            {
+                GeneratePresentationConfigFile(packageOutputDir);
+            }
+            base.Pack(packageOutputDir, outputDir, dryRun);
+        }
+
+        /// <summary>
+        /// This function will generated the config.json using the html template.
+        /// This file is packed and included in the root of the zip file, which will then be applied transformation within the target environment config.json (located at /assets/config.json).
+        /// </summary>
+        private void GeneratePresentationConfigFile(IDirectoryInfo packageOutputDir)
+        {
+            Log.Debug("Generating Presentation config.json");
+
+            string path = this.fileSystem.Path.Join(packageOutputDir.FullName, CliConstants.CmfPackagePresentationConfig);
+            string fileContent = ResourceUtilities.GetEmbeddedResourceContent($"{CliConstants.FolderTemplates}/{CmfPackage.PackageType}/{CliConstants.CmfPackagePresentationConfig}");
+
+            fileContent = fileContent.Replace(CliConstants.TokenVersion, CmfPackage.Version);
+
+            this.fileSystem.File.WriteAllText(path, fileContent);
+        }
     }
 }

--- a/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
@@ -78,6 +78,9 @@ namespace Cmf.CLI.Handlers
                     }
             );
 
+            // Exclude built assets/config.json from copied content
+            DefaultContentToIgnore.Add(CliConstants.CmfPackagePresentationConfig);
+
             var projectRoot = FileSystemUtilities.GetProjectRoot(this.fileSystem);
             var tsLBOsPath = this.fileSystem.Path.Join(projectRoot.FullName, "Libs", "LBOs", "TypeScript");
             var tsLBOsDir = this.fileSystem.DirectoryInfo.New(tsLBOsPath);
@@ -205,18 +208,6 @@ namespace Cmf.CLI.Handlers
         }
 
         /// <summary>
-        /// Gets the content to pack, excluding the assets/config.json file (generated in build).
-        /// This file cannot be included since it would replace the config.json running in container.
-        /// </summary>
-        internal override List<FileToPack> GetContentToPack(IDirectoryInfo packageOutputDir)
-        {
-            var filesToPack = base.GetContentToPack(packageOutputDir);
-
-            string configRelativePath = $"assets{this.fileSystem.Path.DirectorySeparatorChar}config.json";
-            return filesToPack.Where(ftp => !ftp.Target.FullName.EndsWith(configRelativePath)).ToList();
-        }
-
-        /// <summary>
         /// This function will pack the html package. It will also generate the config.json file in the root of the zip.
         /// </summary>
         public override void Pack(IDirectoryInfo packageOutputDir, IDirectoryInfo outputDir, bool dryRun = false)
@@ -237,9 +228,30 @@ namespace Cmf.CLI.Handlers
             Log.Debug("Generating Presentation config.json");
 
             string path = this.fileSystem.Path.Join(packageOutputDir.FullName, CliConstants.CmfPackagePresentationConfig);
-            string fileContent = ResourceUtilities.GetEmbeddedResourceContent($"{CliConstants.FolderTemplates}/{CmfPackage.PackageType}/{CliConstants.CmfPackagePresentationConfig}");
+            string fileContent = ResourceUtilities.GetEmbeddedResourceContent($"{CliConstants.FolderTemplates}/{CmfPackage.PackageType}/config.ng.json");
+
+            IDirectoryInfo cmfPackageDirectory = CmfPackage.GetFileInfo().Directory;
+            List<string> transformInjections = new();
+
+            foreach (ContentToPack contentToPack in CmfPackage.ContentToPack)
+            {
+                if (contentToPack.Action == PackAction.Transform)
+                {
+                    transformInjections.Add(contentToPack.Source);
+                }
+            }
 
             fileContent = fileContent.Replace(CliConstants.TokenVersion, CmfPackage.Version);
+
+            string injection = string.Empty;
+            if (transformInjections.HasAny())
+            {
+                // Trailing commas are required because the injection token is not the last property.
+                var injections = transformInjections.Select(injection => this.fileSystem.File.ReadAllText($"{cmfPackageDirectory}/{injection}") + ",");
+                injection = string.Join(System.Environment.NewLine, injections);
+            }
+
+            fileContent = fileContent.Replace(CliConstants.TokenJDTInjection, injection);
 
             this.fileSystem.File.WriteAllText(path, fileContent);
         }

--- a/cmf-cli/resources/templateFiles/HTML/config.json
+++ b/cmf-cli/resources/templateFiles/HTML/config.json
@@ -1,14 +1,3 @@
 {
-  "@jdt.remove": {
-    "@jdt.path": "$.packages.available[?($(packagesToRemove))]"
-  },
-  "@jdt.merge": [
-    {
-      "@jdt.path": "$.packages.available",
-      "@jdt.value": [ $(packagesToAdd) ]
-    }
-  ],
-  $(JDTInjection)
-  "cacheId": "$(cacheId)",
   "customizationVersion": "$(version)"
 }

--- a/cmf-cli/resources/templateFiles/HTML/config.json
+++ b/cmf-cli/resources/templateFiles/HTML/config.json
@@ -1,3 +1,14 @@
 {
+  "@jdt.remove": {
+    "@jdt.path": "$.packages.available[?($(packagesToRemove))]"
+  },
+  "@jdt.merge": [
+    {
+      "@jdt.path": "$.packages.available",
+      "@jdt.value": [ $(packagesToAdd) ]
+    }
+  ],
+  $(JDTInjection)
+  "cacheId": "$(cacheId)",
   "customizationVersion": "$(version)"
 }

--- a/cmf-cli/resources/templateFiles/HTML/config.ng.json
+++ b/cmf-cli/resources/templateFiles/HTML/config.ng.json
@@ -1,3 +1,4 @@
 {
+  $(JDTInjection)
   "customizationVersion": "$(version)"
 }

--- a/cmf-cli/resources/templateFiles/HTML/config.ng.json
+++ b/cmf-cli/resources/templateFiles/HTML/config.ng.json
@@ -1,5 +1,3 @@
 {
-  $(JDTInjection)
-  "cacheId": "$(cacheId)",
   "customizationVersion": "$(version)"
 }

--- a/tests/Objects/MockPackage.cs
+++ b/tests/Objects/MockPackage.cs
@@ -36,6 +36,7 @@ namespace tests.Objects
               ""name"": ""customization.package""
             }")},
             { MockUnixSupport.Path(@"c:\ui\src\packages\customization.common\customization.common.js"), new MockFileData(string.Empty)},
+            { MockUnixSupport.Path(@"c:\ui\transform\my-config-patch.json"), new MockFileData("\"jdttest\": true")}, // adding jdtinjection file
             { MockUnixSupport.Path(@"c:\ui\package.json"), new MockFileData(
             @"{
               ""name"": ""customization.package""
@@ -55,6 +56,10 @@ namespace tests.Objects
                   ""ignoreFiles"": [
                     "".npmignore""
                   ]
+                }},
+                {{
+                  ""source"": ""{MockUnixSupport.Path("transform\\my-config-patch.json").Replace("\\", "\\\\")}"",
+                  ""action"": ""Transform""
                 }}
               ]
             }}")}});

--- a/tests/Specs/Pack.cs
+++ b/tests/Specs/Pack.cs
@@ -294,6 +294,7 @@ namespace tests.Specs
                     List<string> expectedFiles = new()
                     {
                         "manifest.xml",
+                        "config.json",
                         "node_modules/customization.package/package.json",
                         "node_modules/customization.package/customization.common.js"
                     };
@@ -301,6 +302,26 @@ namespace tests.Specs
                     foreach (var expectedFile in expectedFiles)
                     {
                         Assert.NotNull(entriesToExtract.FirstOrDefault(x => x.Item2.Equals(expectedFile)));
+                    }
+
+                    Assert.Null(entriesToExtract.FirstOrDefault(x => x.Item2.Equals("assets/config.json")));
+
+                    var manifestEntry = zip.GetEntry("manifest.xml");
+                    Assert.NotNull(manifestEntry);
+                    using (var manifestStream = manifestEntry.Open())
+                    using (var manifestReader = new StreamReader(manifestStream))
+                    {
+                        var manifestXmlContent = manifestReader.ReadToEnd();
+                        Assert.Contains("<step type=\"TransformFile\" file=\"config.json\" tagFile=\"true\" relativePath=\"assets\" />", manifestXmlContent);
+                    }
+
+                    var configEntry = zip.GetEntry("config.json");
+                    Assert.NotNull(configEntry);
+                    using (var configStream = configEntry.Open())
+                    using (var configReader = new StreamReader(configStream))
+                    {
+                        var configJsonContent = configReader.ReadToEnd();
+                        Assert.Contains("\"customizationVersion\": \"1.1.0\"", configJsonContent);
                     }
                 }
             }

--- a/tests/Specs/Pack.cs
+++ b/tests/Specs/Pack.cs
@@ -322,6 +322,7 @@ namespace tests.Specs
                     {
                         var configJsonContent = configReader.ReadToEnd();
                         Assert.Contains("\"customizationVersion\": \"1.1.0\"", configJsonContent);
+                        Assert.Contains("\"jdttest\": true", configJsonContent);
                     }
                 }
             }


### PR DESCRIPTION
# **What was done**

Everytime an html package is now deployed it will correctly transform config.json file

# **Validation checklist**

Please ensure the following conditions are met in order for this PR to be merged:
*  [X] Code validation (careful with side-effects)
* [X] Integration test run provided
* [X] Main WorkItem is linked
* [X] Target branch version is correct
