### PR TITLE
docs: document npm allow-scripts requirement for CLI and plugins

### DIFF
--- a/docs/src/01-install/index.md
+++ b/docs/src/01-install/index.md
@@ -81,10 +81,19 @@ The development of IoT drivers on Critical Manufacturing MES has a dependency fo
 
 ## 2. Install CLI
 
+!!! warning "NPM `allow-scripts` requirement"
+
+    Recent NPM versions may block install-time scripts by default as a
+    security measure. Since `@criticalmanufacturing/cli` relies on install
+    scripts, the installation can fail or complete incompletely unless the
+    package is explicitly allowed to run them. The first command below
+    allows the package's install scripts before installing.
+
  1. Open a command line with administration privileges.
- 2. Execute the command:
+ 2. Execute the commands:
 
     ```PowerShell
+    npm config set allow-scripts=@criticalmanufacturing/cli --location=user
     npm install -g @criticalmanufacturing/cli
     ```
 

--- a/docs/src/03-explore/plugins/index.md
+++ b/docs/src/03-explore/plugins/index.md
@@ -5,3 +5,14 @@ The Critical Manufacturing cli is designed with a plugin system for extensibilit
 In the meanwhile, some plugins are already in development. Here follows a non-exhaustive plugin list:
 
 - [Portal SDK](https://www.npmjs.com/package/@criticalmanufacturing/portal) - command line tools to interact with the Critical Manufacturing Customer Portal.
+
+!!! warning "NPM `allow-scripts` requirement"
+
+    Plugins are distributed as NPM packages, so the same
+    [`allow-scripts` requirement](../../01-install/index.md#2-install-cli)
+    that applies to installing the CLI also applies to them. Before
+    installing a plugin, add it to the `allow-scripts` allowlist, e.g.:
+
+    ```PowerShell
+    npm config set allow-scripts=@criticalmanufacturing/portal --location=user
+    ```


### PR DESCRIPTION
# **What was done**

- `docs/src/01-install/index.md`: added an NPM `allow-scripts` warning to the
  Install CLI section.
- `docs/src/03-explore/plugins/index.md`: added the same warning for plugins,
  which are also NPM packages.

in scope of issue #775 

# **Validation checklist**

Please ensure the following conditions are met in order for this PR to be merged:
* [ ] Code validation (careful with side-effects)
* [ ] Integration test run provided
* [ ] Main WorkItem is linked
* [ ] Target branch version is correct
