### PR TITLE
feat: refactor IoT workflow migrations

### DIFF
--- a/cmf-cli/Commands/upgrade/UpgradeBaseCommand.cs
+++ b/cmf-cli/Commands/upgrade/UpgradeBaseCommand.cs
@@ -57,28 +57,20 @@ namespace Cmf.CLI.Commands
             };
             cmd.Add(baseVersionArgument);
 
-            var iotVersionOption = new Option<string>("--iotVersion", "-iot")
+            var manifestOption = new Option<string>("--manifest", "-m")
             {
-                Description = "New MES version for the IoT workflows & masterdatas."
+                Description = "The manifest file to use for the upgrade."
             };
-            cmd.Add(iotVersionOption);
-
-            var iotPackagesToIgnoreOption = new Option<List<string>>("--iotPackagesToIgnore", "-ignore")
-            {
-                Description = "IoT packages to ignore when updating the MES version of the tasks in IoT workflows",
-                AllowMultipleArgumentsPerToken = true
-            };
-            cmd.Add(iotPackagesToIgnoreOption);
+            cmd.Add(manifestOption);
 
             // Add the handler
             cmd.SetAction((parseResult, cancellationToken) =>
             {
                 var packagePath = parseResult.GetValue(packagePathArgument);
                 var baseVersion = parseResult.GetValue(baseVersionArgument);
-                var iotVersion = parseResult.GetValue(iotVersionOption);
-                var iotPackagesToIgnore = parseResult.GetValue(iotPackagesToIgnoreOption);
+                var manifest = parseResult.GetValue(manifestOption);
 
-                Execute(packagePath, baseVersion, iotVersion, iotPackagesToIgnore);
+                Execute(packagePath, baseVersion, manifest);
                 return Task.FromResult(0);
             });
         }
@@ -88,10 +80,8 @@ namespace Cmf.CLI.Commands
         /// </summary>
         /// <param name="packagePath">The package path.</param>
         /// <param name="baseVersion">The new Base version.</param>
-        /// <param name="iotVersion">New MES version for the IoT workflows & masterdata</param>
-        /// <param name="iotPackagesToIgnore">IoT packages to ignore when updating the MES version of the tasks in IoT workflows</param>
-        /// <exception cref="CliException"></exception>
-        public void Execute(IDirectoryInfo packagePath, string baseVersion, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <param name="manifest">The manifest file to use for the upgrade.</param>
+        public void Execute(IDirectoryInfo packagePath, string baseVersion, string manifest = null)
         {
             using var activity = ExecutionContext.ServiceProvider?.GetService<ITelemetryService>()?.StartExtendedActivity(this.GetType().Name);
 
@@ -100,27 +90,11 @@ namespace Cmf.CLI.Commands
             foreach (IFileInfo path in cmfPackagePaths)
             {
                 Log.Debug($"Processing {path.FullName}");
-                Execute(CmfPackage.Load(path), baseVersion, iotVersion, iotPackagesToIgnore);
+                new UpgradeCommand(this.fileSystem).Execute(path.Directory, baseVersion, manifest);
             }
 
             UpdateProjectConfig(packagePath, baseVersion);
             Log.Warning("Don't forget to update pipeline files");
-        }
-
-        /// <summary>
-        /// Executes the specified CMF package.
-        /// </summary>
-        /// <param name="cmfPackage">The CMF package.</param>
-        /// <param name="version">The version.</param>
-        /// <param name="iotVersion">New MES version for the IoT workflows & masterdata</param>
-        /// <param name="iotPackagesToIgnore">IoT packages to ignore when updating the MES version of the tasks in IoT workflows</param>
-        /// <exception cref="CliException"></exception>
-        public void Execute(CmfPackage cmfPackage, string version, string iotVersion, List<string> iotPackagesToIgnore)
-        {
-            IDirectoryInfo packageDirectory = cmfPackage.GetFileInfo().Directory;
-            IPackageTypeHandler packageTypeHandler = PackageTypeFactory.GetPackageTypeHandler(cmfPackage);
-
-            packageTypeHandler.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
         }
 
         #region Utilities

--- a/cmf-cli/Commands/upgrade/UpgradeCommand.cs
+++ b/cmf-cli/Commands/upgrade/UpgradeCommand.cs
@@ -1,0 +1,84 @@
+using Cmf.CLI.Constants;
+using Cmf.CLI.Core.Attributes;
+using Cmf.CLI.Core.Interfaces;
+using Cmf.CLI.Factories;
+using System.CommandLine;
+using System.IO.Abstractions;
+using System.Threading.Tasks;
+
+namespace Cmf.CLI.Commands
+{
+    /// <summary>
+    /// Performs an upgrade of the current package
+    /// </summary>
+    /// <seealso cref="BaseCommand" />
+    [CmfCommand("upgrade", Id = "upgrade", Description = "Project upgrade utilities")]
+    public class UpgradeCommand : BaseCommand
+    {
+        
+        /// <summary>
+        /// constructor for System.IO filesystem
+        /// </summary>
+        public UpgradeCommand() : base()
+        {
+        }
+
+        /// <summary>
+        /// constructor
+        /// </summary>
+        /// <param name="fileSystem"></param>
+        public UpgradeCommand(IFileSystem fileSystem) : base(fileSystem)
+        {
+        }
+
+        /// <summary>
+        /// Configure command
+        /// </summary>
+        /// <param name="cmd"></param>
+        public override void Configure(Command cmd)
+        {
+            var packagePathArgument = new Argument<IDirectoryInfo>("packagePath")
+            {
+                Description = "Package path",
+                CustomParser = argResult => Parse<IDirectoryInfo>(argResult, ".")
+            };
+            cmd.Add(packagePathArgument);
+
+            var baseVersionArgument = new Argument<string>("BaseVersion")
+            {
+                Description = "New framework/MES Version"
+            };
+            cmd.Add(baseVersionArgument);
+
+            var manifestOption = new Option<string>("--manifest", "-m")
+            {
+                Description = "The manifest file to use for the upgrade."
+            };
+            cmd.Add(manifestOption);
+
+            cmd.SetAction((parseResult) =>
+            {
+                var packagePath = parseResult.GetValue(packagePathArgument);
+                var baseVersion = parseResult.GetValue(baseVersionArgument);
+                var manifest = parseResult.GetValue(manifestOption);
+
+                Execute(packagePath, baseVersion, manifest);
+                return Task.FromResult(0);
+            });
+        }
+
+        /// <summary>
+        /// Executes the specified package path.
+        /// </summary>
+        /// <param name="packagePath">The package path.</param>
+        /// <param name="version">The new framework/MES version.</param>
+        /// <param name="manifest">The manifest file to use for the upgrade.</param>
+        public void Execute(IDirectoryInfo packagePath, string version, string manifest = null)
+        {
+            IFileInfo cmfpackageFile = this.fileSystem.FileInfo.New(this.fileSystem.Path.Combine(packagePath.FullName, CliConstants.CmfPackageFileName));
+
+            IPackageTypeHandler packageTypeHandler = PackageTypeFactory.GetPackageTypeHandler(cmfpackageFile);
+            packageTypeHandler.Upgrade(version, manifest);
+        }
+    }
+}

--- a/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/BusinessPackageTypeHandler.cs
@@ -116,13 +116,10 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <inheritdoc/>
+        public override void Upgrade(string version, string manifest = null)
         {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
+            base.Upgrade(version, manifest);
             UpgradeBaseUtilities.UpdateCSharpProject(this.fileSystem, this.CmfPackage, version, true);
         }
     }

