### PR TITLE
fix: iot tasks scaffolding handle empty choices

### DIFF
--- a/cmf-cli/Commands/new/iot/GenerateTaskCommand.cs
+++ b/cmf-cli/Commands/new/iot/GenerateTaskCommand.cs
@@ -150,17 +150,23 @@ namespace Cmf.CLI.Commands.New.IoT
             string[] taskLibraryDependsOnProtocols = taskLibraryPkgJson.criticalManufacturing.tasksLibrary.dependsOnProtocol.ToObject<string[]>();
             string[] taskLibraryDependsOnScope = taskLibraryPkgJson.criticalManufacturing.tasksLibrary.dependsOnScope.ToObject<string[]>();
 
-            task.DependsOnProtocol = AnsiConsole.Prompt(
-                new MultiSelectionPrompt<string>()
-                    .Title("Is this task specific for any protocol?")
-                    .NotRequired()
-                    .AddChoices(taskLibraryDependsOnProtocols));
+            if (taskLibraryDependsOnProtocols.Length > 0)
+            {
+                task.DependsOnProtocol = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("Is this task specific for any protocol?")
+                        .NotRequired()
+                        .AddChoices(taskLibraryDependsOnProtocols));
+            }
 
-            task.DependsOnScope = AnsiConsole.Prompt(
-                new MultiSelectionPrompt<string>()
-                    .Title("On which scopes this library can be used")
-                    .NotRequired()
-                    .AddChoices(taskLibraryDependsOnScope));
+            if (taskLibraryDependsOnScope.Length > 0)
+            {
+                task.DependsOnScope = AnsiConsole.Prompt(
+                    new MultiSelectionPrompt<string>()
+                        .Title("On which scopes this library can be used")
+                        .NotRequired()
+                        .AddChoices(taskLibraryDependsOnScope));
+            }
 
             if (ExecutionContext.Instance.ProjectConfig.MESVersion.Major >= 12)
             {

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -600,8 +600,8 @@ namespace tests.Specs
                 consoleTask.Input.PushTextWithEnter(""); // icon class name (default)
                 consoleTask.Input.PushTextWithEnter(""); // isProtocol: No (default false)
                 consoleTask.Input.PushTextWithEnter(""); // lifecycle: Productive (first selection prompt option)
-                consoleTask.Input.PushTextWithEnter(""); // dependsOnProtocol (MultiSelect)
-                consoleTask.Input.PushTextWithEnter(""); // dependsOnScope (MultiSelect, 1 choice "ConnectIoT"): no selection + confirm
+                // dependsOnProtocol is skipped: task library has no protocols (empty list from library setup)
+                consoleTask.Input.PushTextWithEnter(""); // dependsOnScope MultiSelect (library has ["ConnectIoT"]): no selection + confirm
 
                 if (isMesV12)
                 {


### PR DESCRIPTION
# **What was done**
- Added guards to skip the Depends on Protocol and Depends on Scope prompts when there are no available options, preventing empty MultiSelectionPrompts from being created.
- Fixed scaffolding failures caused by empty Spectre.Console prompts.

Closes #752