### PR TITLE
fix: remove deprecated always_auth from npmrc sync

### DIFF
--- a/core/Repository/Credentials/NPMRepositoryCredentials.cs
+++ b/core/Repository/Credentials/NPMRepositoryCredentials.cs
@@ -63,7 +63,6 @@ namespace Cmf.CLI.Core.Repository.Credentials
                         var auth = Convert.ToBase64String(authBytes);
 
                         config.SetValue("", $"//{repoUri}:_auth", auth);
-                        config.SetValue("", $"//{repoUri}:always_auth", "true");
 
                         // Make sure we unset any potential conflicting properties
                         config.RemoveValue("", $"//{repoUri}:_authToken");
@@ -73,7 +72,6 @@ namespace Cmf.CLI.Core.Repository.Credentials
                     else if (cred is BearerCredential bearerCredential)
                     {
                         config.SetValue("", $"//{repoUri}:_authToken", bearerCredential.Token);
-                        config.SetValue("", $"//{repoUri}:always_auth", "true");
 
                         // Make sure we unset any potential conflicting properties
                         config.RemoveValue("", $"//{repoUri}:_auth");

--- a/tests/Specs/RepositoryCredentials.cs
+++ b/tests/Specs/RepositoryCredentials.cs
@@ -768,7 +768,6 @@ public class RepositoryCredentials
                 registry="https://criticalmanufacturing.io/repository/npm/"
                 //registry.npmjs.org/:_auth="V2h5V291bGQ6WW91RG9UaGF0"
                 //criticalmanufacturing.io/repository/npm/:_authToken="header.payload.signature"
-                //criticalmanufacturing.io/repository/npm/:always_auth="true"
                 """
             ) }
         });
@@ -800,9 +799,7 @@ public class RepositoryCredentials
             registry="https://criticalmanufacturing.io/repository/npm/"
             //registry.npmjs.org/:_auth="V2h5V291bGQ6WW91RG9UaGF0"
             //custom-registry.com/:_authToken="A.B.C"
-            //criticalmanufacturing.io/repository/npm/:always_auth="true"
             //criticalmanufacturing.io/repository/npm/:_auth="{expectedAuth}"
-            //custom-registry.com/:always_auth="true"
             """
         );
     }


### PR DESCRIPTION
## Description

`cmf login sync` was writing `always_auth=true` to `~/.npmrc` for every synced NPM credential (both Basic and Bearer auth). This npm config option has been deprecated since npm [v7](https://docs.npmjs.com/cli/v7/using-npm/changelog#v7111-2021-04-23) and is being fully removed in upcoming versions, causing warnings and errors for users.

This PR removes the `always_auth` writes entirely — the `_auth` / `_authToken` values alone are sufficient for authenticating with private registries.

### Changes

- **`NPMRepositoryCredentials.cs`** — removed `config.SetValue` for `always_auth` in both the Basic and Bearer credential sync paths
- **`RepositoryCredentials.cs` (tests)** — removed `always_auth` from mock input and expected output assertions