--- a/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
+++ b/cmf-cli/Handlers/PackageType/DataPackageTypeHandlerV2.cs
@@ -17,7 +17,7 @@ namespace Cmf.CLI.Handlers
     public class DataPackageTypeHandlerV2 : PackageTypeHandler
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DataPackageTypeHandler" /> class.
+        /// Initializes a new instance of the <see cref="DataPackageTypeHandlerV2" /> class.
         /// </summary>
         /// <param name="cmfPackage">The CMF package.</param>
         public DataPackageTypeHandlerV2(CmfPackage cmfPackage) : base(cmfPackage)
@@ -52,8 +52,8 @@ namespace Cmf.CLI.Handlers
                         }
                      });
 
-            BuildSteps = new IBuildCommand[]
-            {
+            BuildSteps =
+            [
                 new JSONValidatorCommand()
                 {
                     DisplayName = "JSON Validator Command",
@@ -64,7 +64,7 @@ namespace Cmf.CLI.Handlers
                     DisplayName = "DEE Validator Command",
                     FilesToValidate = GetContentToPack(this.fileSystem.DirectoryInfo.New("."))
                 }
-            };
+            ];
 
             cmfPackage.DFPackageType = PackageType.Business; // necessary because we restart the host during installation
 
@@ -91,21 +91,13 @@ namespace Cmf.CLI.Handlers
             base.Pack(packageOutputDir, outputDir, dryRun);
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <inheritdoc/>
+        public override void Upgrade(string version, string manifest = null)
         {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
+            base.Upgrade(version, manifest);
             UpgradeBaseUtilities.UpdateCSharpProject(this.fileSystem, this.CmfPackage, version, true);
 
-            if (iotVersion == null)
-            {
-                return;
-            }
-
-            UpgradeBaseUtilities.UpdateIoTMasterdatasAndWorkflows(this.fileSystem, this.CmfPackage, iotVersion, iotPackagesToIgnore);
+            UpgradeBaseUtilities.UpdateIoTMasterdataFiles(this.fileSystem, this.CmfPackage, version, manifest);
         }
 
         /// <summary>

