### PR TITLE
fix(scaffold): use dynamic TargetFramework for data package Actions project

### DIFF
--- a/cmf-cli/Commands/new/DataCommand.cs
+++ b/cmf-cli/Commands/new/DataCommand.cs
@@ -72,7 +72,7 @@ namespace Cmf.CLI.Commands.New
                 "--rootRelativePath", relativePathToRoot,
                 "--repositoryType", repoType.ToString()
             });
-            args.AddRange(new []{ "--targetFramework", DependencyVersionService.NET6TARGETFRAMEWORK });
+            args.AddRange(new []{ "--targetFramework", ExecutionContext.ServiceProvider.GetService<IDependencyVersionService>().DotNetTargetFramework(version) });
 
             return args;
         }

--- a/tests/Specs/New.cs
+++ b/tests/Specs/New.cs
@@ -208,6 +208,35 @@ namespace tests.Specs
             RunNew(new DataCommand(), "Cmf.Custom.Data");
         }
 
+        [Fact, Trait("TestCategory", "Integration")]
+        public void Data_TargetFramework_Net8_For_MES11()
+        {
+            RunNew(new DataCommand(), "Cmf.Custom.Data",
+                extraAsserts: args =>
+                {
+                    var (_, dir) = args;
+                    var actionsCsproj = Path.Combine(dir, "Cmf.Custom.Data", "DEEs", "Cmf.Custom.tenant.Actions.csproj");
+                    File.Exists(actionsCsproj).Should().BeTrue();
+                    var content = File.ReadAllText(actionsCsproj);
+                    content.Should().Contain("<TargetFramework>net8.0</TargetFramework>");
+                });
+        }
+
+        [Fact, Trait("TestCategory", "Integration")]
+        public void Data_TargetFramework_Net6_For_MES10()
+        {
+            RunNew(new DataCommand(), "Cmf.Custom.Data",
+                mesVersion: "10.2.0",
+                extraAsserts: args =>
+                {
+                    var (_, dir) = args;
+                    var actionsCsproj = Path.Combine(dir, "Cmf.Custom.Data", "DEEs", "Cmf.Custom.tenant.Actions.csproj");
+                    File.Exists(actionsCsproj).Should().BeTrue();
+                    var content = File.ReadAllText(actionsCsproj);
+                    content.Should().Contain("<TargetFramework>net6.0</TargetFramework>");
+                });
+        }
+
         [Fact, Trait("TestCategory", "LongRunning"), Trait("TestCategory", "Integration")]
         public void Data_WithBusiness()
         {


### PR DESCRIPTION
## Description

Fixes #770

### Problem

The Data command's `GenerateArgs` method hardcoded `net6.0` as the target framework when scaffolding the Actions project in data packages. This meant the Actions `.csproj` was always generated with `<TargetFramework>net6.0</TargetFramework>`, even for MES 11+ where `net8.0` is expected. Meanwhile, the Common project (scaffolded by `BusinessCommand`) correctly used `net8.0` for MES 11+.

### Fix

Changed `DataCommand.cs:75` to resolve the target framework dynamically via `IDependencyVersionService.DotNetTargetFramework(version)`, matching the pattern already used by `BusinessCommand` and `TestCommand`:

| MES version | TargetFramework |
|-------------|----------------|
| >= 11       | `net8.0`       |
| < 11        | `net6.0`       |

### Tests

Added two integration tests in `tests/Specs/New.cs`:

- **`Data_TargetFramework_Net8_For_MES11`** — verifies the Actions `.csproj` contains `<TargetFramework>net8.0</TargetFramework>` when MES version is 11.2.2
- **`Data_TargetFramework_Net6_For_MES10`** — verifies the Actions `.csproj` contains `<TargetFramework>net6.0</TargetFramework>` when MES version is 10.2.0