--- a/cmf-cli/Handlers/PackageType/HelpNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HelpNgCliPackageTypeHandler.cs
@@ -191,13 +191,10 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <inheritdoc/>
+        public override void Upgrade(string version, string manifest = null)
         {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
+            base.Upgrade(version, manifest);
             UpgradeBaseUtilities.UpdateNPMProject(this.fileSystem, this.CmfPackage, version);
 
             // Update the version in the config.json file

--- a/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/HtmlNgCliPackageTypeHandler.cs
@@ -180,13 +180,10 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <inheritdoc/>
+        public override void Upgrade(string version, string manifest = null)
         {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
+            base.Upgrade(version, manifest);
             UpgradeBaseUtilities.UpdateNPMProject(this.fileSystem, this.CmfPackage, version);
 
             IFileInfo projectConfig = this.fileSystem.FileInfo.New(Path.Join(this.CmfPackage.GetFileInfo().DirectoryName, "src", "assets", "config.json"));

--- a/cmf-cli/Handlers/PackageType/IoTDataPackageTypeHandlerV2.cs
+++ b/cmf-cli/Handlers/PackageType/IoTDataPackageTypeHandlerV2.cs
@@ -4,14 +4,11 @@ using Cmf.CLI.Core.Enums;
 using Cmf.CLI.Core.Objects;
 using Cmf.CLI.Utilities;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Text.RegularExpressions;
 
 namespace Cmf.CLI.Handlers
 {
@@ -88,23 +85,6 @@ namespace Cmf.CLI.Handlers
 
                 #endregion Bump IoT Masterdata
             }
-        }
-
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
-        {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
-            UpgradeBaseUtilities.UpdateCSharpProject(this.fileSystem, this.CmfPackage, version, true);
-
-            if (iotVersion == null)
-            {
-                return;
-            }
-
-            UpgradeBaseUtilities.UpdateIoTMasterdatasAndWorkflows(this.fileSystem, this.CmfPackage, iotVersion, iotPackagesToIgnore);
         }
 
         /// <summary>

--- a/cmf-cli/Handlers/PackageType/IoTPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/IoTPackageTypeHandler.cs
@@ -239,13 +239,10 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <inheritdoc/>
+        public override void Upgrade(string version, string manifest = null)
         {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
+            base.Upgrade(version, manifest);
             UpgradeBaseUtilities.UpdateNPMProject(this.fileSystem, this.CmfPackage, version);
         }
 

--- a/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/PackageTypeHandler.cs
@@ -498,11 +498,9 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public virtual void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore) {
+        /// <inheritdoc />
+        public virtual void Upgrade(string version, string manifest = null)
+        {
             Log.Information($"Will bump {CmfPackage.PackageId}");
 
             // Read and parse the JSON

--- a/cmf-cli/Handlers/PackageType/TestPackageTypeHandler.cs
+++ b/cmf-cli/Handlers/PackageType/TestPackageTypeHandler.cs
@@ -127,13 +127,10 @@ namespace Cmf.CLI.Handlers
             }
         }
 
-        /// <summary>
-        /// Bumps the Base version of the package
-        /// </summary>
-        /// <param name="version">The new Base version.</param>
-        public override void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore)
+        /// <inheritdoc/>
+        public override void Upgrade(string version, string manifest = null)
         {
-            base.UpgradeBase(version, iotVersion, iotPackagesToIgnore);
+            base.Upgrade(version, manifest);
             UpgradeBaseUtilities.UpdateCSharpProject(this.fileSystem, this.CmfPackage, version, false);
         }
 

--- a/cmf-cli/Utilities/UpgradeBaseUtilities.cs
+++ b/cmf-cli/Utilities/UpgradeBaseUtilities.cs
@@ -2,15 +2,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Abstractions;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using Cmf.CLI.Core;
 using Cmf.CLI.Core.Objects;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
 using Cmf.CLI.Core.Enums;
-using System.Text.Json.Nodes;
 using System.Runtime.CompilerServices;
+using Cmf.CLI.Builders;
+using System;
 
 [assembly: InternalsVisibleTo("tests")]
 namespace Cmf.CLI.Utilities
@@ -112,38 +112,16 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Updates version references in IoT master data and automation workflow files
-        /// within a given package, skipping specific packages if configured.
+        /// Updates IoT Masterdata and Automation Workflows files executing the appropriate migration scripts.
         /// </summary>
         /// <param name="fileSystem">The file system abstraction used to access files.</param>
         /// <param name="cmfPackage">The CMF package being processed.</param>
         /// <param name="version">The new Base version.</param>
-        /// <param name="iotPackagesToIgnore">List of package names to ignore during the update (e.g., custom tasks).</param>
-        public static void UpdateIoTMasterdatasAndWorkflows(IFileSystem fileSystem, CmfPackage cmfPackage, string version, List<string> iotPackagesToIgnore)
-        {
-            /// You might be wondering why the ignorePackages starts with these three packages by default:
-            /// 
-            /// When I was testing this command on a bunch of projects, 
-            /// I noticed that the version of these template packages were being inadvertently changed on a lot of projects.
-            /// 
-            /// While one is able to use the --iotPackagesToIgnore flag to ignore these packages,
-            /// by adding these packages to the ignore list by default we make the usage of this command more ergonomic.
-            
-            List<string> ignorePackages = new List<string>()
-            {
-                "@criticalmanufacturing/connect-iot-controller-engine-custom-utilities-tasks", // SMT Template
-                "@criticalmanufacturing/connect-iot-controller-engine-custom-smt-utilities-tasks", // SMT Template
-                "@criticalmanufacturing/connect-iot-utilities-semi-tasks", // Semi Template
-            };
-            ignorePackages.AddRange(iotPackagesToIgnore ?? []);
-
-            // Useful debug info
-            Log.Debug("Packages that will be ignored:");
-            ignorePackages.ForEach(pkg => Log.Debug($"  - {pkg}"));
-
-            List<string> mdlFiles = new List<string>();
-            List<string> workflowFiles = new List<string>();
-
+        /// <param name="manifest">Optional manifest file path for the migration tool.</param>
+        public static void UpdateIoTMasterdataFiles(IFileSystem fileSystem, CmfPackage cmfPackage, string version, string manifest = null)
+        {        
+            List<string> args = [];
+            string workflowsFolder = null; 
             foreach (ContentToPack contentToPack in cmfPackage.ContentToPack ?? [])
             {
                 if (contentToPack.Source?.Contains(@"$(version)") ?? false)
@@ -154,190 +132,45 @@ namespace Cmf.CLI.Utilities
 
                 if (contentToPack.ContentType == ContentType.MasterData)
                 {
-                    mdlFiles.AddRange(fileSystem.Directory.GetFiles(
-                        cmfPackage.GetFileInfo().DirectoryName,
-                        contentToPack.Source,
-                        SearchOption.AllDirectories
-                    ));
-                }
-                else if (contentToPack.ContentType == ContentType.AutomationWorkFlows)
+                    var mdFilePath = fileSystem.Path.GetFullPath(fileSystem.Path.Combine(cmfPackage.GetFileInfo().DirectoryName, contentToPack.Source)).Replace("*", "");
+                    args.Add(mdFilePath);
+                } else if (contentToPack.ContentType == ContentType.AutomationWorkFlows)
                 {
-                    workflowFiles.AddRange(fileSystem.Directory.GetFiles(
-                        cmfPackage.GetFileInfo().DirectoryName,
-                        contentToPack.Source,
-                        SearchOption.AllDirectories
-                    ));
+                    workflowsFolder = fileSystem.Path.GetFullPath(fileSystem.Path.Combine(cmfPackage.GetFileInfo().DirectoryName, contentToPack.Source)).Replace("*", "");
                 }
             }
 
-            if (mdlFiles.Where(mdl => !mdl.EndsWith(".json")).Any())
+            if (!string.IsNullOrEmpty(workflowsFolder))
             {
-                Log.Warning("Only .json masterdata files will be updated");
+                args.AddRange(["--workflowsFolder", workflowsFolder]);
             }
 
-            // Update the MES references that might be present in the mdl files
-            foreach (string mdlPath in mdlFiles.Where(mdl => mdl.EndsWith(".json")))
+            if (!string.IsNullOrEmpty(manifest))
             {
-                UpdateIoTMasterdata(mdlPath, fileSystem, cmfPackage, version, ignorePackages);
+                args.AddRange(["--manifest", manifest]);
             }
 
-            Log.Debug("Processing workflows...");
-            // Update the IoT workflows
-            foreach (string wflPath in workflowFiles.Where(path => path.EndsWith(".json")))
+            args.AddRange(["--registry", ExecutionContext.Instance.ProjectConfig.NPMRegistry.ToString()]);
+            args.AddRange(["--version", version]);
+
+            var npxCommand = new NPXCommand
             {
-                UpdateIoTWorkflow(wflPath, fileSystem, cmfPackage, version, ignorePackages);
-            }
-        }
+                Command = "workflow-migration-tool",
+                Args = [.. args],
+                ForceColorOutput = true,
+                DisplayName = "Workflow Migration Tool",
+                WorkingDirectory = fileSystem.Directory.GetParent(cmfPackage.GetFileInfo().FullName)
+            };
 
-        /// <summary>
-        /// Updates version values in a given IoT master data (.json) file.
-        /// </summary>
-        /// <param name="mdlPath">Path to the master data file.</param>
-        /// <param name="fileSystem">The file system abstraction used to access files.</param>
-        /// <param name="cmfPackage">The CMF package that owns the master data.</param>
-        /// <param name="version">The new Base version.</param>
-        /// <param name="ignorePackages">List of task package names to ignore.</param>
-        private static void UpdateIoTMasterdata(string mdlPath, IFileSystem fileSystem, CmfPackage cmfPackage, string version, List<string> ignorePackages)
-        {
-            // Update some versions in several places in the masterdata
-            string text = fileSystem.File.ReadAllText(mdlPath);
-            foreach (string key in new string[] { "PackageVersion", "ControllerPackageVersion", "MonitorPackageVersion", "ManagerPackageVersion" })
+            try
             {
-                text = UpgradeBaseUtilities.UpdateJsonValue(text, key, version);
+                npxCommand.Exec();
+                Log.Information("Migration complete.");
             }
-
-            // Updating the versions in <DM>AutomationController requires special handling
-            JObject packageJsonObject = JsonConvert.DeserializeObject<JObject>(text);
-
-            if (packageJsonObject.ContainsKey("<DM>AutomationController"))
+            catch (Exception ex)
             {
-                JObject automationControllers = packageJsonObject["<DM>AutomationController"] as JObject;
-
-                foreach (JProperty prop in automationControllers.Properties())
-                {
-                    UpdateTaskLibraryPackageJson(prop, version, ignorePackages);
-                }
+                throw new CliException($"Workflow migration failed: {ex.Message}");
             }
-
-            SerializeWithOriginalIndentation(mdlPath, text, packageJsonObject, fileSystem);
-        }
-
-        /// <summary>
-        /// Updates the version of package strings listed in the "TasksLibraryPackages" field of a given <DM>AutomationController JSON property.
-        /// </summary>
-        /// <param name="prop">The JSON property representing a controller entry within the "<DM>AutomationController" object.</param>
-        /// <param name="version">The new version string to apply to all eligible package entries.</param>
-        /// <param name="ignorePackages"> A list of package name substrings to exclude from version updates.
-        /// Any package string that contains a substring from this list will be skipped.
-        /// </param>
-        /// <remarks>
-        /// The "TasksLibraryPackages" field may be stored either as a JSON array or as a stringified JSON array.
-        /// This method detects the format and updates the version suffix (e.g., "@11.1.3") for each package string,
-        /// while preserving the original format of the field (string or array). I have no idea why are two different
-        /// formats are allowed in this field, but now we're stuck supporting them both
-        /// </remarks>
-        private static void UpdateTaskLibraryPackageJson(JProperty prop, string version, List<string> ignorePackages)
-        {
-            JObject controller = (JObject)prop.Value;
-            JToken tasksLibraryPackagesToken = controller["TasksLibraryPackages"];
-
-            if (tasksLibraryPackagesToken == null || tasksLibraryPackagesToken.Type == JTokenType.Null)
-            {
-                return;
-            }
-
-            JArray tasksLibraryPackages = null;
-            bool wasStringFormat = false;
-
-            if (tasksLibraryPackagesToken.Type == JTokenType.String)
-            {
-                string rawString = tasksLibraryPackagesToken.ToString();
-                if (!string.IsNullOrWhiteSpace(rawString))
-                {
-                    tasksLibraryPackages = JsonConvert.DeserializeObject<JArray>(rawString);
-                    wasStringFormat = true;
-                }
-            }
-            else if (tasksLibraryPackagesToken.Type == JTokenType.Array)
-            {
-                tasksLibraryPackages = (JArray)tasksLibraryPackagesToken;
-            }
-
-            if (tasksLibraryPackages == null)
-            {
-                return;
-            }
-
-            for (int i = 0; i < tasksLibraryPackages.Count; i++)
-            {
-                string packageStr = tasksLibraryPackages[i]?.ToString();
-
-                if (string.IsNullOrEmpty(packageStr) || ignorePackages.Any(ignore => packageStr.Contains(ignore)))
-                {
-                    continue;
-                }
-                tasksLibraryPackages[i] = Regex.Replace(packageStr, @"@\d+.*$", $"@{version}");
-            }
-
-            if (wasStringFormat)
-            {
-                // Write back as a compact JSON string
-                controller["TasksLibraryPackages"] = JsonConvert.SerializeObject(tasksLibraryPackages, Formatting.None);
-            }
-            else
-            {
-                // Preserve original JArray structure
-                controller["TasksLibraryPackages"] = tasksLibraryPackages;
-            }
-        }
-
-        /// <summary>
-        /// Updates the package version references in an IoT automation workflow file, 
-        /// skipping any package names included in the ignore list.
-        /// </summary>
-        /// <param name="wflPath">Path to the workflow .json file.</param>
-        /// <param name="fileSystem">The file system abstraction used to access files.</param>
-        /// <param name="cmfPackage">The CMF package that owns the workflow.</param>
-        /// <param name="version">The new Base version.</param>
-        /// <param name="ignorePackages">List of task package names to skip when applying the version update.</param>
-        private static void UpdateIoTWorkflow(string wflPath, IFileSystem fileSystem, CmfPackage cmfPackage, string version, List<string> ignorePackages)
-        {
-            Log.Debug($"  - {wflPath}");
-            string packageJson = fileSystem.File.ReadAllText(wflPath);
-            dynamic packageJsonObject = JsonConvert.DeserializeObject(packageJson);
-
-            if (!packageJsonObject.ContainsKey("tasks"))
-            {
-                throw new CliException(string.Format(CoreMessages.MissingMandatoryPropertyInFile, "tasks", wflPath));
-            }
-            if (!packageJsonObject.ContainsKey("converters"))
-            {
-                throw new CliException(string.Format(CoreMessages.MissingMandatoryPropertyInFile, "converters", wflPath));
-            }
-
-            foreach (var task in packageJsonObject?["tasks"])
-            {
-                string name = (string)task["reference"]["package"]["name"];
-                if (ignorePackages.Any(ignore => name.Contains(ignore)))
-                {
-                    continue; // If there's a match with a package in the ignorePackages, skip the version bump
-                }
-
-                task["reference"]["package"]["version"] = version;
-            }
-
-            foreach (var converter in packageJsonObject?["converters"])
-            {
-                string name = (string)converter["reference"]["package"]["name"];
-                if (ignorePackages.Any(ignore => name.Contains(ignore)))
-                {
-                    continue; // If there's a match with a package in the ignorePackages, skip the version bump
-                }
-
-                converter["reference"]["package"]["version"] = version;
-            }
-
-            SerializeWithOriginalIndentation(wflPath, packageJson, packageJsonObject, fileSystem);
         }
 
         /// <summary>

--- a/core/Interfaces/IPackageTypeHandler.cs
+++ b/core/Interfaces/IPackageTypeHandler.cs
@@ -29,9 +29,8 @@ namespace Cmf.CLI.Core.Interfaces
         /// Bumps the Base version of the package
         /// </summary>
         /// <param name="version">The new Base version.</param>
-        /// <param name="iotVersion">New MES version for the IoT workflows & masterdata</param>
-        /// <param name="iotPackagesToIgnore">IoT packages to ignore when updating the MES version of the tasks in IoT workflows</param>
-        public abstract void UpgradeBase(string version, string iotVersion, List<string> iotPackagesToIgnore);
+        /// <param name="manifest">The manifest file to use for the upgrade.</param>
+        public abstract void Upgrade(string version, string manifest = null);
 
         /// <summary>
         /// Builds this instance.

--- a/core/Utilities/IoTUtilities.cs
+++ b/core/Utilities/IoTUtilities.cs
@@ -64,7 +64,7 @@ namespace Cmf.CLI.Utilities
         }
 
         /// <summary>
-        /// Bumps the io t master data.
+        /// Bumps the iot master data.
         /// </summary>
         /// <param name="automationWorkflowFileGroup">The automation workflow file group.</param>
         /// <param name="version">The version.</param>
@@ -142,7 +142,7 @@ namespace Cmf.CLI.Utilities
             }
 
             string[] xmlMasterDatas = fileSystem.Directory.GetFiles(parentDirectory.FullName, "*.xml");
-            string[] xlsxMasterDatas = fileSystem.Directory.GetFiles(parentDirectory.FullName, "*.xml");
+            string[] xlsxMasterDatas = fileSystem.Directory.GetFiles(parentDirectory.FullName, "*.xlsx");
 
             if (xmlMasterDatas == null || xmlMasterDatas.Length == 0)
             {

--- a/tests/Specs/Upgrade.cs
+++ b/tests/Specs/Upgrade.cs
@@ -1,0 +1,154 @@
+using System.Collections.Generic;
+using System.IO.Abstractions.TestingHelpers;
+using Cmf.CLI.Commands;
+using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace tests.Specs;
+
+public class Upgrade
+{
+    [Fact]
+    public void RootPackage()
+    {
+        string version = "11.1.6";
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            {
+                "/cmfpackage.json",
+                new MockFileData(
+                    @"{
+                      ""packageId"": ""Cmf.SMT.Package"",
+                      ""version"": ""3.2.0"",
+                      ""description"": ""Root package"",
+                      ""packageType"": ""Root"",
+                      ""isInstallable"": true,
+                      ""isUniqueInstall"": false,
+                      ""dependencies"": [
+                        {
+                          ""id"": ""DS.ClickHouse.Workaround"",
+                          ""version"": ""1.2.0""
+                        },
+                        {
+                          ""id"": ""Cmf.Environment"",
+                          ""version"": ""11.1.3""
+                        },
+                        {
+                          ""id"": ""criticalmanufacturing.deploymentmetadata"",
+                          ""version"": ""11.1.3""
+                        },
+                        {
+                          ""id"": ""CriticalManufacturing.DeploymentMetadata"",
+                          ""version"": ""11.1.3""
+                        }
+                      ]
+                    }"
+                )
+            },
+        });
+
+        var cmd = new UpgradeCommand(fileSystem);
+        cmd.Execute(fileSystem.DirectoryInfo.New("/"), version);
+
+        string rootCmfpackageContents = fileSystem.File.ReadAllText("/cmfpackage.json");
+        JObject rootCmfpackageObject = (JObject)JsonConvert.DeserializeObject(rootCmfpackageContents);
+
+        rootCmfpackageObject["dependencies"][0]["version"].ToString().Should().Be("1.2.0");
+        rootCmfpackageObject["dependencies"][1]["version"].ToString().Should().Be(version);
+        rootCmfpackageObject["dependencies"][2]["version"].ToString().Should().Be(version);
+        rootCmfpackageObject["dependencies"][3]["version"].ToString().Should().Be(version);
+    }
+
+    [Fact]
+    public void BusinessPackage()
+    {
+        string version = "11.1.6";
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            {
+                "/Business/cmfpackage.json",
+                new MockFileData(
+                    @"{
+                      ""packageId"": ""Cmf.SMT.Business"",
+                      ""version"": ""3.2.0"",
+                      ""description"": ""Business Package"",
+                      ""packageType"": ""Business"",
+                      ""isInstallable"": true,
+                      ""isUniqueInstall"": false
+                    }"
+                )
+            },
+            {
+                "/Business/Common/a.b.c.csproj",
+                new MockFileData(
+                    @"
+                    <Project Sdk=""Microsoft.NET.Sdk"">
+                    	<ItemGroup>
+                    		<PackageReference Include=""Cmf.Foundation.BusinessObjects"" Version=""11.1.5"" />
+                    		<PackageReference Include=""Cmf.MessageBus.Client"" Version=""11.1.5"" />
+                    		<PackageReference Include=""Cmf.Common.CustomActionUtilities"" Version=""10.1.0"" GeneratePathProperty=""true"" />
+                    		<PackageReference Include=""Cmf.LoadBalancing"" Version=""11.1.5"" />
+                    	</ItemGroup>
+                    </Project>
+                    "
+                )
+            }
+        });
+
+        var cmd = new UpgradeCommand(fileSystem);
+        cmd.Execute(fileSystem.DirectoryInfo.New("/Business"), version);
+
+        string csprojContents = fileSystem.File.ReadAllText("/Business/Common/a.b.c.csproj");
+        csprojContents.Should().Contain($@"<PackageReference Include=""Cmf.Foundation.BusinessObjects"" Version=""{version}"" />");
+        csprojContents.Should().Contain($@"<PackageReference Include=""Cmf.MessageBus.Client"" Version=""{version}"" />");
+        csprojContents.Should().Contain($@"<PackageReference Include=""Cmf.Common.CustomActionUtilities"" Version=""{version}"" GeneratePathProperty=""true"" />");
+        csprojContents.Should().Contain(@"<PackageReference Include=""Cmf.LoadBalancing"" Version=""11.1.5"" />");
+    }
+
+    [Fact]
+    public void TestPackage()
+    {
+        string version = "11.1.6";
+
+        var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
+        {
+            {
+                "/cmfpackage.json",
+                new MockFileData(
+                    @"{
+                      ""packageId"": ""Cmf.SMT.Tests"",
+                      ""version"": ""3.2.0"",
+                      ""description"": ""Tests Package"",
+                      ""packageType"": ""Tests"",
+                      ""isInstallable"": false,
+                      ""isUniqueInstall"": false
+                    }"
+                )
+            },
+            {
+                "/Common/a.b.c.csproj",
+                new MockFileData(
+                    @"
+                        <Project Sdk=""Microsoft.NET.Sdk"">
+                          <ItemGroup>
+                            <PackageReference Include=""Cmf.Common.TestUtilities"" Version=""2.3.157590"" />
+                            <PackageReference Include=""Cmf.Common.TestFramework.ConnectIoT"" Version=""1.0.131717"" />
+                            <PackageReference Include=""Cmf.Dev.Mes.TestScenarios"" Version=""11.1.5"" />
+                          </ItemGroup>
+                        </Project>
+                    "
+                )
+            }
+        });
+
+        var cmd = new UpgradeCommand(fileSystem);
+        cmd.Execute(fileSystem.DirectoryInfo.New("/"), version);
+
+        string csprojContents = fileSystem.File.ReadAllText("/Common/a.b.c.csproj");
+        csprojContents.Should().Contain($@"<PackageReference Include=""Cmf.Dev.Mes.TestScenarios"" Version=""{version}"" />");
+    }
+}

--- a/tests/Specs/UpgradeBase.cs
+++ b/tests/Specs/UpgradeBase.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.IO.Abstractions.TestingHelpers;
 using System.Linq;
@@ -53,7 +52,7 @@ public class UpgradeBase
         });
 
         UpgradeBaseCommand cmd = new UpgradeBaseCommand(fileSystem);
-        cmd.Execute(fileSystem.FileInfo.New(projectConfigPath).Directory, "11.1.6", "11.1.6", []);
+        cmd.Execute(fileSystem.FileInfo.New(projectConfigPath).Directory, "11.1.6", "11.1.6");
 
         string projectConfigContents = fileSystem.File.ReadAllText(projectConfigPath);
 
@@ -176,10 +175,8 @@ public class UpgradeBase
                 )
             }
         });
-
-
         UpgradeBaseCommand cmd = new UpgradeBaseCommand(fileSystem);
-        cmd.Execute(fileSystem.DirectoryInfo.New("/"), version, version, []);
+        cmd.Execute(fileSystem.DirectoryInfo.New("/"), version);
 
         string rootCmfpackageContents = fileSystem.File.ReadAllText("/cmfpackage.json");
 
@@ -207,13 +204,10 @@ public class UpgradeBase
     }
 
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void DataPackage(bool iotShouldBeUpdated)
+    [Fact]
+    public void DataPackage()
     {
         string version = "11.1.6";
-        string iotVersion = "11.1.6-123";
 
         var fileSystem = new MockFileSystem(new Dictionary<string, MockFileData>
         {
@@ -508,50 +502,15 @@ public class UpgradeBase
             }
         });
 
-        UpgradeBaseCommand cmd = new UpgradeBaseCommand(fileSystem);
-        cmd.Execute(fileSystem.DirectoryInfo.New(@"/"), version, iotShouldBeUpdated ? iotVersion : null, ["ignore-this-package"]);
+        ExecutionContext.Initialize(fileSystem);
+
+        UpgradeBaseUtilities.UpdateCSharpProject(fileSystem, new CmfPackage(fileSystem.FileInfo.New("/cmfpackage.json")), version, true);
 
         string csprojContents = fileSystem.File.ReadAllText(@"/DEEs/a.b.c.csproj");
         csprojContents.Should().Contain(
             $@"<PackageReference Include=""Cmf.MessageBus.Client"" Version=""{version}"" />"
         );
 
-        if (iotShouldBeUpdated)
-        {
-            #region Masterdata validations
-            string mdlContents = fileSystem.File.ReadAllText(@"/MasterData/a.json");
-            mdlContents.Should().ContainAll([
-                $@"""PackageVersion"": ""{iotVersion}""",
-                $@"""MonitorPackageVersion"": ""{iotVersion}""",
-                $@"""ManagerPackageVersion"": ""{iotVersion}""",
-                $@"""ControllerPackageVersion"": ""{iotVersion}""",
-                $@"@criticalmanufacturing/connect-iot-controller-engine-core-tasks@{iotVersion}",
-                $@"@criticalmanufacturing/connect-iot-random@{iotVersion}",
-                $@"@criticalmanufacturing/connect-iot-controller-engine-custom-utilities-tasks@5.4.3", // The industry templates iot packages should remain unchanged
-                $@"@criticalmanufacturing/connect-iot-controller-engine-custom-smt-utilities-tasks@5.4.3",
-                $@"@criticalmanufacturing/connect-iot-utilities-semi-tasks@5.4.3",
-            ]);
-            Assert.Equal(7, Regex.Matches(mdlContents, iotVersion.Replace(".", "\\.")).Count);
-            #endregion IoT Masterdata validations
-
-            #region Workflow validations
-            string wflContents = fileSystem.File.ReadAllText(@"/AutomationWorkFlows/workflow.json");
-            JObject workflowJsonObject = (JObject)JsonConvert.DeserializeObject(wflContents);
-
-            // Tasks
-            workflowJsonObject["tasks"][0]["reference"]["package"]["version"].ToString().Should().Be(iotVersion);
-            workflowJsonObject["tasks"][1]["reference"]["package"]["version"].ToString().Should().Be("11.1.5");
-            workflowJsonObject["tasks"][2]["reference"]["package"]["version"].ToString().Should().Be(iotVersion);
-
-            // Converters
-            workflowJsonObject["converters"][0]["reference"]["package"]["version"].ToString().Should().Be(iotVersion);
-            workflowJsonObject["converters"][1]["reference"]["package"]["version"].ToString().Should().Be("1.2.3");
-
-            Assert.Equal(3, Regex.Matches(wflContents, iotVersion.Replace(".", "\\.")).Count);
-            Assert.Single(Regex.Matches(wflContents, "11.1.5".Replace(".", "\\."))); // Ignored task
-            Assert.Single(Regex.Matches(wflContents, "1.2.3".Replace(".", "\\."))); // Ignored converter
-            #endregion IoT Workflow validations
-        }
     }
 
     [Theory]
@@ -778,10 +737,8 @@ public class UpgradeBase
                 )
             }
         });
-
-
         UpgradeBaseCommand cmd = new UpgradeBaseCommand(fileSystem);
-        cmd.Execute(fileSystem.DirectoryInfo.New("/"), version, null, []);
+        cmd.Execute(fileSystem.DirectoryInfo.New("/"), version);
 
         string csprojContents = fileSystem.File.ReadAllText("/Common/a.b.c.csproj");
         csprojContents.Should().Contain(


### PR DESCRIPTION
# **What was done**

The previous IoT workflow upgrade process consisted of changing the tasks' version in the JSON file, which is against the recommendations of the Product team. A new utility, the workflow-migration-tool, was developed as a standalone npm package. The utility goes through all the masterdata and workflow files and updates the tasks, applying all the migration scripts needed. This is the correct, safe way to perform these kinds of upgrades. 

The `cmf upgrade` command was being used as a placeholder so users could use the `cmf upgrade base` command. The latter is an anti-pattern since it goes through all the package files and performs an upgrade. Now, the `cmf upgrade` command is no longer a placeholder and can be used to perform an upgrade in the specified package only.
The `cmf upgrade base` behavior was kept.

Finally, existing unit tests were updated and new ones were added for the UpgradeCommand.

Closes #758 #759 #760 

# **Dependencies**

Depends on the Connect IoT workflow-migration-tool package.

# **Validation checklist**

Please ensure the following conditions are met in order for this PR to be merged:
* [x] Code validation (careful with side-effects)
* [x] Integration test run provided
* [x] Main WorkItem is linked
* [x] Target branch version is correct
